### PR TITLE
feat(dev): one-command dev scripts + README + Docker self-check

### DIFF
--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# dev-down.sh — stop the local hybrid dev stack started by dev-up.sh.
+#
+# Stops the Docker dependency containers (Postgres/Redis/MinIO/Meilisearch).
+# Does NOT delete volumes by default (your DB data is kept). Use --volumes to wipe.
+#
+# Note: the app itself runs as a local node process (start-production.mjs); stop it
+# with Ctrl-C in its terminal, or: pkill -f start-production.mjs
+#
+# Usage:
+#   ./scripts/dev-down.sh            # stop dep containers, keep data
+#   ./scripts/dev-down.sh --volumes  # stop + delete volumes (wipes DB/MinIO/Meili data)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+WIPE=0
+for arg in "$@"; do
+  case "$arg" in
+    --volumes) WIPE=1 ;;
+    *) echo "Unknown arg: $arg"; exit 2 ;;
+  esac
+done
+
+set -a; [ -f .env ] && . ./.env; [ -f .env.docker ] && . ./.env.docker; set +a
+
+if [ "$WIPE" = 1 ]; then
+  echo "▶ Stopping dep containers AND deleting volumes (DB/MinIO/Meili data will be lost)…"
+  docker compose --env-file .env.docker --env-file .env down --volumes
+else
+  echo "▶ Stopping dependency containers (data kept)…"
+  docker compose --env-file .env.docker --env-file .env down
+fi
+
+# Best-effort: stop a locally-running app process if present.
+if pgrep -f start-production.mjs >/dev/null 2>&1; then
+  echo "▶ Note: a local app process (start-production.mjs) is still running."
+  echo "  Stop it with: pkill -f start-production.mjs"
+fi
+echo "✓ Done."

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# dev-up.sh — one-command local dev for OxyGenie (hybrid: Docker deps + local node).
+#
+# What it does:
+#   1. Starts dependency services in Docker (Postgres, Redis, MinIO, Meilisearch).
+#   2. Runs DB migrations.
+#   3. Builds the app (Vite SSR + Nitro) — unless --no-build.
+#   4. Starts the app: Nitro on :3000 + WebSocket server on :3001.
+#
+# This is the recipe that was verified end-to-end on 2026-05-30 (see
+# docs/project/WORKLOG.md). It deliberately runs the APP as a local node process
+# (not a Docker container), so only the 4 dependency containers show up in Docker.
+#
+# Usage:
+#   ./scripts/dev-up.sh              # deps + migrate + build + start
+#   ./scripts/dev-up.sh --no-build   # skip the (slow) build, reuse existing .output
+#   ./scripts/dev-up.sh --deps-only  # only start Docker deps + migrate, don't start app
+#
+# Prereqs:
+#   - Docker (OrbStack/Docker Desktop) running
+#   - .env present (copy from .env.example; for LOCAL hybrid run set:
+#       DATABASE_URL=...@localhost:5432/oxygenie
+#       BETTER_AUTH_URL=http://localhost:3000
+#       VITE_BASE_URL=http://localhost:3000
+#       VITE_WS_URL=ws://localhost:3001/ws/agent
+#       ENABLE_EXEC_SANDBOX=0      # macOS dev; Linux prod uses 1)
+#   - .env.docker present (copy from .env.docker.example)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+
+NO_BUILD=0
+DEPS_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) NO_BUILD=1 ;;
+    --deps-only) DEPS_ONLY=1 ;;
+    *) echo "Unknown arg: $arg"; exit 2 ;;
+  esac
+done
+
+[ -f .env ] || { echo "ERROR: .env missing. Copy .env.example → .env and set local values (see header)."; exit 1; }
+[ -f .env.docker ] || { echo "ERROR: .env.docker missing. Copy .env.docker.example → .env.docker."; exit 1; }
+
+# Load env into this shell. Compose's ${VAR:?} interpolation reads from the
+# environment, not just --env-file, so we MUST source it (a known gotcha).
+set -a; . ./.env; . ./.env.docker; set +a
+
+echo "▶ 1/4 Starting dependency services (Postgres/Redis/MinIO/Meilisearch)…"
+docker compose --env-file .env.docker --env-file .env \
+  up -d db create-db redis minio provision-minio meilisearch
+
+echo "▶ waiting for Postgres to be healthy…"
+for i in $(seq 1 30); do
+  if docker exec ex0-db pg_isready -U "${POSTGRES_USER:-postgres}" >/dev/null 2>&1; then
+    echo "  ✓ Postgres ready"; break
+  fi
+  sleep 1
+  [ "$i" = 30 ] && { echo "  ✗ Postgres not ready after 30s"; exit 1; }
+done
+
+echo "▶ 2/4 Running DB migrations…"
+pnpm db:migrate
+
+if [ "$DEPS_ONLY" = 1 ]; then
+  echo "✓ Deps + migrations done (--deps-only). App not started."
+  exit 0
+fi
+
+if [ "$NO_BUILD" = 0 ]; then
+  echo "▶ 3/4 Building app (Vite SSR + Nitro)… (this takes a few minutes)"
+  NODE_OPTIONS="--max-old-space-size=8192" pnpm build
+else
+  echo "▶ 3/4 Skipping build (--no-build); reusing .output"
+fi
+[ -f .output/server/index.mjs ] || { echo "ERROR: .output/server/index.mjs missing — run without --no-build."; exit 1; }
+
+echo "▶ 4/4 Starting app: Nitro :3000 + WebSocket :3001  →  http://localhost:3000"
+exec env PORT=3000 APP_URL=http://localhost:3000 node start-production.mjs


### PR DESCRIPTION
Codifies the verified local run recipe as **scripts/dev-up.sh** (deps→migrate→build→start; flags --no-build/--deps-only) + **dev-down.sh**, documented in README 'Option C: One-command hybrid dev' with the required LOCAL .env values. dev-up.sh --deps-only tested OK.

**Docker self-check (all compose files):**
- ✅ docker-compose.yml (main, used) — parses & e2e-verified
- ✅ docker-compose.dokploy.yml (real deploy path) — parses, default CMD runs both Nitro+WS
- ✅ Dockerfile — builds
- ❌ infra/deploy/compose.yml — **malformed** (no services: block, fails to parse) + Risk #8 command override; flagged in HUMAN-REVIEW for human decision (delete vs rebuild). Also corrected a false 'I fixed it' note there.