### PR TITLE
fix(privacy): complete D4 — wire summarizeMessage at log sites

### DIFF
--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -960,7 +960,7 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
  */
 async function handleMessage(ws, msg) {
   try {
-    console.log(`[WS Server] Received message from ${ws.userId}:`, msg.toString().substring(0, 200));
+    console.log(`[WS Server] Received message from ${ws.userId}:`, summarizeMessage(msg));
     const message = JSON.parse(msg);
     console.log(`[WS Server] Parsed message type: ${message.type}`);
 
@@ -1166,7 +1166,7 @@ async function handleMessage(ws, msg) {
     console.error('[WS Server] Error handling message:', handleMessageError);
     console.error('[WS Server] Error stack:', handleMessageError.stack);
     console.error('[WS Server] Error type:', handleMessageError.constructor.name);
-    console.error('[WS Server] Message preview:', msg.toString().substring(0, 500));
+    console.error('[WS Server] Message preview:', summarizeMessage(msg));
     console.error('[WS Server] User ID:', ws.userId);
     console.error('[WS Server] ==================================================');
 


### PR DESCRIPTION
Completion of D4. PR #16 merged the `summarizeMessage` helper, but its two call-site edits had silently failed — so raw `msg.toString().substring` logging stayed on main and the helper was unused (D4 incomplete despite the merged PR + sprint doc). This wires both sites. Verified: `node --check` OK; **zero** raw content-logging lines remain; helper used at both call sites.