### PR TITLE
docs(env): fix sandbox flag name + document agent bounds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,13 @@ ANTHROPIC_API_KEY="sk-ant-api03-xxxxx"
 # Development: uses temp directory; Production (Docker): /data/users
 CLAUDE_SESSIONS_ROOT="/tmp/claude-sessions"
 
-# Enable OS-level sandbox (sandbox-runtime) for code execution
-# Requires Linux + bubblewrap; disabled by default for compatibility
-SANDBOX_ENABLED="false"
+# OS-level exec sandbox (@anthropic-ai/sandbox-runtime) for tool code execution.
+# ENABLED BY DEFAULT. Secrets are always stripped from the child env regardless;
+# when active it also denies network + fences the filesystem to the session workspace.
+# Linux needs bubblewrap+socat+ripgrep and the worker container run with
+# `security_opt: [seccomp=unconfined]`; macOS uses Apple Seatbelt (no deps).
+# Set to "0" to disable the OS sandbox (env-strip still applies).
+# ENABLE_EXEC_SANDBOX="1"
 
 # Claude Agent permission mode: "default" | "bypassPermissions" | "requested"
 # CLAUDE_PERMISSION_MODE="default"
@@ -130,6 +134,16 @@ MCP_STORE_DIR="src/mcp-store"
 PYTHON_RUNNER_TIMEOUT_MS="10000"
 PYTHON_RUNNER_MAX_OUTPUT_BYTES="512000"
 PYTHON_RUNNER_MAX_CODE_BYTES="200000"
+
+# =============================================================================
+# AGENT LOOP SAFETY BOUNDS (Risk #5)
+# =============================================================================
+# Cap runaway / abandoned agent runs. Both default to 0 = unbounded.
+# AGENT_MAX_TURNS: max agentic turns per run (-> SDK query maxTurns).
+# AGENT_WALLCLOCK_TIMEOUT_MS: hard wall-clock limit; the worker force-stops the
+# run and emits a terminal error frame even if blocked awaiting the model.
+# AGENT_MAX_TURNS="40"
+# AGENT_WALLCLOCK_TIMEOUT_MS="600000"
 
 # =============================================================================
 # DATABASE CONFIGURATION


### PR DESCRIPTION
Small correctness fix to `.env.example`:
- `SANDBOX_ENABLED="false"` was an orphan (zero code refs) that wrongly implied the exec sandbox is off by default. The code reads `ENABLE_EXEC_SANDBOX` and is **ON by default** (env-strip always applies; OS sandbox active where supported). Renamed + clarified.
- Documented `AGENT_MAX_TURNS` / `AGENT_WALLCLOCK_TIMEOUT_MS` (Risk #5 bounds; default 0 = unbounded).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)