### PR TITLE
fix(ws): suppress C2 recovery error on intentional abort/replace

### DIFF
--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -671,6 +671,9 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
   // Kill any existing worker for this connection
   if (ws.workerProcess) {
     console.log('[WS Server] Killing existing worker process');
+    // Intentional replace: suppress the close-handler recovery error.
+    ws.workerProcess.__intentionalAbort = true;
+    ws.workerProcess.__terminalSent = true;
     ws.workerProcess.kill();
     ws.workerProcess = null;
   }
@@ -1097,6 +1100,9 @@ async function handleMessage(ws, msg) {
         // Gracefully terminate worker process if running
         if (ws.workerProcess) {
           const worker = ws.workerProcess;
+          // Intentional abort: we send 'aborted' below; suppress recovery error.
+          worker.__intentionalAbort = true;
+          worker.__terminalSent = true;
           console.log('[WS Server] Attempting to kill worker process');
 
           try {


### PR DESCRIPTION
Follow-up to #22. The two intentional-kill sites (new-chat replace-kill at handleChat entry, and the abort handler) didn't set `__intentionalAbort`, so the close handler emitted a spurious `worker_exited` error AFTER the legitimate `aborted` frame. Set `__intentionalAbort`+`__terminalSent` at both. Verified: node --check OK; `__intentionalAbort=true` at exactly 2 sites.