### PR TITLE
docs(project): project memory — vision, roadmap, status, architecture review

### DIFF
--- a/docs/project/HUMAN-REVIEW.md
+++ b/docs/project/HUMAN-REVIEW.md
@@ -1,0 +1,40 @@
+# Human Review Checklist — for when you return (~2 weeks)
+
+Everything I could NOT do autonomously, or that needs your decision / verification /
+external resource. Grouped by urgency. (Living — I append as I hit blockers.)
+
+## 🔴 Blocks live functionality — please action
+- [ ] **Renew the GLM Coding Plan** (key in `.env`; endpoint `open.bigmodel.cn/api/anthropic`,
+  model `glm-5.1`). It returned `1309 套餐已到期`, so **no live agent run has been tested
+  end-to-end**. Wiring is correct; should work on renewal. → then re-run an actual chat.
+- [ ] **Rotate the shared LLM key** if it was ever exposed: `ANTHROPIC/OPENAI/ZHIPU` all used one
+  proxy value. (No git leak found, but it's reused widely.)
+
+## 🟠 Decisions only you can make (I implemented sane defaults / left flagged)
+- [ ] **Billing/metering model** (Workstream D2): what one run costs, free tier, per-token vs per-run.
+  I wired `spendOneCredit`/usage plumbing with a placeholder policy — confirm or change.
+- [ ] **Data retention & audit scope** (D3): what to log, how long, compliance constraints.
+- [ ] **Sandbox scale backend** (A5): Modal vs Daytona vs E2B vs self-hosted Docker/K8s. Needs an
+  account + budget for the 100→1000 bake-off. I implemented local + container backends only.
+- [ ] **Design checkpoint for the execution-layer re-platform** (A5): review the proposed typed
+  `ExecutionRuntime` + per-session sandbox pool + queue/worker model BEFORE I build it (1-way door).
+
+## 🟡 Implemented but NOT verified by me (please verify / run)
+- [ ] **Deploy fix (Risk #8)** — I corrected the compose/ports so the WS server boots, but I have no
+  Dokploy access and did not deploy. Verify a real deploy serves web + a working `/ws/agent`.
+- [ ] **`security_opt: [seccomp=unconfined]` on the `app` service** — required for the srt sandbox in
+  containers. Confirm your prod/Dokploy runtime allows it (or set the equivalent).
+- [ ] **DB migrations** (D1/D3 add tables) — I tested against a local Postgres only; review + run
+  against staging/prod with care.
+- [ ] **srt sandbox on your prod Linux host** — verified on OrbStack (Debian/arm64, seccomp=unconfined).
+  Confirm bubblewrap user-namespaces work on the prod host kernel (Ubuntu 24 may restrict userns).
+
+## 🟢 Review the merged PRs (I self-merged after CI; your eyes still valuable)
+- [ ] PR #3 — srt Python sandbox + secret env-strip (security-critical; see verified test output).
+- [ ] _other merged PRs listed in `SPRINT-2026-06.md` → PR ledger_
+
+## ℹ️ Notes
+- `oxy-srt-sandbox` container is left running in OrbStack as the sandbox verification harness.
+- The 5.78GB full `oxygenie:latest` app image build was NOT exercised end-to-end (GLM-blocked); I
+  used lightweight containers + local Postgres for verification instead.
+- Skipped (out of scope without you): anything needing external accounts, real load testing, prod deploy.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,26 @@
+# OxyGenie — Project Memory
+
+This folder is the **single source of truth** for where this project is going and
+where it currently stands. It exists so that **anyone** (a new contributor, or a
+future maintainer with no prior context) can pick up the repo and know what to
+do, what *not* to do, and the direction to push in.
+
+## The four documents
+
+| File | What it is | How often it changes |
+|---|---|---|
+| [`VISION.md`](./VISION.md) | The big picture: what OxyGenie is, the end goal, our architectural identity, and the do/don't principles. | Rarely (only on strategic shifts) |
+| [`ROADMAP.md`](./ROADMAP.md) | The phased plan from foundation → surpassing Deep Agents, with exit criteria per phase. | Occasionally (when a phase completes or is re-scoped) |
+| [`STATUS.md`](./STATUS.md) | **The living memory.** Current phase, what's done / in progress / next, and the backlog with difficulty tags. | **Continuously** — update it whenever state changes |
+| [`research/2026-05-architecture-review.md`](./research/2026-05-architecture-review.md) | The adversarial architecture review and the **Deep Agents comparison** that grounds the whole plan. | Frozen snapshot (re-run as a new dated file if redone) |
+
+## Rules for keeping this memory useful
+
+1. **Update `STATUS.md` as part of finishing any task** — treat it like updating a
+   changelog. A stale STATUS is worse than none.
+2. **Every claim about the codebase should cite files** (path + symbol), so the
+   reasoning can be re-verified. The architecture review models this.
+3. **Decisions go in `STATUS.md` → Decision log** with a one-line rationale, so we
+   don't re-litigate settled choices.
+4. This is the canonical project memory for the **code repo**. Internal
+   role/process docs may live elsewhere, but direction + state live here.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -1,0 +1,92 @@
+# OxyGenie — Roadmap
+
+Phased plan from foundation to surpassing Deep Agents. Each phase lists its goal
+and **exit criteria**. Track live progress in [`STATUS.md`](./STATUS.md).
+
+> Sequencing principle: *make parallel multi-contributor work safe first
+> (foundation), then close security gaps, then make capabilities measurable,
+> then catch up to Deep Agents.* Don't build features on an unsafe/untestable base.
+
+---
+
+## Phase 0 — Foundation (enable safe, parallel contribution)
+
+**Goal:** anyone of any skill level can contribute safely, in parallel, with
+guardrails.
+
+- [x] Split product into its own repo (`oxygenie`), history + tags preserved.
+- [x] Hygiene: untrack `.env.docker` (+ template), ignore runtime data dirs.
+- [x] Secret-leak audit of full history (clean).
+- [x] CI gates on `main`: build check + **gitleaks** secret scan + PR template + CODEOWNERS.
+- [x] Branch protection on `main` (required checks + CODEOWNER review, no direct push).
+- [ ] **Isolated, reproducible dev environment** (devcontainer / compose dev
+      profile; secrets separated; one-command boot of web + ws-server + services).
+- [ ] **TS-ify the agent runtime** (`ws-server.mjs`/`ws-query-worker.mjs`) with a
+      typed WebSocket message protocol — prerequisite for safely adding harness features.
+- [ ] Make the test suite CI-runnable (split unit vs e2e; provision Postgres/services)
+      → re-enable `test` as a hard gate.
+- [ ] Fix TS errors → re-enable `typecheck` as a hard gate.
+- [ ] Migrate 15 REST routes → Server Functions → re-enable `validate-routes` as a hard gate.
+
+**Exit criteria:** green, meaningful CI as a hard gate; a contributor can boot the
+full stack locally in one command without touching real secrets.
+
+---
+
+## Phase 1 — Security hardening (gate before real/multi-tenant use)
+
+**Goal:** close the high-severity risks from the architecture review so the
+product is safe to run with real data / real tenants.
+
+- [ ] **Sandbox the exec tools** (Python/Bash) — run under `bubblewrap`
+      (already installed) with `--unshare-net` + workspace-only binds; **strip
+      secrets** from the worker/python env to an explicit allowlist. *(Risk #1)*
+- [ ] Keep `canUseTool` active even in `bypassPermissions` mode. *(Risk #2)*
+- [ ] Add owner predicates to fix **cross-tenant file/attachment access**. *(Risks #3,#4)*
+- [ ] Add `maxTurns` / `maxBudgetUsd` + a server watchdog (turn/cost bounds). *(Risk #5)*
+- [ ] Fix deploy so the WS server actually boots; reconcile ports. *(Risk #8)*
+- [ ] Cooperative abort (AbortController) + remove dead `ws.abortController`. 
+- [ ] Client liveness: heartbeat/timeout + surface worker-crash to UI. *(Risk #10)*
+
+**Exit criteria:** every "high"/"critical" review risk has a fix + a regression test.
+
+---
+
+## Phase 2 — Observability & accounting (make "production" measurable)
+
+**Goal:** you can tell whether the system is healthy and what it costs.
+
+- [ ] Actually meter usage (`spendOneCredit` is currently never called).
+- [ ] Persist token/cost/turns per run server-side (from the SDK `result` event).
+- [ ] Audit log table for security-relevant actions.
+- [ ] Stop logging raw message content unconditionally (PII).
+
+**Exit criteria:** per-run cost + usage visible and billable; an audit trail exists.
+
+---
+
+## Phase 3 — Catch up to (and pass) Deep Agents (capabilities)
+
+**Goal:** match Deep Agents' harness strengths, on top of our platform advantages.
+
+- [ ] **Todo / plan panel** (surface `TodoWrite` as structured UI).
+- [ ] **First-class sub-agent panel** (nested input/output, not regex-detected).
+- [ ] **Human-in-the-loop tool approval** (approve / reject / edit round-trip).
+- [ ] **Checkpointing / durable run resume** (resume an interrupted run, not just reload history).
+- [ ] **Context management** (summarization / compaction; memory layer).
+- [ ] Unify shared logic so the two runtimes can't fork (skill-sync, path guards).
+
+**Exit criteria:** parity-or-better with `deep-agents-ui` on todo/sub-agent/HITL,
+plus durable resume — while keeping our isolation + multi-tenant + web edge.
+
+---
+
+## Phase 4 — Multi-model & scale maturity
+
+**Goal:** real provider abstraction and horizontal scale.
+
+- [ ] Model registry / capability catalog / provider routing + failover.
+- [ ] Split shared credentials per capability (remove single-key blast radius).
+- [ ] Concurrency caps / backpressure / horizontal scale story for ws-server.
+
+**Exit criteria:** swap/route models without code changes; bounded resource use under load.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -3,9 +3,9 @@
 Phased plan from foundation to surpassing Deep Agents. Each phase lists its goal
 and **exit criteria**. Track live progress in [`STATUS.md`](./STATUS.md).
 
-> Sequencing principle: *make parallel multi-contributor work safe first
-> (foundation), then close security gaps, then make capabilities measurable,
-> then catch up to Deep Agents.* Don't build features on an unsafe/untestable base.
+> Sequencing principle: *foundation (safe parallel work) → decide the execution
+> runtime/scale model → close security gaps → make capabilities measurable → catch
+> up to Deep Agents.* Don't build features on an unsafe / untestable / un-scalable base.
 
 ---
 
@@ -33,14 +33,47 @@ full stack locally in one command without touching real secrets.
 
 ---
 
+## Phase 0.5 — Execution-runtime architecture & sandbox (decision + re-platform)
+
+**Goal:** decide and stand up the execution model the rest of the product depends on,
+**before** pouring effort into a single-node design that can't scale. Grounded by
+[`research/2026-05-scalability-and-runtime.md`](./research/2026-05-scalability-and-runtime.md).
+
+Why now: the current model — a per-**message** Node child spawn behind a single
+stateful `ws-server`, with local-disk + in-memory session state — cannot reach
+hundreds/thousands of concurrent sessions, and it gates sandboxing (Risk #1),
+checkpointing, and cost. Deep-read of hermes-agent, deer-flow, ruflo, and Anthropic's
+`sandbox-runtime` validated a clear path.
+
+- [ ] **Adopt `@anthropic-ai/sandbox-runtime` (srt)** (TS, Apache-2.0) as the exec
+      sandbox primitive — deny-network + workspace-fenced FS per tool-call. This *is*
+      the Risk #1 fix; it uses bubblewrap (already installed) under the hood on Linux.
+- [ ] **Define a TS `ExecutionRuntime` interface** (start / exec / stream / abort /
+      snapshot / stop) — pattern from hermes-agent `BaseEnvironment` + deer-flow
+      `SandboxProvider`. First backend: local-process + srt.
+- [ ] **Move execution off per-message spawn** → per-session sandbox (warm pool,
+      reused across messages) behind that interface.
+- [ ] **Decouple tiers**: stateless web/WS gateway · shared session state
+      (Postgres/Redis) · object-store workspaces · queue-driven worker pool.
+- [ ] **Pick the scale backend** (spike): serverless sandboxes (Modal/Daytona/E2B,
+      hibernate-on-idle, Node SDKs) vs self-managed container pool (Docker → K8s
+      provisioner, à la deer-flow). Decide **Plan A (integrate)** vs **B (self-build)**.
+- [ ] **Concurrency spike**: memory/latency curve at 100 → 1000 concurrent sessions.
+
+**Exit criteria:** a TS `ExecutionRuntime` abstraction with srt sandboxing live; a
+documented A-vs-B decision + a 1000-concurrent-session benchmark; execution no longer
+pinned to a single box.
+
+---
+
 ## Phase 1 — Security hardening (gate before real/multi-tenant use)
 
 **Goal:** close the high-severity risks from the architecture review so the
 product is safe to run with real data / real tenants.
 
-- [ ] **Sandbox the exec tools** (Python/Bash) — run under `bubblewrap`
-      (already installed) with `--unshare-net` + workspace-only binds; **strip
-      secrets** from the worker/python env to an explicit allowlist. *(Risk #1)*
+- [ ] **Sandbox the exec tools** (Python/Bash) — via the Phase-0.5 `ExecutionRuntime`
+      + `srt` (deny-net, workspace-fenced FS); **strip secrets** from the worker/python
+      env to an explicit allowlist. *(Risk #1 — primitive chosen in Phase 0.5)*
 - [ ] Keep `canUseTool` active even in `bypassPermissions` mode. *(Risk #2)*
 - [ ] Add owner predicates to fix **cross-tenant file/attachment access**. *(Risks #3,#4)*
 - [ ] Add `maxTurns` / `maxBudgetUsd` + a server watchdog (turn/cost bounds). *(Risk #5)*

--- a/docs/project/SPRINT-2026-06.md
+++ b/docs/project/SPRINT-2026-06.md
@@ -1,0 +1,63 @@
+# Sprint Plan — 2 weeks (autonomous run, started 2026-05-30)
+
+Goal: complete **Phase 0.5 (execution runtime & sandbox)** and land most of **Phase 1
+(security hardening)** + **Phase 2 (observability) plumbing**, as small verified PRs.
+
+## Operating model (how I run autonomously)
+- One work item → feature branch → PR → CI green → **self-merge to main** (owner/admin),
+  so later work builds on main. Each PR is small + revertible.
+- **Verify what I can** (Docker/OrbStack with `seccomp=unconfined`, local Postgres). What I
+  can't verify (live model runs, prod deploy, scale) → implement + mark **NEEDS-VERIFY** in
+  `HUMAN-REVIEW.md` and skip the run.
+- **Subagents** for isolated investigation + simple/parallel tasks (context isolation).
+- Update this file + `STATUS.md` + `WORKLOG.md` as I go.
+
+Status legend: ✅ done · 🔵 in progress · ⬜ todo · ⏸️ blocked (needs human) · 🧪 needs-verify
+
+---
+
+## Workstream A — Execution runtime & sandbox (Phase 0.5)
+- ✅ A1 — srt sandbox for Python tool exec + secret env-strip (**PR #3**, verified in container)
+- ⬜ A2 — Sandbox the **Bash** tool the same way (currently disallowed by default; wrap when enabled)
+- ⬜ A3 — Restrict the **worker env globally**: `ws-server.mjs` passes full `process.env` to the
+  worker (`workerEnv = {...process.env}`); narrow to an allowlist so secrets never enter the worker.
+- ⏸️ A4 — `glm-image` tool runs in-process (not sandboxed) → move to a sandboxed subprocess or proxy.
+  *(design choice; smaller priority)*
+- ⏸️ A5 — Typed `ExecutionRuntime` interface + Docker/serverless backends + per-session sandbox pool.
+  **Big refactor — needs a design checkpoint with the human before building.** (Phase 0.5 core)
+
+## Workstream B — Tenant isolation & auth (Phase 1, Risks #2/#3/#4)
+- 🔵 B1 — Cross-tenant **file/attachment** access: add owner predicates to
+  `src/routes/api/workspace/$sessionId.documents.ts` + `src/server/function/message-attachment.server.ts`
+  (+ audit all `db.select().from(files/...)` for missing `clientId`/owner scoping). Regression tests vs local Postgres. *(Block C)*
+- ⬜ B2 — Keep `canUseTool` active in `bypassPermissions` mode (Risk #2).
+- ⬜ B3 — Unify the two path-traversal guards (`path-security.js` vs route `validateFilePath`).
+
+## Workstream C — Agent loop safety (Phase 1, Risks #5/#10 + abort)
+- ⬜ C1 — `maxTurns` / `maxBudgetUsd` on `query()` + a server-side wall-clock watchdog (Risk #5).
+- ⬜ C2 — Client liveness: heartbeat + idle timeout; emit terminal frame on worker crash (Risk #10).
+- ⬜ C3 — Cooperative abort via AbortController; remove dead `ws.abortController` references.
+- ⬜ C4 — Backpressure: honor `ws.bufferedAmount` / stdout drain.
+
+## Workstream D — Observability & accounting (Phase 2; plumbing only, policy deferred)
+- ⬜ D1 — Persist token/cost/turns per run from the SDK `result` event (new table + migration).
+- ⬜ D2 — Wire `spendOneCredit` on run completion (plumbing; **billing policy = human decision**).
+- ⬜ D3 — Audit-log table for security-relevant actions.
+- ⬜ D4 — Stop unconditional message-content logging (`ws-server.mjs:952,1158`) — guard behind env.
+
+## Workstream E — Foundation hygiene (Phase 0 leftovers)
+- ⬜ E1 — Fix `docker:up` so it works without manual `source .env` (compose `${VAR:?}` interpolation).
+- ⬜ E2 — Make tests CI-runnable: split unit vs e2e; run unit in CI; e2e via compose services (partial).
+- ⬜ E3 — Chip away TS errors → re-enable `typecheck` as a hard gate (delegate batches to subagents).
+- ⬜ E4 — Migrate the cross-tenant REST routes → Server Functions (overlaps B1); then chip the rest.
+- ⬜ E5 — Bump gitleaks/checkout actions off Node 20 (deprecation ~2026-06-16).
+
+## Rough sequencing (2 weeks)
+Week 1: A1✅ → **B1** → C1 → C2/C3 → A2/A3 → D4 + E1 (quick wins).
+Week 2: D1/D2/D3 → B2/B3 → E2/E3 → E4. A5 + scale work await the design checkpoint + accounts.
+
+## PR ledger
+- PR #1 — CI gates (merged)
+- PR #2 — project memory + research (open → merging)
+- PR #3 — srt Python sandbox / Risk #1 (open, CI green)
+- _next PRs appended here as opened/merged_

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -1,23 +1,27 @@
 # OxyGenie — Status (Living Memory)
 
 > **This is the living memory of the project. Update it whenever state changes.**
-> Last updated: **2026-05-29**
+> Last updated: **2026-05-30**
 
 ## Current position (one-paragraph snapshot)
 
-We have finished the **research phase** (an adversarial architecture review +
-Deep Agents comparison — see [`research/`](./research/2026-05-architecture-review.md))
-and are now in **Phase 0: Foundation**. We are *laying the groundwork* (repo
-split, CI gates, dev environment) **before** starting the actual tuning/hardening
-work. No production tuning or security fixes have started yet — that begins in
-Phase 1 once the foundation is solid.
+Research is done — the adversarial architecture review + Deep Agents comparison
+([`research/2026-05-architecture-review.md`](./research/2026-05-architecture-review.md))
+**and** a scalability / execution-runtime study
+([`research/2026-05-scalability-and-runtime.md`](./research/2026-05-scalability-and-runtime.md)).
+We are in **Phase 0: Foundation**, laying groundwork (repo split, CI gates, dev env)
+**before** real tuning. The runtime study added **Phase 0.5** (execution-runtime + sandbox
+decision) ahead of Phase 1: adopt Anthropic's `srt` for sandboxing + a TS `ExecutionRuntime`
+abstraction, then a 100→1000-concurrency bake-off (serverless vs self-hosted sandboxes).
+No production tuning / security fixes have started yet.
 
 ## Phase tracker
 
 | Phase | State |
 |---|---|
-| Research (architecture review + Deep Agents comparison) | ✅ Done |
+| Research (architecture review, Deep Agents comparison, scalability/runtime) | ✅ Done |
 | **Phase 0 — Foundation** | 🔵 In progress |
+| Phase 0.5 — Execution-runtime & sandbox decision | ⬜ Not started (defined) |
 | Phase 1 — Security hardening | ⬜ Not started |
 | Phase 2 — Observability & accounting | ⬜ Not started |
 | Phase 3 — Catch up to Deep Agents | ⬜ Not started |
@@ -25,6 +29,12 @@ Phase 1 once the foundation is solid.
 
 ## Done (most recent first)
 
+- ✅ **Scalability / runtime research** (deep-read of hermes-agent, deer-flow, ruflo,
+  Anthropic `srt`) → target architecture + Plan A/B + **Phase 0.5** added to ROADMAP.
+  Key find: adopt `@anthropic-ai/sandbox-runtime` (TS, Apache-2.0) for exec isolation.
+  See `research/2026-05-scalability-and-runtime.md`. *(2026-05-30)*
+- ✅ **References filled + indexed**: shallow-cloned 5 new agent repos, updated key ones,
+  created tracked `references/INDEX.md` (query-first memory) + this repo's `WORKLOG.md`. *(2026-05-30)*
 - ✅ **main branch protection** on `oxygenie` (required checks: `Quality Checks (22.12)`
   + `gitleaks`; 1 review + CODEOWNER required; no direct/force push). *(2026-05-29)*
 - ✅ Repo made **public** (it's an open-source product; history was already public via
@@ -61,7 +71,7 @@ Phase 1 once the foundation is solid.
 | Migrate 15 REST routes → Server Functions | M | Overlaps cross-tenant security fixes (Risks #3/#4) |
 | Make tests CI-runnable (unit/e2e split + services) | M | Then make `test` a hard gate |
 | Fix TS errors | S–M | Good starter task; then make `typecheck` a hard gate |
-| Sandbox Python/Bash exec (bubblewrap) + env allowlist | M–L | **Critical** (Risk #1); highest security priority |
+| Sandbox Python/Bash exec — adopt `srt` + env allowlist | M | **Critical** (Risk #1); via Phase 0.5 `ExecutionRuntime` + Anthropic `srt` |
 | `changedoc` (ai-pr-docs) needs `OPENAI_API_KEY` secret | S (chore) | Deferred by decision; or disable the AI workflows |
 | Archive old public repo `constructa-starter` | S (chore) | Avoid two-public-repo confusion |
 | Bump gitleaks/checkout actions off Node 20 | S (chore) | Deprecation forced ~2026-06-16 |
@@ -74,6 +84,14 @@ Phase 1 once the foundation is solid.
 
 ## Decision log
 
+- **2026-05-30** — Execution layer: insert **Phase 0.5** (runtime + sandbox) before Phase 1.
+  Adopt **`@anthropic-ai/sandbox-runtime` (srt)** as the exec sandbox primitive; define a TS
+  **`ExecutionRuntime`** abstraction (pattern from hermes-agent `BaseEnvironment` + deer-flow
+  `SandboxProvider`); then bake-off serverless (Modal/Daytona/E2B) vs self-hosted container pool
+  at 100→1000 concurrency. Rationale: per-message-spawn + single ws-server can't scale; srt is
+  TS/Apache-2.0 and fixes Risk #1. (See `research/2026-05-scalability-and-runtime.md`.)
+- **2026-05-30** — Reference mgmt: shallow-clone repos, keep tracked `references/INDEX.md`,
+  query-first / record-on-deep-contact. ruflo judged out-of-scope (local CC augmentation, not server scaling).
 - **2026-05-29** — Strategy: **harden + borrow from Deep Agents; do not migrate/integrate.**
   Rationale: Deep Agents is a single-process library with divergent goals; our
   platform/isolation/SDK investment is the asset. (See VISION §5.)

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -1,0 +1,92 @@
+# OxyGenie — Status (Living Memory)
+
+> **This is the living memory of the project. Update it whenever state changes.**
+> Last updated: **2026-05-29**
+
+## Current position (one-paragraph snapshot)
+
+We have finished the **research phase** (an adversarial architecture review +
+Deep Agents comparison — see [`research/`](./research/2026-05-architecture-review.md))
+and are now in **Phase 0: Foundation**. We are *laying the groundwork* (repo
+split, CI gates, dev environment) **before** starting the actual tuning/hardening
+work. No production tuning or security fixes have started yet — that begins in
+Phase 1 once the foundation is solid.
+
+## Phase tracker
+
+| Phase | State |
+|---|---|
+| Research (architecture review + Deep Agents comparison) | ✅ Done |
+| **Phase 0 — Foundation** | 🔵 In progress |
+| Phase 1 — Security hardening | ⬜ Not started |
+| Phase 2 — Observability & accounting | ⬜ Not started |
+| Phase 3 — Catch up to Deep Agents | ⬜ Not started |
+| Phase 4 — Multi-model & scale | ⬜ Not started |
+
+## Done (most recent first)
+
+- ✅ **main branch protection** on `oxygenie` (required checks: `Quality Checks (22.12)`
+  + `gitleaks`; 1 review + CODEOWNER required; no direct/force push). *(2026-05-29)*
+- ✅ Repo made **public** (it's an open-source product; history was already public via
+  the old `constructa-starter` mirror, and verified secret-free). *(2026-05-29)*
+- ✅ **CI gates merged to main** (PR #1): `pnpm build` check, **gitleaks** secret scan
+  (full-history config + placeholder allowlist), PR template, CODEOWNERS. *(2026-05-29)*
+- ✅ **Secret-leak audit** of full git history (incl. dangling objects): **clean** —
+  no real keys; only placeholders in example/doc files; `data/` never committed. *(2026-05-29)*
+- ✅ **Hygiene**: untracked `.env.docker` → `.env.docker.example`; ignored `/data/`,
+  `/user-data/`. *(2026-05-29)*
+- ✅ **Repo split**: product extracted to `github.com/foreveryh/oxygenie` (private→public),
+  full 383-commit history + 4 tags; `origin`=oxygenie, `upstream`=constructa-starter. *(2026-05-29)*
+- ✅ **Research**: adversarial architecture review + Deep Agents (py/js/ui) comparison
+  + Claude Agent SDK alignment. See `research/2026-05-architecture-review.md`.
+
+## In progress
+
+- 🔵 Building out **project memory** (this `docs/project/` set). *(2026-05-29)*
+
+## Next up (Phase 0 remainder, roughly ordered)
+
+1. ⬜ **Isolated, reproducible dev environment** (devcontainer / compose dev profile;
+   secrets separated; one-command boot of web + ws-server + Postgres/Redis/MinIO/Meili).
+   *(Also the starting point for Phase 1 Risk #1.)*
+2. ⬜ **TS-ify the agent runtime** + typed WS protocol (prerequisite for harness features).
+3. ⬜ Make tests CI-runnable (unit/e2e split + service containers) → re-enable `test` gate.
+4. ⬜ Fix TS errors → re-enable `typecheck` gate.
+5. ⬜ Migrate 15 REST routes → Server Functions → re-enable `validate-routes` gate.
+
+## Backlog (with difficulty tags)
+
+| Item | Difficulty | Notes |
+|---|---|---|
+| Migrate 15 REST routes → Server Functions | M | Overlaps cross-tenant security fixes (Risks #3/#4) |
+| Make tests CI-runnable (unit/e2e split + services) | M | Then make `test` a hard gate |
+| Fix TS errors | S–M | Good starter task; then make `typecheck` a hard gate |
+| Sandbox Python/Bash exec (bubblewrap) + env allowlist | M–L | **Critical** (Risk #1); highest security priority |
+| `changedoc` (ai-pr-docs) needs `OPENAI_API_KEY` secret | S (chore) | Deferred by decision; or disable the AI workflows |
+| Archive old public repo `constructa-starter` | S (chore) | Avoid two-public-repo confusion |
+| Bump gitleaks/checkout actions off Node 20 | S (chore) | Deprecation forced ~2026-06-16 |
+
+## Known weakened gates (intentionally non-blocking until backlog done)
+
+- `typecheck` — non-blocking (pre-existing TS errors).
+- `validate-routes` — non-blocking (15 pre-existing REST-route violations).
+- `test` — non-blocking (suite is e2e/integration; needs DB + live server in CI).
+
+## Decision log
+
+- **2026-05-29** — Strategy: **harden + borrow from Deep Agents; do not migrate/integrate.**
+  Rationale: Deep Agents is a single-process library with divergent goals; our
+  platform/isolation/SDK investment is the asset. (See VISION §5.)
+- **2026-05-29** — Repo topology: separate code repo (`oxygenie`) from the docs/PM
+  repo; **no submodule** (friction for many contributors); keep old remote as `upstream`.
+- **2026-05-29** — Make `oxygenie` **public** to unlock free branch protection and
+  because it is intended to be open-source; verified safe (history already public + secret-free).
+- **2026-05-29** — Phase-0 CI: keep `lint`/`build`/`gitleaks` as hard gates now;
+  `typecheck`/`validate-routes`/`test` non-blocking until their backlog items land.
+
+## How to use this file
+
+- Update the **snapshot**, **Done/In progress/Next**, and **Decision log** as part of
+  finishing any meaningful task.
+- When a phase's exit criteria are met, flip its row in the Phase tracker and in `ROADMAP.md`.
+- Keep difficulty tags on backlog items so work can be parcelled out by skill level.

--- a/docs/project/VISION.md
+++ b/docs/project/VISION.md
@@ -1,0 +1,86 @@
+# OxyGenie — Vision & Architectural Identity
+
+> **North star:** turn OxyGenie into an excellent open-source project that
+> **surpasses Deep Agents** — by combining Deep Agents' *harness* strengths with
+> OxyGenie's *platform* strengths, on a security-first, production-grade base.
+
+## 1. What OxyGenie is
+
+OxyGenie is a **web-based, multi-tenant, autonomous Claude-agent platform** —
+think "Claude Desktop as a deployable SaaS." It is built on **TanStack Start**
+(SSR + Nitro) and deliberately runs **two agent runtimes side by side**:
+
+1. **Process-isolated Claude Agent SDK runtime** (the real interactive loop).
+   A standalone WebSocket server (`ws-server.mjs`) authenticates each socket
+   against the web app, then **spawns a fresh child process per message**
+   (`ws-query-worker.mjs`) that calls `@anthropic-ai/claude-agent-sdk`'s
+   `query()` inside a per-session sandbox workspace with a per-user
+   `CLAUDE_HOME`, a path-security guard, dynamic MCP servers, and on-disk Skills.
+2. **In-process Mastra runtime** (`src/mastra`) over HTTP/SSE for
+   file-analysis / workflow tasks, currently on Zhipu GLM.
+
+Around these sits a conventional SaaS stack: Better Auth + organizations,
+Drizzle/Postgres, Polar billing, a BullMQ worker, S3/MinIO, Meilisearch.
+
+**Key truth:** OxyGenie is *not* an agent harness in the Deep Agents sense — it
+**delegates the agent loop to the Claude Agent SDK's `claude_code` preset** and
+invests its own engineering in the **multi-tenant platform shell** (transport,
+isolation, permissions, web UI, deployability).
+
+## 2. What we are trying to be (the production harness)
+
+A production-grade autonomous-agent product with:
+multi-model support · multi-tenancy · deployability · observability ·
+autonomous execution · a real web UI · and **strong security/sandboxing**.
+
+## 3. Where we already win (keep these)
+
+Validated by the architecture review (see `research/`):
+
+- **Process isolation of the agent loop** — fault + tenant isolation, clean
+  OS-level cancellation. Stronger than Deep Agents' in-process model.
+- **Cross-user filesystem fencing + realpath anti-symlink** (`src/claude/path-security.js`).
+- **A sophisticated web tier** — streaming with throttling, WebSocket
+  reconnect/backoff + re-resume, run-queue with epoch cancellation, rich
+  artifact/file previews. Ahead of `deep-agents-ui`.
+- **Config-driven, provider-pluggable MCP layer** (`src/claude/mcp/manager.js`).
+
+## 4. Where Deep Agents wins (what we must catch up on)
+
+Because Deep Agents *is* the harness, it ships first-class:
+**planning/todo**, **sub-agents** (typed, per-subagent overrides),
+**human-in-the-loop tool approval**, **checkpointing / durable resume**, and
+**context management** (summarization, prompt caching, memory). OxyGenie
+currently delegates or lacks these. Closing this gap — *on top of* our platform
+advantages — is the path to surpassing Deep Agents.
+
+## 5. Strategic decision (settled)
+
+**Harden the current design and borrow patterns — do NOT migrate to or integrate
+Deep Agents.** Deep Agents is a single-process LangGraph library with divergent
+goals; a wholesale migration would discard our platform investment and SDK
+alignment. We re-implement the missing harness capabilities against our own
+WebSocket protocol and the Claude Agent SDK.
+
+## 6. Principles — do / don't
+
+**Do**
+- Security-first: treat tool execution as untrusted; sandbox it; least-privilege env.
+- Keep the process-isolation substrate; preserve tenant isolation everywhere.
+- Use **TanStack Server Functions** for server logic (typed RPC).
+- Minimal necessary change; extend/adapt over rewrite (this repo started from a starter).
+- Evidence-based decisions: cite files; record decisions in `STATUS.md`.
+- Make capabilities testable + observable before declaring them "done."
+
+**Don't**
+- Commit secrets / `.env` / credentials (a secret scanner enforces this).
+- Add new REST API routes under `src/routes/api/*` (use Server Functions).
+- Weaken or bypass cross-tenant isolation for convenience.
+- Migrate wholesale to Deep Agents, or over-engineer ahead of need.
+- Let the two runtimes (Claude SDK vs Mastra) silently fork shared logic.
+
+## 7. Pointers
+
+- Phased plan → [`ROADMAP.md`](./ROADMAP.md)
+- Current state + ToDo (living) → [`STATUS.md`](./STATUS.md)
+- The research that grounds all of this → [`research/2026-05-architecture-review.md`](./research/2026-05-architecture-review.md)

--- a/docs/project/WORKLOG.md
+++ b/docs/project/WORKLOG.md
@@ -1,0 +1,57 @@
+# Work Log — Lessons & Techniques
+
+Running log of problems hit and techniques learned while developing OxyGenie, so we
+(and future contributors / agents) don't repeat them. Append newest at the top.
+
+## Environment & tooling gotchas (this workspace)
+
+- **Shell is `zsh`, not bash.** Avoid bash-isms:
+  - `declare -A` / `${!arr[@]}` / `${arr[$k]}` → `bad substitution` (an associative-array
+    clone loop silently failed this way and cloned nothing).
+  - Unquoted globs that don't match (e.g. `readme*.md`) → zsh **errors** (`no matches found`)
+    and can abort the command. Quote paths; use explicit filenames.
+  - Prefer `git -C <dir>` over `cd <dir>` (cwd persistence across calls is flaky; `cd` can
+    also prompt for permission).
+- **Don't trust the terminal echo when output looks doubled/garbled.** Write status to a
+  file and `Read` it instead — several "confirmations" were corrupted renders that misled me.
+- **`gh repo clone <owner>/<repo>`** (authenticated) beats raw `git clone` over HTTPS, which
+  prompts for a username on private/404 repos (`could not read Username` → looks like a hang).
+- **Shallow clone references**: `gh repo clone X dir -- --depth 1 --single-branch` (read-only study).
+
+## Subagent / delegation discipline
+
+- **Verify a path exists (cheap `ls`) BEFORE delegating a subagent to read it.** Delegating 5
+  summaries to repos that weren't actually cloned wasted ~230k tokens (each agent explored the
+  whole tree to conclude "missing").
+- **Constrain read scope explicitly** ("read only README head + top-level `ls`; do not recurse")
+  or agents over-read (a haiku summarizer burned ~46k tokens scanning a whole repo).
+- **Don't mix fail-prone Bash with Agent calls in one tool batch** — a Bash error cancels the
+  entire parallel batch (lost 5 queued agents this way).
+- Delegation triage: mechanical/bounded → cheap subagents (haiku/sonnet); architecture
+  comprehension / decisions / log analysis → do it myself.
+
+## Git / GitHub
+
+- **`git commit -- <pathspec>` commits the WORKING-TREE version of a still-present path.** After
+  `git rm --cached .env.docker` (file kept on disk), passing `.env.docker` in the commit pathspec
+  re-added it. Fix: stage the removal and commit staged changes (no pathspec), or `--amend`.
+- **Branch protection on a *private* repo needs GitHub Pro (or an org/Team).** Free + private →
+  classic protection and rulesets both 403. We made the repo public (it's open-source) to unlock it.
+- **Selective commits**: when there are unrelated in-flight changes, stage exact paths and commit
+  only those — verify with `git diff --cached --name-only` before committing.
+
+## Workflow tool
+
+- **Don't naively slice a giant JSON payload into a single synthesis prompt** — a 90k-char
+  `.slice()` truncated upstream data and the synthesizer (correctly) refused to fabricate the
+  missing parts. Split synthesis into ordered sub-writers, or compact the data first.
+- A workflow's cached agent results survive in `journal.jsonl`; you can recover and re-synthesize
+  from them if the synthesis step fails (e.g., transient API 529s).
+
+## Reference-library management
+
+- Shallow-clone into `references/`; keep a tracked `references/INDEX.md` (repos stay git-ignored).
+- **Query the INDEX first; record on first deep contact** (upgrade 🟡→🟢 with key files). Don't
+  re-scan a tree you've already characterized.
+
+_Last updated: 2026-05-30._

--- a/docs/project/research/2026-05-architecture-review.md
+++ b/docs/project/research/2026-05-architecture-review.md
@@ -1,0 +1,260 @@
+# OxyGenie — Adversarial Architecture Review & Deep Agents Comparison
+
+> **Status:** frozen research snapshot · **Date:** 2026-05 · **Subject:** the
+> `oxygenie` codebase (formerly `constructa-starter`) vs the Deep Agents family.
+>
+> Method: a read-only, multi-agent review — parallel investigators per workstream,
+> independent adversarial refuters per major finding, and comparison agents vs the
+> Deep Agents Python/JS/UI references and the Claude Agent SDK docs. Every finding
+> below survived (or was downgraded by) an adversarial refuter. Refuted/overstated
+> claims were dropped. File paths are repo-relative to the product root.
+
+---
+
+## 1. What OxyGenie is architecturally trying to be
+
+An **enterprise, multi-tenant, web-delivered autonomous Claude-agent platform**
+on TanStack Start (SSR + Nitro), running **two independent agent runtimes**:
+
+1. **Process-isolated Claude Agent SDK runtime** (the real interactive loop):
+   `ws-server.mjs` owns `/ws/agent` (`ws-server.mjs:1195`), authenticates each
+   socket by HTTP-calling Better Auth (`ws-server.mjs:567`), and spawns a fresh
+   child per message (`ws-server.mjs:771`). The child `ws-query-worker.mjs` calls
+   `@anthropic-ai/claude-agent-sdk@0.1.76`'s `query()` (`ws-query-worker.mjs:427`)
+   in a per-session workspace with per-user `CLAUDE_HOME`, a path-security guard,
+   dynamic MCP servers, and on-disk Skills.
+2. **In-process Mastra runtime** (`src/mastra`) over HTTP/SSE (`src/routes/api/chat.tsx`),
+   Zhipu GLM (`zhipuai/glm-5.0`).
+
+Defining trait: **process isolation of the agent loop from the web tier.**
+OxyGenie is **not** a harness in the Deep Agents sense — it delegates the loop to
+the SDK's `claude_code` preset (`ws-query-worker.mjs:442,451-455`) and invests in
+the multi-tenant platform shell. It is **two single-vendor runtimes** (Anthropic
+for chat, Zhipu for Mastra) plus a genuinely pluggable MCP/Skills layer — not a
+unified multi-model router.
+
+---
+
+## 2. Architecture map
+
+### Layers
+
+| Layer | Key paths | Role |
+|---|---|---|
+| Web/SSR (TanStack Start + Nitro) | `src/router.tsx`, `src/start.ts`, `src/routes/**`, `vite.config.ts` | HTTP/SSR + UI; all `/api/*`; auto-migrate on boot (`src/start.ts:10-12`) |
+| Claude WS runtime (isolated) | `ws-server.mjs`, `ws-query-worker.mjs`, `start-production.mjs` | The real Claude loop: socket, auth-by-HTTP, session/workspace/skills, child lifecycle, DB-via-HTTP |
+| Claude shared modules | `src/claude/path-security.js`, `src/claude/mcp/manager.js`, `src/claude/python/runner.js`, `src/claude/adapters/ws-adapter.ts`, `src/claude/skills/*` | `.js` runs in worker; `.ts` serves Nitro/browser |
+| Mastra runtime | `src/mastra/*`, `src/routes/api/chat.tsx` | 2nd runtime; in-process; HTTP/SSE; GLM |
+| Server fns & API | `src/server/*`, `src/routes/api/agent-sessions/*`, `src/routes/api/workspace/$sessionId.*` | `/api/agent-sessions` + `/api/auth/*` are the callbacks the WS server uses |
+| Persistence | `src/db/schema/*` | `agent_session` (Claude index) + `mastra_thread` (Mastra) — separate models |
+| Background jobs | `src/worker/*` | BullMQ: credit refill + Meilisearch reindex |
+| Deploy | `Dockerfile`, `docker-compose*.yml`, `infra/deploy/*`, `.github/workflows/*` | Multi-stage image; Node+Python+LibreOffice+Playwright |
+
+### Runtime flow — Claude chat (the real loop)
+1. Browser mounts Assistant UI with `ClaudeAgentWSAdapter` (`src/claude/adapters/ws-adapter.ts`).
+2. Persistent WS to `/ws/agent`; `run()` sends `{type:'chat',...}`.
+3. Socket terminates in `ws-server.mjs` (not Nitro); auth via `/api/auth/get-session`.
+4. `handleChat` (`ws-server.mjs:658`) resolves CLAUDE_HOME/workspace, `.claude` symlink, syncs Skills, fetches org permission mode, spawns the worker (`:771`).
+5. Worker builds path-security `canUseTool` + MCP servers, calls `query()` (`:427`).
+6. Worker streams SDK events as stdout JSON lines; `ws-server` forwards `{type:'message',event}`; on `system.init` captures SDK `session_id` and POSTs `/api/agent-sessions`.
+7. Browser maps SDK blocks → Assistant UI parts (text throttled 100ms) into a Zustand store.
+
+### Verified correction
+`vite.config.ts:42-43` claims a Nitro plugin `server/plugins/websocket.mjs` handles
+the WS server — **that file doesn't exist**; the WS server boots only via
+`start-production.mjs`/`start.sh`. Dead documentation.
+
+---
+
+## 3. Deep Agents (Python) comparison
+*Ref: `references/useful_frameworks/deepagents`*
+
+| Capability | OxyGenie | Deep Agents (Py) | Assessment |
+|---|---|---|---|
+| Owns the agent loop | Delegated to SDK `query()` + `claude_code` preset | `create_deep_agent` builds a LangGraph middleware stack (`graph.py:217`) | divergent-goals |
+| Planning/todo | None of its own; renders count only | `TodoListMiddleware` in every stack | reference-better |
+| Sub-agents | SDK Task tool only; forwards `parent_tool_use_id` | `SubAgentMiddleware`, per-subagent overrides | reference-better |
+| Virtual filesystem | Real on-disk per-session workspace, path-fenced | Pluggable backends (State/FS/Sandbox/Store) | divergent-goals |
+| State/durability | Stateless per msg; SDK `resume` + DB map | LangGraph checkpointer, `DeltaChannel` reducer | divergent-goals |
+| Human-in-the-loop | Hard allow/deny only, no round-trip | `HumanInTheLoopMiddleware` (approve/edit/reject) | reference-better |
+| FS access control | Per-user prefix + realpath + cross-user denial | `FilesystemPermission` rules | **oxygenie-better** |
+| Sandbox/exec isolation | OS process-per-msg + Docker | optional `SandboxBackendProtocol` | **oxygenie-better** |
+| Context mgmt | none of its own (relies on preset) | summarization + prompt caching + memory | reference-better |
+| Multi-tenant identity | first-class (auth/org/roles) | out of scope | **oxygenie-better** |
+
+**Takeaway:** OxyGenie invests in the *platform*; Deep Agents *is* the harness.
+Not substitutes. We win on isolation/multi-tenancy/FS-fencing; they win on
+planning/sub-agents/HITL/checkpointing/context — because those are harness features
+we chose not to own.
+
+---
+
+## 4. Deep Agents JS comparison
+*Ref: `references/useful_frameworks/deepagentsjs`*
+
+| Capability | OxyGenie | Deep Agents JS | Assessment |
+|---|---|---|---|
+| Construction API | direct `query()` options object | `createDeepAgent()` factory → compiled graph (`agent.ts:140-502`) | divergent-goals |
+| Compile-time typing | none — untyped `.mjs`, JSON over stdin | heavy generic inference (`types.ts:104-227`) | reference-better |
+| Structured responses | opt-in `outputFormat`, env+regex gated | typed `responseFormat` strategies | reference-better |
+| Subagent streaming | `parent_tool_use_id` rollup only | typed `run.subagents` (`stream.ts:49-112`) | reference-better |
+| HITL / interrupts | `canUseTool` deny only | `interruptOn` + checkpoint pause | divergent-goals |
+| Checkpointing | none; SDK `resume` | `checkpointer`/`store` → full graph state | divergent-goals |
+| Run cancellation | **OS process kill** (reliable) | in-process `config.signal` only | **oxygenie-better** |
+| Multi-tenant/web | built-in | out of scope | **oxygenie-better** |
+| Process isolation | child per message | in-process graph | **oxygenie-better** |
+
+**Takeaway:** starkest gap is **type safety**; biggest offset is our
+**process-isolated cancellation**.
+
+---
+
+## 5. Deep Agents UI comparison
+*Ref: `references/useful_frameworks/deep-agents-ui`*
+
+| Capability | OxyGenie | Deep Agents UI | Assessment |
+|---|---|---|---|
+| Streaming render | custom generator, 100ms throttle, reasoning split | `useStream` reduces server stream | **oxygenie-better** |
+| Tool-call viz | rich per-turn timeline + per-type drawers | generic expandable boxes | **oxygenie-better** |
+| Sub-agent (Task) viz | none dedicated (regex "backgrounded") | first-class `SubAgentIndicator` | reference-better |
+| Todo / plan panel | **none** | dedicated todo panel from `stream.values.todos` | **oxygenie-missing** |
+| File/artifacts | real disk tree + artifact previews | editable in-state `Record<string,string>` | divergent-goals |
+| HITL approval | **none** (programmatic deny only) | full approve/reject/edit + Debug step-through | reference-better |
+| Reconnect/error | app-level backoff + re-resume + beforeunload | delegated to SDK | **oxygenie-better** |
+| Run queueing | promise-gate + epoch cancel + switch modal | single `isLoading` gate | divergent-goals |
+
+**Three concrete UI gaps to borrow:** (1) todo/plan panel, (2) first-class
+sub-agent panel, (3) HITL approve/reject/edit.
+
+---
+
+## 6. Claude Agent SDK alignment
+*Verified vs installed `@anthropic-ai/claude-agent-sdk@0.1.76` + docs.*
+
+| Surface | OxyGenie usage | Aligned? |
+|---|---|---|
+| Package/version, `query()` entry, options shape | correct for 0.1.76 | ✅ |
+| `canUseTool`/`PermissionResult` | conforms; realpath + cross-user denial exceed baseline | ✅ strong |
+| `permissionMode` union | hardcodes `delegate` (not in docs), omits `auto` | ⚠️ divergent |
+| MCP servers (sdk/stdio/sse/http) | uniform per-user resolution + `${VAR}` templating | ✅ strong |
+| `settingSources:['project']` + Skills | via `.claude` symlink | ✅ (symlink-dependent) |
+| system prompt / tools preset | correct `{type:'preset',...}` | ✅ |
+| Subagents (`agents` option) | **never used**; `Agent` absent from `allowedTools` | ❌ unused |
+| Hooks | **never configured** | ❌ unused |
+| `maxTurns`/`maxBudgetUsd` | supported, **not used** | ❌ |
+| AbortSignal / `interrupt()` | supported, **not used** (`ws.abortController` is dead code) | ❌ |
+| In-repo CLAUDE.md SDK docs | stale/wrong signatures | ❌ doc drift |
+
+**Net:** call-shape alignment is high; safety options + subagents/hooks go unused.
+
+---
+
+## 7. Capabilities that are MISSING
+
+1. Turn / wall-clock / token-cost bound on the loop (`ws-query-worker.mjs:429-465`; no watchdog).
+2. Usage metering that runs — `spendOneCredit` (`src/server/credits.ts:46`) has **zero callers**.
+3. Server-side token/cost accounting — the SDK `result` event is forwarded but **not persisted** (`ws-server.mjs:806-867`).
+4. Audit log — no audit table exists.
+5. Real OS sandbox — `bubblewrap` installed (`Dockerfile:62`) but **never invoked**.
+6. HITL approval, todo panel, sub-agent panel (vs `deep-agents-ui`).
+7. Unified model registry / provider failover.
+8. Conversation checkpointing (`resumeSessionAt` exists in SDK, unused).
+9. Subagents & hooks (`agents`/`hooks` never passed).
+
+---
+
+## 8. Capabilities that EXIST but are FRAGILE
+
+1. `bypassPermissions` removes the path-security guard entirely (`ws-query-worker.mjs:435-436`).
+2. Cancellation is process-kill only; `ws.abortController` is dead code (`ws-server.mjs:1058-1060,1230`).
+3. Concurrent same-connection message silently kills the in-flight worker (`ws-server.mjs:661-665`).
+4. Silent socket death parks the client generator forever — no timeout (`ws-adapter.ts:823-826`).
+5. Forked skill-sync — two *live* divergent paths (inline JS in `ws-server.mjs` vs TS `manager.ts`).
+6. Two divergent path-traversal guards over the same files (`ws-query-worker.mjs:189` vs `$sessionId.file.$filePath.ts:14-37`).
+7. No backpressure on worker stdout / WS send.
+8. No global concurrency cap (one worker per connection).
+9. Single shared `ZHIPU_API_KEY` (chat + image + 4 MCP servers).
+10. Unconditional message-content logging (`ws-server.mjs:952,1158`) → PII in logs.
+11. `requireUser()` fails open to `dev-user-123` when `NODE_ENV!=='production'` (`require-user.ts:20-34`).
+12. Structured output gated by a filename regex + env flag (`ws-query-worker.mjs:131-142,214-221`).
+
+---
+
+## 9. Where our design may be BETTER / more appropriate
+
+1. Process-isolated agent loop (fault + tenant isolation; clean kill-on-abort).
+2. Cross-user FS denial + realpath anti-symlink (`path-security.js:147-163,289-296`).
+3. Config-driven, provider-pluggable MCP layer (`manager.js`).
+4. Sophisticated web tier (streaming throttle, reconnect/re-resume, run-queue, artifacts).
+5. OS-process cancellation (reliably reclaims compute).
+
+---
+
+## 10. Top 10 risks (post-refutation, ranked)
+
+| # | Risk | Severity | Evidence |
+|---|---|---|---|
+| 1 | **Python MCP tool = arbitrary code exec OUTSIDE the path guard, with full secrets env + unrestricted network** | **critical** | `path-security.js:4,270-272`; `python/runner.js:196-205`; `ws-query-worker.mjs:226-271,324-331`; `ws-server.mjs:734-744` |
+| 2 | `bypassPermissions` disables `canUseTool` entirely | high | `ws-query-worker.mjs:435-436`; `path-security.js:289-305` |
+| 3 | Cross-tenant file download (no owner predicate) | high | `$sessionId.documents.ts:124-131,170-205` |
+| 4 | Cross-tenant attachment access | high | `message-attachment.server.ts:99-151` |
+| 5 | No turn/timeout/cost cap on the loop | high | `ws-query-worker.mjs:429-465` |
+| 6 | No OS sandbox; bubblewrap installed but unused | high | `ws-server.mjs:771`; `Dockerfile:62,138` |
+| 7 | Usage credits never deducted (`spendOneCredit` unused) | high | `credits.ts:46-72` |
+| 8 | Deploy bypasses the WS server; port mismatch | high | `infra/deploy/compose.yml:14-16`; `start-production.mjs`; `Dockerfile:99,151` |
+| 9 | `dokku config:set` interleaves comment lines (env risk) | high | `.github/workflows/deploy.yml:123-160` |
+| 10 | Silent socket death + unsignaled worker crash → hung UI | high | `ws-adapter.ts:823-827`; `ws-server.mjs:884-910` |
+
+**Refuted/downgraded (excluded):** `realSdkSessionId` drift (SDK keeps id on non-fork
+resume); `sessionMapping` lost on restart (persisted in Postgres); `messageHandler`
+corruption (overstated); hardcoded Mastra model (trivial → low).
+
+---
+
+## 11. Top 10 highest-leverage fixes (effort S/M/L)
+
+| # | Fix | Effort | Addresses |
+|---|---|---|---|
+| 1 | Route non-file tools (python/Bash) through `canUseTool`; strip secrets from worker/python env | M | Risk 1 |
+| 2 | Run exec tools under `bubblewrap --unshare-net` + workspace-only binds | M | Risks 1,6 |
+| 3 | Add owner predicates to `documents.ts` / `message-attachment.server.ts` | S | Risks 3,4 |
+| 4 | Wire `maxTurns`/`maxBudgetUsd` + server watchdog | S+S | Risk 5 |
+| 5 | Call `spendOneCredit` + persist usage/cost from the `result` event | M | Missing #2/#3 |
+| 6 | Fix deploy to boot `start-production.mjs`; reconcile ports | M | Risk 8 |
+| 7 | Rewrite `dokku config:set` (drop interleaved comments) | S | Risk 9 |
+| 8 | Client heartbeat/idle timeout + terminal frame on worker crash | M | Risk 10 |
+| 9 | Keep `canUseTool` in `bypassPermissions` (narrowed) | M | Risk 2 |
+| 10 | Collapse skill-sync to one shared module; guard message-content logging | M+S | Fragile 5,10 |
+
+---
+
+## 12. Recommendation
+
+**Harden the current design — security first — and borrow three UI patterns
+(todo panel, sub-agent panel, HITL). Do NOT migrate to or integrate Deep Agents.**
+The comparison shows Deep Agents is a single-process library with divergent goals;
+OxyGenie's process isolation, multi-tenancy, web tier, and SDK alignment are the
+assets. Surviving risks are security/resource-bounding gaps, not architectural
+dead-ends — most are small wires into features the codebase already ships
+(`bubblewrap`, `canUseTool`, `maxTurns`, `spendOneCredit`). The single most urgent
+item is **Risk #1** (unsandboxed Python exec with full secrets) — exploitable today.
+
+---
+
+## 13. Minimal spike plan (each with pass/fail)
+
+1. **Contain the Python/exec tool** — bubblewrap `--unshare-net` + workspace bind + secret-stripped env. *Pass:* a Python tool call can't read `ANTHROPIC_API_KEY`, can't open a socket, can't read another user's workspace.
+2. **Cross-tenant proof** — owner predicates; test user B requesting user A's `fileId`/attachment is denied.
+3. **Budget + watchdog** — `maxTurns`/`maxBudgetUsd` + timeout; a looping prompt terminates and an abandoned worker is killed with a terminal frame.
+4. **Usage accounting** — completed turn writes a usage ledger row + server-side cost; balance decrements.
+5. **Deploy boots both servers** — fresh deploy serves web + a working `/ws/agent`.
+6. **UI liveness** — killing the worker/socket surfaces an error and unblocks the composer within N seconds.
+7. **Borrow todo + sub-agent + HITL panels** — a plan renders as a todo panel, a Task shows a nested sub-agent card, a gated tool prompts before proceeding.
+
+---
+
+### Provenance note
+Finding IDs are not globally unique across workstreams; each verdict was attributed
+by evidence content. Matrices/§1–§6 are taken from the comparison/investigator
+agents; §7–§13 are synthesized across all ten workstreams. Re-run as a new dated
+file under `research/` if the review is repeated.

--- a/docs/project/research/2026-05-scalability-and-runtime.md
+++ b/docs/project/research/2026-05-scalability-and-runtime.md
@@ -1,0 +1,149 @@
+# OxyGenie — Scalability & Execution-Runtime Research
+
+> **Status:** decision-grade research snapshot · **Date:** 2026-05-30
+> **Question:** can OxyGenie's current execution model serve hundreds/thousands of
+> concurrent sessions, is there a more elegant design, and which mature projects can
+> we adopt? Grounded by a deep-read of four reference repos (see `references/INDEX.md`).
+
+---
+
+## 1. The problem with the current execution model
+
+OxyGenie today runs the real agent loop as a **fresh Node child process per chat
+message** (`ws-server.mjs:771` → `ws-query-worker.mjs`) behind a **single stateful
+`ws-server`** process, with **per-user `CLAUDE_HOME` + per-session workspace on local
+disk** and an **in-memory `sessionMapping`** (`ws-server.mjs:214`). Consequences:
+
+- **Per-message spawn** loads the full SDK each time (~80–200 MB, hundreds of ms).
+  ~1000 concurrent messages ⇒ ~1000 Node processes ⇒ 100+ GB RAM — infeasible on one box.
+- **Single ws-server** = vertical bottleneck + SPOF; no clustering.
+- **Local state** (disk workspaces + in-memory map) ⇒ can't run N gateway replicas.
+- No queue / backpressure / concurrency cap.
+
+**Verdict:** fine for a single-node prototype; **not** built for hundreds/thousands of
+concurrent sessions. The execution layer needs a deliberate architecture decision
+**before** investing in security hardening / feature catch-up that would be rebuilt.
+
+---
+
+## 2. What the deep-read found (hypotheses → verdicts)
+
+| # | Hypothesis | Verdict | Evidence |
+|---|---|---|---|
+| H1 | hermes-agent gives a pluggable runtime-backend abstraction incl. serverless sandboxes | ✅ Confirmed | `tools/environments/base.py` `BaseEnvironment` ABC; Local/Docker/SSH/Singularity/Modal/Daytona backends; per-session LRU agent cache (128, 1h TTL) in `gateway/run.py`; SQLite session store resumable; Modal/Daytona snapshot hibernate/wake. **MIT, Python.** |
+| H2 | deer-flow validates a deployable backend/frontend + sandbox-mode + sizing | ✅ Confirmed | `backend/.../sandbox/sandbox_provider.py` `SandboxProvider` ABC (acquire/get/release); Local/Docker/**K8s-provisioner** backends; per-`{user}/{thread}` dirs; LangGraph checkpointer (SQLite→Postgres); SSE `StreamBridge`; sizing 8vCPU/16GB+ shared. **MIT, Python/FastAPI.** |
+| H3 | ruflo is a different problem (local Claude Code augmentation), not server scaling | ✅ Confirmed | Installs into user `.claude/`, local stdio MCP + hooks (`bin/cli.js`, `plugin/hooks/hooks.json`); "federation" = peer mTLS between user machines; "swarm" = single-machine bash `&`; **no sandbox**. **MIT, TS.** Borrowable only: 3-tier model routing, HNSW memory. |
+| H4 | sandbox-runtime is the low-level sandbox primitive to wrap | ✅✅ Confirmed (better than hoped) | **Anthropic `@anthropic-ai/sandbox-runtime` (srt) — TypeScript, Apache-2.0.** macOS Seatbelt + Linux bubblewrap+seccomp+namespaces + Windows WFP; deny-net + workspace-fenced FS by default; CLI `srt <cmd>` **and** library `SandboxManager.wrapWithSandbox(cmd)` → `spawn`. |
+
+**Headline:** the sandbox primitive we need is an **Anthropic-maintained, TypeScript,
+Apache-2.0 library** that drops into our Node server in ~10 lines and directly fixes the
+critical Risk #1 (unsandboxed Python/Bash with full secrets + network).
+
+---
+
+## 3. Reference details worth keeping
+
+### hermes-agent (Nous Research) — runtime-backend abstraction (pattern template)
+- `BaseEnvironment` (`tools/environments/base.py`): `execute()`, abstract `_run_bash() → ProcessHandle`,
+  `init_session()`, `cleanup()`, `_before_execute()` (file-sync hook). `ProcessHandle` duck-typed
+  protocol; `_ThreadedProcessHandle` bridges blocking SDK calls to a unified poll loop.
+- Backends: `local.py`, `docker.py` (hardened: `--cap-drop ALL`, `no-new-privileges`, `--pids-limit`,
+  tmpfs), `ssh.py`, `singularity.py`, `modal.py` (serverless + snapshot id store), `daytona.py`
+  (named sandbox stop/start = hibernate/wake).
+- Session: per-session long-lived agent, LRU(128)+1h TTL (`gateway/run.py`); SQLite (`hermes_state.py`)
+  resumable across restarts.
+- **Borrow (pattern, re-impl in TS):** the `BaseEnvironment`/`ProcessHandle` interface; per-session
+  cache+eviction; Modal/Daytona create-on-first-use + hibernate + snapshot-id persistence (both have Node SDKs).
+
+### deer-flow (ByteDance) — deployable architecture + pluggable sandbox provider
+- `SandboxProvider` ABC (`backend/.../sandbox/sandbox_provider.py`): `acquire/get/release`; `Sandbox`
+  ABC (`sandbox.py`): `execute_command`, file ops. Pluggable by dotted class path in `config.yaml`
+  (`resolve_class()`); Local / Docker / **Kubernetes provisioner sidecar** (sandbox pods, port 8002).
+- Runtime: single asyncio FastAPI gateway; per-turn `asyncio.Task` (`runtime/runs/worker.py`); SSE
+  `StreamBridge`; sub-agents via thread pools (cap 3); LangGraph checkpointer; per-`{user}/{thread}` dirs.
+- Claude Code integration via ACP (`invoke_acp_agent` → `npx @zed-industries/claude-agent-acp`).
+- **Borrow (pattern):** `SandboxProvider.acquire/release` lifecycle; K8s-provisioner sidecar for
+  sandbox pods (a concrete Plan-B scale path); per-user/thread isolation; checkpointer for resume.
+
+### sandbox-runtime (Anthropic `srt`) — the sandbox primitive to adopt
+- TS (Node ≥18), Apache-2.0. `SandboxManager.initialize(config)` + `wrapWithSandbox(cmd)` → `spawn`.
+- Config: `network.allowedDomains` (`[]` = none), `filesystem.denyRead/allowRead/allowWrite/denyWrite`.
+- macOS `sandbox-exec`; Linux bwrap + seccomp BPF (vendored) + net-namespace removal + socat proxy
+  (deps: `bubblewrap`, `socat`, `ripgrep` — we already install bubblewrap); Windows WFP.
+- **Caveat:** `SandboxManager` is module-level singleton → true per-session isolation needs process
+  separation or careful `reset()` sequencing (fits a per-session worker model well).
+- Key files: `src/sandbox/sandbox-manager.ts`, `.../linux-sandbox-utils.ts`, `.../macos-sandbox-utils.ts`.
+
+### ruflo — not our problem (recorded so we don't re-investigate)
+- Local Claude Code augmentation (hooks/daemon/local MCP); peer federation, not server scaling; no sandbox.
+- Borrow only: 3-tier model-routing heuristic; HNSW vector memory (`AgentDBBackend.ts`) if we add semantic recall.
+
+---
+
+## 4. Target architecture (proposed)
+
+Three decoupled tiers, each scaled independently:
+
+```
+[ Browser ]
+    | WS/SSE
+[ Stateless Gateway ]  (Nitro + a thin WS relay; no session state held locally)
+    | enqueue / route by sessionId
+[ Queue (Redis/NATS/SQS) ]
+    |
+[ Agent Worker Pool ]  (horizontal; each worker drives the SDK loop)
+    |  ExecutionRuntime (TS interface)
+    +-- backend: local-process + srt        (now / dev)
+    +-- backend: container (Docker)          (next)
+    +-- backend: serverless sandbox          (scale: Modal / Daytona / E2B, hibernate-on-idle)
+[ Shared state ]  Postgres/Redis (sessions, mappings, checkpoints) + object store (workspaces)
+```
+
+- **Sandbox primitive:** `srt` wraps every tool exec (deny-net, workspace-fenced FS).
+- **Per-session sandbox** (warm pool, reused across messages) replaces per-message spawn.
+- **State is shared, not local** → any worker handles any session; gateways are stateless/replicable.
+- **`ExecutionRuntime` interface** (`start/exec/stream/abort/snapshot/stop`) isolates the backend
+  choice so we can start local and grow to serverless/K8s without touching the agent loop.
+
+---
+
+## 5. Decision: Plan A vs Plan B
+
+- **Plan A — Integrate, don't reinvent (recommended lean).** Adopt **srt** for sandboxing
+  immediately (it's TS/Apache-2.0/Anthropic). For scale, wrap a **serverless sandbox provider
+  (Modal or Daytona, both have Node SDKs; or E2B)** behind the `ExecutionRuntime` interface —
+  offloading the hard "schedule thousands of sandboxes across hosts" problem to a managed service.
+- **Plan B — Self-build the pool.** If managed sandboxes are too costly / not self-hostable enough,
+  build a Docker→Kubernetes provisioner pool (deer-flow's model) behind the same interface.
+
+**Recommendation:** adopt **srt now** (independent of A/B — it's the Risk #1 fix and the local
+backend), define the **`ExecutionRuntime`** interface, and run a **bake-off spike** (Modal/Daytona
+vs Docker/K8s) at 100→1000 concurrent to choose A vs B with data. The interface means the choice
+is reversible and incremental.
+
+---
+
+## 6. Spike plan (Phase 0.5)
+
+1. **srt integration spike** — wrap the Python/Bash tool exec with `SandboxManager.wrapWithSandbox`;
+   *pass:* a tool call can't read `ANTHROPIC_API_KEY`, can't open a socket, can't read another
+   user's workspace (this is the Risk #1 acceptance test).
+2. **`ExecutionRuntime` interface + local backend** — define `start/exec/stream/abort/snapshot/stop`;
+   port one chat path off per-message spawn to a per-session sandboxed runtime.
+3. **State decoupling spike** — move `sessionMapping` + workspace pointers to Postgres/Redis +
+   object store; run two gateway replicas behind a load balancer for one logical session.
+4. **Scale bake-off** — implement a Modal *or* Daytona backend and a Docker backend; benchmark
+   memory/latency at 100 → 1000 concurrent sessions; record the curve; **decide A vs B**.
+
+---
+
+## 7. Relationship to the earlier review
+
+The earlier architecture review (`2026-05-architecture-review.md`) said "harden, don't migrate to
+Deep Agents" — that still holds (Deep Agents is a harness *library*, orthogonal to execution scale).
+This research adds the missing dimension: the **execution/runtime + scale layer** needs a decision
+(Phase 0.5) before Phase 1/3. Several Phase 1 items (esp. Risk #1 sandboxing, and checkpointing in
+Phase 3) are *subsumed* by adopting srt + the `ExecutionRuntime` abstraction.
+
+_Provenance: deep-read by 4 constrained parallel sub-agents over the on-disk reference repos
+(hermes-agent `689ef5e`, deer-flow `e8e9edc`, ruflo `48ca369`, sandbox-runtime `c738eaf`), 2026-05-30._


### PR DESCRIPTION
## Summary
Adds a durable **project memory** under `docs/project/` so anyone taking over the repo (even with no prior context) knows the direction, current state, and what to do next. This captures the research→foundation transition we're in.

## Files
- `docs/project/README.md` — index + how to keep the memory useful
- `docs/project/VISION.md` — big picture, architectural identity, goal (surpass Deep Agents), do/don't principles
- `docs/project/ROADMAP.md` — phased plan: Foundation → Security → Observability → Catch up to Deep Agents → Scale (with exit criteria)
- `docs/project/STATUS.md` — **living memory**: current phase, done/in-progress/next, backlog with difficulty tags, decision log
- `docs/project/research/2026-05-architecture-review.md` — the adversarial architecture review + **Deep Agents (py/js/ui) comparison** that grounds the whole plan

## Notes
- Pure docs; no code paths touched.
- `STATUS.md` is meant to be updated continuously as part of finishing tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)