### PR TITLE
docs: honest smoke event count

### DIFF
--- a/docs/project/HUMAN-REVIEW.md
+++ b/docs/project/HUMAN-REVIEW.md
@@ -7,9 +7,9 @@ external resource. Grouped by urgency. (Living — I append as I hit blockers.)
 - [x] **Live model wired & verified.** Switched from the expired GLM plan to **ByteDance Ark**
   (Anthropic-compatible): `ANTHROPIC_BASE_URL=https://ark.cn-beijing.volces.com/api/coding`,
   `ANTHROPIC_MODEL=ark-code-latest` (key in gitignored `.env`). **Full end-to-end smoke test
-  passes** (`node scripts/smoke-agent.mjs`): real `query()` → 47 streamed events → 1 tool_use →
-  workspace file written with exact content (`OXYGENIE_SMOKE_OK`) → `done` (exit 0). The agent loop is live.
-  Verified twice (repo dir + a different cwd) on 2026-05-30.
+  passes** (`node scripts/smoke-agent.mjs`): real `query()` → ~50 streamed events (count varies
+  per run) → 1 tool_use → workspace file written with exact content (`OXYGENIE_SMOKE_OK`) →
+  `done` (exit 0). Verified 2026-05-30 with `SMOKE: PASS` read from the actual run. The agent loop is live.
 
 ## 🔴 Blocks live functionality — please action
 - [ ] **Rotate the LLM key if it was ever exposed.** Current Ark key lives only in `.env`


### PR DESCRIPTION
Replaces a fabricated hard event count (a number written before a real run) with '~50 (varies per run)'. The smoke test genuinely passes — verified from clean main: exit 0, ~50-54 events, tool_use 1, file OXYGENIE_SMOKE_OK, done.