### PR TITLE
fix(security): scope cross-tenant queries by owner (Risks #3/#4)

### DIFF
--- a/src/routes/api/workspace/$sessionId.documents.ts
+++ b/src/routes/api/workspace/$sessionId.documents.ts
@@ -167,10 +167,12 @@ export const Route = createFileRoute('/api/workspace/$sessionId/documents')({
             console.log(`[POST] Processing file: ${fileId}`);
 
             // Get file details
+            // Tenant isolation: only resolve files owned by the authenticated user
+            // (prevents downloading another tenant's file by id — review Risk #3).
             const [file] = await db
               .select()
               .from(files)
-              .where(eq(files.id, fileId));
+              .where(and(eq(files.id, fileId), eq(files.clientId, user.id)));
 
             if (!file) {
               console.log(`[POST] ERROR: File not found: ${fileId}`);

--- a/src/server/function/knowledge-bases.server.ts
+++ b/src/server/function/knowledge-bases.server.ts
@@ -110,7 +110,7 @@ export const updateKnowledgeBase = createServerFn({ method: 'POST' })
         description: data.description || null,
         updatedAt: new Date(),
       })
-      .where(eq(knowledgeBases.id, data.id))
+      .where(and(eq(knowledgeBases.id, data.id), eq(knowledgeBases.userId, user.id)))
       .returning();
 
     return updated;

--- a/src/server/function/knowledge-bases.server.ts
+++ b/src/server/function/knowledge-bases.server.ts
@@ -141,7 +141,7 @@ export const deleteKnowledgeBase = createServerFn({ method: 'POST' })
 
     await db
       .delete(knowledgeBases)
-      .where(eq(knowledgeBases.id, data.id));
+      .where(and(eq(knowledgeBases.id, data.id), eq(knowledgeBases.userId, user.id)));
 
     return { success: true };
   });

--- a/src/server/function/message-attachment.server.ts
+++ b/src/server/function/message-attachment.server.ts
@@ -3,6 +3,11 @@
  *
  * Handles persistence of user-uploaded attachments per message.
  * Part of P13: Attachment Persistence Pipeline
+ *
+ * Tenant isolation: messageAttachment has no owner column; ownership flows through
+ * sessionId -> agentSession.userId. Every handler that takes a client-supplied
+ * sessionId or attachmentId verifies the session belongs to the authenticated user
+ * before reading/mutating (fixes cross-tenant access, review Risk #4).
  */
 
 import { createServerFn } from '@tanstack/react-start';
@@ -11,6 +16,7 @@ import { z } from 'zod';
 import { eq, and } from 'drizzle-orm';
 import { db } from '~/db/db-config';
 import { messageAttachment } from '~/db/schema/message-attachment.schema';
+import { agentSession } from '~/db/schema/agent-session.schema';
 import { auth } from '~/server/auth.server';
 
 /**
@@ -25,6 +31,27 @@ const requireUser = async () => {
   }
 
   return session.user;
+};
+
+/**
+ * Verify that an agent_session (PK = sessionId) belongs to the given user.
+ * Used to authorize attachment access, which is scoped only via the session FK.
+ */
+const sessionBelongsToUser = async (sessionId: string, userId: string): Promise<boolean> => {
+  const [row] = await db
+    .select({ id: agentSession.id })
+    .from(agentSession)
+    .where(and(eq(agentSession.id, sessionId), eq(agentSession.userId, userId)));
+  return Boolean(row);
+};
+
+/** Resolve the owning sessionId of an attachment (or null if it doesn't exist). */
+const attachmentSessionId = async (attachmentId: string): Promise<string | null> => {
+  const [row] = await db
+    .select({ sessionId: messageAttachment.sessionId })
+    .from(messageAttachment)
+    .where(eq(messageAttachment.id, attachmentId));
+  return row?.sessionId ?? null;
 };
 
 // Input validation schemas
@@ -74,7 +101,10 @@ export const createMessageAttachment = createServerFn({ method: 'POST' })
     return createAttachmentSchema.parse(data);
   })
   .handler(async ({ data }) => {
-    await requireUser();
+    const user = await requireUser();
+    if (!(await sessionBelongsToUser(data.sessionId, user.id))) {
+      throw new Error('FORBIDDEN');
+    }
 
     const [attachment] = await db
       .insert(messageAttachment)
@@ -106,7 +136,12 @@ export const markAttachmentUploaded = createServerFn({ method: 'POST' })
     return markUploadedSchema.parse(data);
   })
   .handler(async ({ data }) => {
-    await requireUser();
+    const user = await requireUser();
+    const ownerSessionId = await attachmentSessionId(data.attachmentId);
+    if (!ownerSessionId) return undefined;
+    if (!(await sessionBelongsToUser(ownerSessionId, user.id))) {
+      throw new Error('FORBIDDEN');
+    }
 
     const [updated] = await db
       .update(messageAttachment)
@@ -134,7 +169,10 @@ export const markAttachmentReferenced = createServerFn({ method: 'POST' })
     return markReferencedSchema.parse(data);
   })
   .handler(async ({ data }) => {
-    await requireUser();
+    const user = await requireUser();
+    if (!(await sessionBelongsToUser(data.sessionId, user.id))) {
+      throw new Error('FORBIDDEN');
+    }
 
     const [updated] = await db
       .update(messageAttachment)
@@ -165,7 +203,8 @@ export const getSessionAttachments = createServerFn({ method: 'GET' })
     return sessionIdSchema.parse({ sessionId });
   })
   .handler(async ({ data }) => {
-    await requireUser();
+    const user = await requireUser();
+    if (!(await sessionBelongsToUser(data.sessionId, user.id))) return [];
 
     try {
       const attachments = await db
@@ -201,7 +240,8 @@ export const getMessageAttachments = createServerFn({ method: 'GET' })
     return messageAttachmentSchema.parse({ sessionId, messageId });
   })
   .handler(async ({ data }) => {
-    await requireUser();
+    const user = await requireUser();
+    if (!(await sessionBelongsToUser(data.sessionId, user.id))) return [];
 
     try {
       const attachments = await db
@@ -234,7 +274,12 @@ export const deleteMessageAttachment = createServerFn({ method: 'POST' })
     return deleteAttachmentSchema.parse(data);
   })
   .handler(async ({ data }) => {
-    await requireUser();
+    const user = await requireUser();
+    const ownerSessionId = await attachmentSessionId(data.attachmentId);
+    if (!ownerSessionId) return { success: true };
+    if (!(await sessionBelongsToUser(ownerSessionId, user.id))) {
+      throw new Error('FORBIDDEN');
+    }
 
     await db
       .delete(messageAttachment)


### PR DESCRIPTION
## Summary
A subagent sweep found **8 handlers** resolving rows by a **client-supplied id without an owner predicate**, allowing cross-tenant read / mutate / delete. This adds owner scoping to all of them.

Owner columns: `files.clientId`, `agentSession.userId`, `knowledgeBases.userId`. `messageAttachment` has no owner column — ownership flows through `sessionId → agentSession.userId`, so a `sessionBelongsToUser()` helper gates those handlers.

## Fixes
| File | Handler(s) | Fix | Sev |
|---|---|---|---|
| `routes/api/workspace/$sessionId.documents.ts` | file lookup in POST | require `files.clientId = user.id` (was: download any tenant's file by id) | HIGH |
| `server/function/message-attachment.server.ts` | create / markUploaded / markReferenced / delete / getSession / getMessage | verify the attachment's session belongs to the user before read/mutate | HIGH/MED |
| `server/function/knowledge-bases.server.ts` | update / delete | re-scope mutation by `knowledgeBases.userId` (close TOCTOU vs the prior ownership SELECT) | MED |

Also hardened `createMessageAttachment` (was insert into any session by id).

## Verification
- Imports/owner-columns checked; oxlint clean on the 3 files (0 errors).
- **NEEDS-VERIFY (tracked in `docs/project/HUMAN-REVIEW.md`)**: a full 2-user integration test needs the auth + DB harness; not run here. The changes are minimal owner-predicate additions on adversarially-confirmed vulnerabilities. CI runs lint/build/secret-scan.

## Safe (already correctly scoped — not touched)
agent-sessions routes, documents.server.ts, workspace file/artifact routes (via `getWorkspaceSession(userId, …)`), kb read/list handlers, `$sessionId.documents.$documentId.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)