### PR TITLE
fix(smoke): dotenv loading + correct doc accuracy

### DIFF
--- a/docs/project/HUMAN-REVIEW.md
+++ b/docs/project/HUMAN-REVIEW.md
@@ -7,8 +7,8 @@ external resource. Grouped by urgency. (Living — I append as I hit blockers.)
 - [x] **Live model wired & verified.** Switched from the expired GLM plan to **ByteDance Ark**
   (Anthropic-compatible): `ANTHROPIC_BASE_URL=https://ark.cn-beijing.volces.com/api/coding`,
   `ANTHROPIC_MODEL=ark-code-latest` (key in gitignored `.env`). **Full end-to-end smoke test
-  passes** (`node --env-file=.env scripts/smoke-agent.mjs`): real `query()` → 47 streamed
-  events → 1 tool_use → workspace file written with exact content → `done`. The agent loop is live.
+  passes** (`node scripts/smoke-agent.mjs`): real `query()` → ~79 streamed events → 1 tool_use →
+  workspace file written with exact content (`OXYGENIE_SMOKE_OK`) → `done`. The agent loop is live.
 
 ## 🔴 Blocks live functionality — please action
 - [ ] **Rotate the LLM key if it was ever exposed.** Current Ark key lives only in `.env`

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -35,7 +35,7 @@ file → done). The earlier GLM-plan blocker is resolved.
 
 - ✅ **Live model wired + end-to-end smoke test** (PR #8): switched to ByteDance Ark
   (`ark-code-latest`, Anthropic-compatible endpoint); `scripts/smoke-agent.mjs` proves the full
-  agent loop — real query → 47 stream events → tool_use → workspace file written → done. *(2026-05-30)*
+  agent loop — real query → streamed events → tool_use → workspace file written → done. *(2026-05-30)*
 - ✅ **Risk #5 — agent run bounds** (PR #5): `AGENT_MAX_TURNS` → `maxTurns`, `AGENT_WALLCLOCK_TIMEOUT_MS`
   → worker watchdog; opt-in (0 = unbounded). Watchdog timing verified in isolation. *(2026-05-30)*
 - ✅ **Risks #3/#4 — cross-tenant access** (PR #4): owner predicates on 8 handlers (files.clientId /

--- a/scripts/smoke-agent.mjs
+++ b/scripts/smoke-agent.mjs
@@ -10,9 +10,12 @@
  * This proves the heart of the system is live (model + streaming + tool exec)
  * WITHOUT needing the WebSocket server, auth, or the database.
  *
- * Run from repo root (loads .env automatically):
- *   node --env-file=.env scripts/smoke-agent.mjs
+ * Run from repo root:
+ *   node scripts/smoke-agent.mjs
+ * (loads .env via dotenv; do NOT use `node --env-file=.env` — its parser mishandles
+ *  this .env's `${VAR}` references and silently drops later vars.)
  */
+import 'dotenv/config';
 import { spawn } from 'node:child_process';
 import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';


### PR DESCRIPTION
Follow-up to PR #8.

- **Bug**: `node --env-file=.env` silently dropped `ANTHROPIC_API_KEY` because this `.env` uses `${VAR}` references that Node's parser mishandles — so the smoke script aborted instead of running. Fixed by loading via `import 'dotenv/config'` and running `node scripts/smoke-agent.mjs`.
- **Doc accuracy**: PR #8's docs said '47 events' — that text was written before a real run. The actual verified run produces **~79 events**. Corrected STATUS.md / HUMAN-REVIEW.md.

**Now genuinely verified** against ByteDance Ark (`ark-code-latest`): `tool_use: 1`, file written with exact content `OXYGENIE_SMOKE_OK`, `done: true`, `SMOKE: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)