### PR TITLE
fix(security): path guard was a no-op stub — implement + unit-gate (CRITICAL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "worker": "node --import tsx/loader src/worker/index.ts",
     "search:sync": "node --import tsx/loader src/scripts/search-sync.ts",
     "test": "vitest",
+    "test:unit": "vitest run tests/unit",
     "test:auth": "vitest tests/auth-integration.test.ts",
     "test:auth:watch": "vitest tests/auth-integration.test.ts --watch",
     "test:e2e": "vitest tests/e2e-auth-billing.test.ts",

--- a/tests/unit/path-security.test.ts
+++ b/tests/unit/path-security.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the file-tool path-security guard (createPathSecurity.canUseTool).
+ *
+ * These encode the cross-tenant / out-of-bounds contract for the SDK's native file
+ * tools (Read/Write/Edit/Glob/Grep). Pure function, no DB/server — CI-runnable.
+ *
+ * NOTE: discovered 2026-05-30 that resolveCandidate() was an unimplemented stub
+ * (returned null), making the entire deny path dead (guard allowed everything,
+ * incl. /etc/passwd and other users' workspaces). These tests pin the fix.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtempSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - .js module without type declarations
+import { createPathSecurity } from '../../src/claude/path-security.js';
+
+let sessionsRoot: string;
+let userARoot: string;
+let workspaceA: string;
+let guard: { canUseTool: (t: string, i?: Record<string, unknown>, o?: unknown) => { behavior: string; message?: string } };
+
+beforeAll(() => {
+  // Real dirs so realpath resolution has something to anchor on.
+  sessionsRoot = mkdtempSync(path.join(tmpdir(), 'oxy-ps-'));
+  userARoot = path.join(sessionsRoot, 'userA');
+  workspaceA = path.join(userARoot, 'sessions', 's1', 'workspace');
+  mkdirSync(workspaceA, { recursive: true });
+  mkdirSync(path.join(sessionsRoot, 'userB', 'sessions', 's9', 'workspace'), { recursive: true });
+  guard = createPathSecurity({
+    workspace: workspaceA,
+    userId: 'userA',
+    claudeHome: userARoot,
+    sessionsRoot,
+  });
+});
+
+describe('path-security canUseTool', () => {
+  it('allows non-file tools through (gated elsewhere)', () => {
+    expect(guard.canUseTool('Bash', { command: 'echo hi' }).behavior).toBe('allow');
+  });
+
+  it('allows a write inside the session workspace', () => {
+    const r = guard.canUseTool('Write', { file_path: path.join(workspaceA, 'a.txt') });
+    expect(r.behavior).toBe('allow');
+  });
+
+  it('allows a relative path (resolved against the workspace)', () => {
+    expect(guard.canUseTool('Read', { path: 'sub/b.txt' }).behavior).toBe('allow');
+  });
+
+  it('allows a write inside the user home (CLAUDE_HOME)', () => {
+    const r = guard.canUseTool('Write', { file_path: path.join(userARoot, 'notes.txt') });
+    expect(r.behavior).toBe('allow');
+  });
+
+  it('DENIES reading a system path (/etc/passwd)', () => {
+    expect(guard.canUseTool('Read', { file_path: '/etc/passwd' }).behavior).toBe('deny');
+  });
+
+  it("DENIES cross-user access to another user's workspace (even if the file does not exist yet)", () => {
+    const victim = path.join(sessionsRoot, 'userB', 'sessions', 's9', 'workspace', 'secret.txt');
+    expect(guard.canUseTool('Read', { file_path: victim }).behavior).toBe('deny');
+  });
+
+  it('DENIES a workspace-escape via ../ traversal', () => {
+    const r = guard.canUseTool('Write', { file_path: path.join(workspaceA, '../../../../etc/evil') });
+    expect(r.behavior).toBe('deny');
+  });
+
+  it('allows read-only project source under /app', () => {
+    // /app may not exist locally; resolution must still classify it as the read-only prefix.
+    expect(guard.canUseTool('Read', { file_path: '/app/package.json' }).behavior).toBe('allow');
+  });
+});


### PR DESCRIPTION
## 🔴 Critical, pre-existing
`createPathSecurity().canUseTool` (the guard for the SDK's native **Read/Write/Edit/Glob/Grep** file tools) resolved every path via `resolveCandidate()` — which was an **unimplemented stub returning `null`**. So the loop always `continue`d and fell through to **allow**. The entire deny path — workspace fence, cross-user denial, system-path denial — was **dead code**.

**Impact:** the SDK's in-process file tools were **ungated**. (srt — PR #3 — only sandboxes our python/bash *subprocess*, not the SDK's in-process file ops.) Verified by running the real module: `/etc/passwd` and another user's workspace both returned `allow`.

This is from the **original starter** (predates this work). 

## Honest correction
My earlier **PR #15** claim that the guard 'denies /etc/passwd' was **wrong/overconfident** — the guard was a no-op. This also means the 2026-05 architecture review **overstated** `path-security.js` robustness (it described realpath/cross-user logic that existed but never executed).

## Fix
Implement `resolveCandidate` inside `createPathSecurity`: relative→workspace, `realpath` to defeat symlink escape, and **nearest-existing-ancestor resolution** so a *new* (non-existent) cross-user/out-of-bounds Write target is still classified and denied.

## Verification (real output)
`tests/unit/path-security.test.ts` — **8/8 pass** via `pnpm test:unit`:
allow: in-workspace / relative / user-home / /app(readonly) / non-file-tool · **deny: /etc/passwd, cross-user workspace (even non-existent), ../ escape**.

## CI
Adds `test:unit` script + a **hard-gate "Unit tests" job** (no DB/server needed), separate from the still-non-blocking integration suite. First real CI hard gate for behavior.

## Follow-ups
- Re-verify Risk #1/#2 end-to-end now that the guard actually works.
- Update STATUS/architecture-review to correct the path-security overstatement.