### PR TITLE
fix(sandbox): Linux-only OS sandbox; macOS degrades to env-strip

### DIFF
--- a/src/claude/execution/sandbox.js
+++ b/src/claude/execution/sandbox.js
@@ -49,7 +49,16 @@ export function buildSafeEnv(overrides = {}) {
 }
 
 function isEnabled() {
-  return process.env.ENABLE_EXEC_SANDBOX !== '0' && SandboxManager != null;
+  if (SandboxManager == null) return false;
+  // Explicit override wins either way.
+  if (process.env.ENABLE_EXEC_SANDBOX === '0') return false;
+  if (process.env.ENABLE_EXEC_SANDBOX === '1') return true;
+  // Default: ON for Linux (the production isolation target, verified with bubblewrap),
+  // OFF for macOS/Windows local dev. On macOS the srt Seatbelt profile denies system
+  // paths (e.g. /private/var/select) and breaks legitimate python; isolation there is
+  // a dev convenience only. NOTE: secret env-stripping (buildSafeEnv) ALWAYS applies,
+  // sandbox on or off — so keys never reach tool code regardless of platform.
+  return process.platform === 'linux';
 }
 
 function buildConfig(workspace) {


### PR DESCRIPTION
End-to-end testing in the browser surfaced this: the Python tool failed (agent fell back to Write) because srt's macOS Seatbelt profile denies system paths (/private/var/select/sh -> Operation not permitted). The OS sandbox is meant for the Linux container (bubblewrap, verified). Default it ON for linux / OFF for macOS+Windows; ENABLE_EXEC_SANDBOX=0/1 overrides. **Secret env-strip always applies regardless of platform.** Verified: runPython('print(2**10)') -> exit 0 / stdout 1024 on macOS.