### PR TITLE
docs: README Option C + correct HUMAN-REVIEW Risk#8 (PR#32 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,45 @@ pnpm install
 5. **Open the app:**  
    http://localhost:3000/agents/claude-chat
 
+### Option C: One-command hybrid dev (recommended for local) ⭐
+
+Runs the **dependency services in Docker** (Postgres, Redis, MinIO, Meilisearch) and the
+**app as a local Node process** (Nitro :3000 + WebSocket :3001). This is the fastest way
+to a running app and is the recipe verified end-to-end (see `docs/project/WORKLOG.md`).
+
+```bash
+# One-time setup
+cp .env.example .env            # then edit .env (see the LOCAL values below)
+cp .env.docker.example .env.docker
+
+# Bring everything up: deps → migrate → build → start
+./scripts/dev-up.sh             # http://localhost:3000
+
+# Faster iterations (reuse the existing build):
+./scripts/dev-up.sh --no-build
+
+# Only start deps + run migrations (then run the app yourself):
+./scripts/dev-up.sh --deps-only
+
+# Tear down the dependency containers:
+./scripts/dev-down.sh
+```
+
+**Required LOCAL `.env` values** (these differ from the Docker port-mapping defaults):
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/oxygenie"
+BETTER_AUTH_URL="http://localhost:3000"      # must match the local port, NOT :5050
+VITE_BASE_URL="http://localhost:3000"
+VITE_WS_URL="ws://localhost:3001/ws/agent"   # WebSocket server runs on :3001
+ENABLE_EXEC_SANDBOX="0"                        # macOS dev (srt Seatbelt breaks python); Linux prod uses 1
+ANTHROPIC_BASE_URL="https://ark.cn-beijing.volces.com/api/coding"  # or your Anthropic-compatible gateway
+ANTHROPIC_MODEL="ark-code-latest"
+```
+
+> Note: the app runs as a **local Node process**, so only the 4 dependency containers
+> appear in Docker/OrbStack — that's expected for hybrid mode.
+
 ## Why OxyGenie?
 
 ### vs. Generic GPT Products (ChatGPT, 豆包, DeepSeek)

--- a/docs/project/HUMAN-REVIEW.md
+++ b/docs/project/HUMAN-REVIEW.md
@@ -25,8 +25,19 @@ external resource. Grouped by urgency. (Living — I append as I hit blockers.)
   `ExecutionRuntime` + per-session sandbox pool + queue/worker model BEFORE I build it (1-way door).
 
 ## 🟡 Implemented but NOT verified by me (please verify / run)
-- [ ] **Deploy fix (Risk #8)** — I corrected the compose/ports so the WS server boots, but I have no
-  Dokploy access and did not deploy. Verify a real deploy serves web + a working `/ws/agent`.
+- [ ] **Deploy fix (Risk #8) — NOT fixed; needs your deploy context.** Correction: this note
+  previously claimed I'd "corrected the compose/ports" — I had **not**. Actual 2026-05-30 Docker
+  self-check findings:
+    - `infra/deploy/compose.yml` is **malformed** — `docker compose -f infra/deploy/compose.yml config`
+      fails (`mapping key "image" already defined at line 132` — `image:` is declared twice on the
+      `app`/`migrate` services). It also pins `command: [node, .output/server/index.mjs]` which would
+      run **only Nitro, not the WebSocket server** (Risk #8). Referenced only by
+      `docs/project/research/2026-05-architecture-review.md`. I did **not** rewrite it (no deploy access
+      to test). Decide: delete it (superseded by `docker-compose.dokploy.yml`) or rebuild it.
+    - ✅ `docker-compose.yml` (main, used locally) — parses & e2e-verified.
+    - ✅ `docker-compose.dokploy.yml` (the real deploy path) — parses; **no** `index.mjs` command
+      override, so the image's default CMD (`start-production.mjs` → both Nitro + WS) runs. Correct.
+    - ✅ `Dockerfile` — builds.
 - [ ] **`security_opt: [seccomp=unconfined]` on the `app` service** — required for the srt sandbox in
   containers. Confirm your prod/Dokploy runtime allows it (or set the equivalent).
 - [ ] **DB migrations** (D1/D3 add tables) — I tested against a local Postgres only; review + run


### PR DESCRIPTION
PR #32's commit message claimed these doc changes but the edits had silently failed; only the .sh scripts landed. This applies them for real and corrects the record. No code changes.