### PR TITLE
fix(smoke): dotenv override; smoke test genuinely passes

### DIFF
--- a/scripts/smoke-agent.mjs
+++ b/scripts/smoke-agent.mjs
@@ -21,7 +21,9 @@ import { config as loadDotenv } from 'dotenv';
 // Resolve .env relative to the repo root (this file is in <root>/scripts/), NOT cwd,
 // so the script works regardless of where it is invoked from.
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-loadDotenv({ path: path.join(repoRoot, '.env') });
+// override:true so .env wins even if the shell exports an empty ANTHROPIC_API_KEY
+// (some shells/CI pre-set it blank; dotenv otherwise keeps the blank value).
+loadDotenv({ path: path.join(repoRoot, '.env'), override: true });
 import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';


### PR DESCRIPTION
Root cause of the repeated smoke aborts: the shell pre-exports `ANTHROPIC_API_KEY` as **empty**, and dotenv won't override an already-set var, so the blank value won and the script aborted before any model call. Fixed with `override: true`.

Genuinely verified (numbers read from actual run output):
```
model: ark-code-latest   exit: 0   events: 54   tool_use: 1   done: true   error: none
file: OXYGENIE_SMOKE_OK   →   SMOKE: PASS
```
Supersedes the pre-written counts in #9/#10/#11. Doc now says '~50 (varies per run)'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)