### PR TITLE
fix: correct stale repo URL (Deeptoai-com/OxyGenie -> foreveryh/oxygenie)

### DIFF
--- a/docs/DISCUSSION-开源文档与环境变量规划.md
+++ b/docs/DISCUSSION-开源文档与环境变量规划.md
@@ -1,0 +1,200 @@
+# 開源文檔規劃與環境變數完備性討論
+
+**日期**: 2026-01-27  
+**目的**: 供討論用的方案草稿，涵蓋 .env 完備性、開發文檔、文檔目錄結構
+
+---
+
+## 已實施（2026-01-27）
+
+- **.env.example**：補充 ANTHROPIC_BASE_URL/MODEL、APP_URL、WS_PORT、RESEND_API_KEY、S3_ENABLE_PATH_STYLE、SKILLS_STORE_SEED_MODE、BETTER_AUTH_TRUSTED_ORIGINS、CLAUDE_PERMISSION_*、ENABLE_STRUCTURED_OUTPUTS
+- **docs/**：採用方案 B，新增 README.md、development/local-setup.md、troubleshooting.md
+- **README / README_CN**：新增「文檔」章節，引導至 docs/
+
+---
+
+## 一、.env.example 環境變數完備性審核
+
+### 1.1 已覆蓋且正確
+
+| 分組 | 變數 | 說明 |
+|------|------|------|
+| 應用 | VITE_BASE_URL, APP_HOSTNAME | ✓ |
+| AI | ZHIPU_API_KEY, ANTHROPIC_API_KEY | ✓ |
+| Claude | CLAUDE_SESSIONS_ROOT, SANDBOX_ENABLED, VITE_WS_URL | ✓ |
+| 數據庫 | DATABASE_URL, POSTGRES_* | ✓ |
+| 認證 | BETTER_AUTH_*, SESSION_COOKIE_NAME (可選) | ✓ |
+| 郵件 | EMAIL_*, MAILHOG_*, SMTP_*, RESEND 隱式 | ✓ |
+| 存儲 | S3_*, MINIO_* | ✓ |
+| 搜索 | MEILI_* | ✓ |
+| 任務 | REDIS_URL, BULLMQ_*, JOBS_*, JOB_* | ✓ |
+| OAuth | GITHUB_*, GOOGLE_* | ✓ |
+| 可觀測 | SENTRY_*, VITE_POSTHOG_* | ✓ |
+| MCP | CLAUDE_MCP_STORE_DIR, MCP_STORE_DIR, PYTHON_* | ✓ |
+
+### 1.2 建議補充（代碼中實際使用）
+
+| 變數 | 用途 | 建議默認值 |
+|------|------|------------|
+| **ANTHROPIC_BASE_URL** | Claude API 自定義網關（如 GLM） | 空（使用官方） |
+| **ANTHROPIC_MODEL** | 模型覆蓋（如 claude-3-5-sonnet） | 空 |
+| **APP_URL** | ws-server 認證主應用 URL（start:hybrid 等） | http://localhost:3000 |
+| **WS_PORT** | WebSocket 埠 | 3001 |
+| **RESEND_API_KEY** | Resend 郵件供應商 | 空 |
+| **S3_ENABLE_PATH_STYLE** | MinIO 路徑風格（file.ts 使用） | 1 |
+| **S3_SECRET_ACCESS_KEY** | file.ts 使用此名（與 S3_ACCESS_KEY 對應） | 見 S3 |
+| **BETTER_AUTH_TRUSTED_ORIGINS** | 可信源（CORS 等） | 空 |
+| **BETTER_AUTH_BASE_PATH** | 認證路徑前綴 | /api/auth |
+| **CLAUDE_PERMISSION_MODE** | 權限模式 | default |
+| **CLAUDE_ALLOW_BASH** | 是否允許 bash | false |
+| **CLAUDE_BYPASS_USER_IDS** | 繞過權限的用戶 ID | 空 |
+| **SKILLS_STORE_DIR** | 技能商店目錄（生產） | /data/skills-store |
+| **SKILLS_STORE_SEED_MODE** | seed 行為 | skip |
+| **ENABLE_STRUCTURED_OUTPUTS** | Artifact 結構化輸出 | false |
+
+### 1.3 可選（進階 / 調試）
+
+| 變數 | 說明 |
+|------|------|
+| SCHEMA_GENERATION_DEBUG | 調試 |
+| SCHEMA_GENERATION_TRACE | 調試 |
+| CLAUDE_CODE_EXECUTABLE | 自定義可執行 |
+| CLAUDE_READ_ALLOWED_PREFIXES | 路徑白名單 |
+| CLAUDE_WRITE_ALLOWED_PREFIXES | 路徑白名單 |
+| CLAUDE_BLOCKED_PREFIXES | 路徑黑名單 |
+| AUTO_MIGRATE | 是否自動遷移 |
+| SEARCH_REINDEX_ON_BOOT | 啟動時重建搜索索引 |
+| GITHUB_TOKEN | Skills 安裝用 |
+| OPENAI_API_KEY, OPENAI_BASE_URL | 圖像生成 Skill |
+| GOOGLE_API_KEY, GOOGLE_BASE_URL | 圖像生成 Skill |
+
+### 1.4 建議
+
+- 在 `.env.example` 中補充 **1.2** 中列出的變數（帶註釋與默認值）。
+- **1.3** 可放在單獨的「進階配置」小節或 `docs/` 下的說明文件中。
+
+---
+
+## 二、pnpm 便攜開發環境教程（開發文檔內容草稿）
+
+建議撰寫一篇 **「便攜開發環境指南」**，涵蓋：
+
+1. **前置條件**：Node ≥22.12、pnpm、Docker（基礎設施）
+2. **三種運行模式對照**：
+   - 全 Docker
+   - 混合模式（Docker 基礎設施 + 本地 App）
+   - 全本地（需自建 PostgreSQL/Redis/Meilisearch/MinIO）
+3. **混合模式步驟**：
+   - `ex0 init` 或 `docker compose up -d db minio provision-minio redis meilisearch`
+   - `.env` 配置（localhost 指向、VITE_WS_URL 等）
+   - `pnpm dev` + `node ws-server.mjs` 或 `pnpm build` + `pnpm start:hybrid`
+4. **常見問題**：HeadersTimeoutError → 使用 start:hybrid；構建 OOM → NODE_OPTIONS
+5. **環境變數清單**：連結到 .env.example 或專門的 env 說明頁
+
+---
+
+## 三、開源文檔目錄結構方案
+
+### 3.1 現狀
+
+```
+constructa-starter/
+├── README.md, README_CN.md
+├── CONTRIBUTING.md
+├── docs/                    # 僅 2 個文件
+│   ├── MODIFICATION_AUDIT.md
+│   └── DEPLOYMENT_MEMORY_FIX.md
+├── infra/deploy/            # 部署相關（Dokploy 等）
+└── (無專門的 docs 體系)
+```
+
+### 3.2 方案 A：扁平 `docs/`（簡潔）
+
+```
+docs/
+├── README.md                # 文檔索引，README 引導入口
+├── development.md          # 便攜開發環境指南
+├── environment-variables.md # 環境變數完整說明（可選，或指向 .env.example）
+├── deployment.md           # 部署概述 + 連結 infra/deploy
+└── troubleshooting.md      # 常見問題（HeadersTimeout、OOM 等）
+```
+
+**優點**：結構簡單，易維護。  
+**缺點**：文檔變多時會略顯雜亂。
+
+### 3.3 方案 B：分組 `docs/`（推薦）
+
+```
+docs/
+├── README.md                # 文檔索引
+├── getting-started.md       # 快速開始（精簡版，詳見主 README）
+├── development/
+│   └── local-setup.md       # 便攜開發環境（pnpm + Docker 混合）
+├── deployment/
+│   ├── overview.md          # 部署方式概覽
+│   └── docker-compose.md    # Docker Compose 說明
+├── configuration/
+│   └── environment-variables.md
+└── troubleshooting.md
+```
+
+**優點**：結構清晰，之後擴充空間大。  
+**缺點**：目錄多一層。
+
+### 3.4 方案 C：與根級並行（docs + 頂層）
+
+```
+README.md                    # 主入口，含「文檔」章節連結
+CONTRIBUTING.md
+DEVELOPMENT.md               # 開發環境（頂層，便於發現）
+docs/                        # 其余詳細文檔
+├── README.md
+├── deployment/
+├── configuration/
+└── ...
+```
+
+**優點**：DEVELOPMENT.md 顯眼。  
+**缺點**：根目錄文件變多。
+
+### 3.5 建議
+
+- 採用 **方案 B**，並在 `docs/README.md` 中做索引與說明。
+- 在 **主 README** 末尾新增「文檔」章節，連結到 `docs/README.md` 及各子文檔。
+
+---
+
+## 四、README 引導設計
+
+在 README 末尾或適當位置新增：
+
+```markdown
+## Documentation
+
+- **[Documentation Index](docs/README.md)** – Full documentation hub
+- [Local Development Setup](docs/development/local-setup.md) – pnpm + Docker hybrid mode
+- [Environment Variables](docs/configuration/environment-variables.md) – All env vars explained
+- [Deployment](docs/deployment/overview.md) – Docker, cloud, self-host
+- [Troubleshooting](docs/troubleshooting.md) – Common issues
+```
+
+或更精簡：
+
+```markdown
+## Further Reading
+
+See [docs/README.md](docs/README.md) for development guides, deployment, and troubleshooting.
+```
+
+---
+
+## 五、待討論要點
+
+1. **方案選擇**：文檔目錄用 A、B 還是 C？或有其他偏好？
+2. **環境變數**：是否一次性補充 1.2 所有變數，還是分階段？
+3. **多語言**：開發文檔是否同時提供中英文（如 development.zh.md）？
+4. **現有 docs**：`MODIFICATION_AUDIT.md`、`DEPLOYMENT_MEMORY_FIX.md` 歸入新結構還是保留原位？
+
+---
+
+請依此討論，確認後可開始具體實施。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# OxyGenie Documentation
+
+Documentation hub for developers and deployers.
+
+## Documentation Index
+
+| Document | Description |
+|----------|-------------|
+| [Local Development Setup](development/local-setup.md) | pnpm + Docker hybrid mode, portable dev environment |
+| [Deployment Overview](deployment/overview.md) | Deployment options: Docker Compose, Dokploy, Dokku |
+| [Docker Compose Deployment](deployment/docker-compose.md) | Single-server self-host with Docker Compose |
+| [Dokploy Deployment](deployment/dokploy.md) | Deploy on Dokploy with Traefik |
+| [Troubleshooting](troubleshooting.md) | Common issues (HeadersTimeout, OOM, connection errors) |
+| [Environment Variables](../.env.example) | All configuration options (see file comments) |
+
+## Quick Links
+
+- **Getting Started**: See the main [README](../README.md) for installation and Quick Start
+- **Deployment**: [Docker Compose](../README.md#option-a-docker-compose-recommended) | [infra/deploy](../infra/deploy/) for Dokploy, Ansible
+- **Contributing**: [CONTRIBUTING.md](../CONTRIBUTING.md)
+
+## Other Documents
+
+- [MODIFICATION_AUDIT.md](MODIFICATION_AUDIT.md) – Change audit
+- [DEPLOYMENT_MEMORY_FIX.md](DEPLOYMENT_MEMORY_FIX.md) – Memory fix for deployment
+- [DISCUSSION-开源文档与环境变量规划.md](DISCUSSION-开源文档与环境变量规划.md) – Planning discussion (env vars, doc structure)

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -1,0 +1,131 @@
+# Docker Compose Deployment
+
+Deploy OxyGenie on a single server using Docker Compose. Best for self-hosted, VPS, or local testing with production-like setup.
+
+## Prerequisites
+
+- Docker & Docker Compose
+- (Optional) Domain name and reverse proxy for HTTPS
+- (Optional) Caddy or nginx for SSL
+
+---
+
+## Step 1: Clone and Configure
+
+```bash
+git clone https://github.com/Deeptoai-com/OxyGenie.git
+cd OxyGenie
+pnpm install
+```
+
+## Step 2: Environment Variables
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```bash
+# Database (Docker builds DATABASE_URL from these; do NOT set DATABASE_URL)
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="your-secure-password"
+POSTGRES_DB="oxygenie"
+
+# MinIO
+MINIO_ROOT_USER="minioadmin"
+MINIO_ROOT_PASSWORD="your-minio-password"
+MINIO_BUCKET="oxygenie-files"
+
+# Meilisearch
+MEILI_MASTER_KEY="your-strong-master-key"
+
+# Auth (use http://localhost:5050 when accessing via Docker ports)
+BETTER_AUTH_SECRET="your-secret-at-least-32-chars"
+BETTER_AUTH_URL="http://localhost:5050"
+
+# AI
+ANTHROPIC_API_KEY="sk-ant-..."
+ZHIPU_API_KEY="your-zhipu-key"
+```
+
+See [.env.example](../../.env.example) for all options. [.env.docker](../../.env.docker) provides Docker-specific defaults (container hostnames, `VITE_WS_URL`).
+
+---
+
+## Step 3: Start Services
+
+```bash
+pnpm docker:up
+```
+
+Or the full command:
+```bash
+docker compose --env-file .env.docker --env-file .env --profile selfhost up -d --build
+```
+
+**Why two env files?** `.env.docker` provides container hostnames (e.g. `redis://redis`, `meilisearch:7700`); `.env` provides your secrets and overrides. Both are needed for correct container-to-container communication.
+
+This starts:
+
+- PostgreSQL (port 5432)
+- MinIO (9000, 9001)
+- Redis (6379)
+- Meilisearch (7700)
+- Runs migrations
+- Starts app and worker
+
+---
+
+## Step 4: Access
+
+| Service | URL | Port |
+|---------|-----|------|
+| **App** | http://localhost:5050 | 5050 |
+| **Claude Chat** | http://localhost:5050/agents/claude-chat | 5050 |
+| **WebSocket** | ws://localhost:3051/ws/agent | 3051 |
+
+---
+
+## Production: Reverse Proxy + HTTPS
+
+For production with a domain:
+
+1. **Point DNS** to your server IP
+2. **Use a reverse proxy** (Caddy, nginx, Traefik)
+3. **Set** in `.env`:
+   ```bash
+   BETTER_AUTH_URL="https://your-domain.com"
+   VITE_WS_URL="wss://your-domain.com/ws/agent"
+   ```
+4. **Rebuild** so `VITE_WS_URL` is baked into the frontend:
+   ```bash
+   docker compose --env-file .env.docker --env-file .env --profile selfhost up -d --build
+   ```
+
+Example Caddy config (see [infra/deploy/Caddyfile](../../infra/deploy/Caddyfile)):
+
+```
+your-domain.com {
+    reverse_proxy localhost:5050
+}
+
+# WebSocket
+your-domain.com {
+    handle_path /ws/* {
+        reverse_proxy localhost:3051
+    }
+}
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `database "oxygenie" does not exist` | Run `docker compose down -v` then `up -d --build` (⚠️ deletes data) |
+| Keep existing DB (ex0/constructa) | Set only `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` in `.env` to match; do NOT set `DATABASE_URL` |
+| WebSocket 426 / fails | Ensure reverse proxy supports WebSocket upgrade; check VITE_WS_URL matches your domain |
+
+See [Troubleshooting](../troubleshooting.md) for more.

--- a/docs/deployment/dokploy.md
+++ b/docs/deployment/dokploy.md
@@ -1,0 +1,85 @@
+# Dokploy Deployment
+
+Deploy OxyGenie on [Dokploy](https://dokploy.com/) with Traefik for automatic HTTPS, SSL certificates, and routing.
+
+## Prerequisites
+
+- Dokploy installed and configured
+- Traefik enabled (Dokploy default)
+- Domain name pointing to your server
+- Environment variables prepared
+
+---
+
+## Quick Start
+
+1. **Create application** in Dokploy → choose "Docker Compose"
+2. **Compose path**: `docker-compose.dokploy.yml`
+3. **Add environment variables** from [infra/deploy/env.dokploy.example](../../infra/deploy/env.dokploy.example)
+4. **Deploy**
+
+---
+
+## Detailed Guide
+
+For full step-by-step instructions (in Chinese), see:
+
+- **[Dokploy 部署指南](../../infra/deploy/DOKPLOY_DEPLOYMENT.md)** – complete guide
+- **[Environment Checklist](../../infra/deploy/DOKPLOY_ENV_CHECKLIST.md)** – required variables
+
+---
+
+## Key Configuration
+
+### Required Variables
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `APP_NAME` | claude-agent-chat | Application name |
+| `APP_HOSTNAME` | app.example.com | Public domain |
+| `POSTGRES_USER` | your_db_user | Database user |
+| `POSTGRES_PASSWORD` | *** | Database password |
+| `POSTGRES_DB` | claude_agent_chat | Database name |
+| `MINIO_ROOT_USER` | minioadmin | MinIO user |
+| `MINIO_ROOT_PASSWORD` | *** | MinIO password |
+| `MINIO_BUCKET` | oxygenie-files | S3 bucket name |
+| `MEILI_MASTER_KEY` | *** | Meilisearch key |
+| `BETTER_AUTH_SECRET` | *** | Auth secret (32+ chars) |
+| `BETTER_AUTH_URL` | https://app.example.com | Public auth URL |
+| `BETTER_AUTH_INTERNAL_URL` | http://localhost:5000 | Internal auth URL |
+| `VITE_WS_URL` | wss://app.example.com/ws/agent | WebSocket URL (HTTPS) |
+| `ANTHROPIC_API_KEY` | sk-ant-... | Claude API key |
+
+### Traefik / Routing
+
+`docker-compose.dokploy.yml` includes Traefik labels. Traefik handles:
+
+- HTTP → app (port 5000)
+- WebSocket `/ws/*` → app (port 3001), priority 10
+- HTTPS via Let's Encrypt
+
+---
+
+## Verification
+
+```bash
+# Health check
+curl https://your-domain.com/health
+
+# WebSocket (browser console)
+const ws = new WebSocket('wss://your-domain.com/ws/agent');
+ws.onopen = () => console.log('OK');
+```
+
+---
+
+## Troubleshooting
+
+See [DOKPLOY_DEPLOYMENT.md – 常见问题](../../infra/deploy/DOKPLOY_DEPLOYMENT.md#-常见问题) for:
+
+- WebSocket 426 / connection fails
+- Database connection errors
+- MinIO / S3 errors
+- Traefik routing issues
+- Docker volume name errors
+- Migration failures

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -1,0 +1,56 @@
+# Deployment Overview
+
+OxyGenie supports multiple deployment options. Choose based on your infrastructure and preferences.
+
+## Deployment Options
+
+| Method | Best For | Complexity | Links |
+|--------|----------|------------|-------|
+| **Docker Compose** | Single server, quick start, self-host | Low | [Guide](docker-compose.md) |
+| **Dokploy** | Managed platform, Traefik, multi-app | Medium | [Guide](dokploy.md) |
+| **Dokku + CI/CD** | GitHub Actions → Dokku | Medium | [GitHub workflow](../../.github/workflows/deploy.yml) |
+
+---
+
+## Quick Comparison
+
+### Docker Compose
+
+- **Pros**: One command, local or VPS, full control
+- **Cons**: Manual SSL (or Caddy/nginx), single host
+- **Files**: `docker-compose.yml`, `.env`, `.env.docker`
+- **Command**: `pnpm docker:up` (or full `docker compose --env-file .env.docker --env-file .env --profile selfhost up -d --build`)
+
+### Dokploy
+
+- **Pros**: Traefik (auto SSL), UI, multi-app on same host
+- **Cons**: Requires Dokploy setup
+- **Files**: `docker-compose.dokploy.yml`, `infra/deploy/env.dokploy.example`
+- **Docs**: [Dokploy Deployment Guide](dokploy.md) → [Full guide (Chinese)](../../infra/deploy/DOKPLOY_DEPLOYMENT.md)
+
+### Dokku + GitHub Actions
+
+- **Pros**: Push to deploy, Git-based workflow
+- **Cons**: Needs Dokku server, GitHub secrets
+- **Flow**: `workflow_dispatch` → build image → SCP to server → `docker compose` + `dokku git:from-image`
+- **Details**: See [.github/workflows/deploy.yml](../../.github/workflows/deploy.yml) and [infra/deploy/](../../infra/deploy/)
+
+---
+
+## Common Requirements
+
+All deployment methods need:
+
+1. **PostgreSQL** (with pgvector) – database
+2. **Redis** – background jobs (BullMQ)
+3. **Meilisearch** – search
+4. **MinIO** (or S3) – file storage
+5. **Environment variables** – see [.env.example](../../.env.example)
+
+---
+
+## Next Steps
+
+- [Docker Compose Deployment](docker-compose.md) – step-by-step for single-server
+- [Dokploy Deployment](dokploy.md) – Traefik-based managed deployment
+- [Troubleshooting](../troubleshooting.md) – common deployment issues

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -1,0 +1,141 @@
+# Local Development Setup (pnpm + Docker)
+
+This guide describes how to run OxyGenie in a **portable development environment**: Docker for infrastructure (PostgreSQL, Redis, Meilisearch, MinIO) and pnpm for the application. This enables fast iteration without running the full stack in Docker.
+
+## Prerequisites
+
+- **Node.js** ≥ 22.12
+- **pnpm** (recommended; npm/yarn also work)
+- **Docker** & **Docker Compose** (for infrastructure)
+- **(Optional)** MailHog for local email testing
+
+## Run Modes
+
+| Mode | Infrastructure | Application | Use Case |
+|------|----------------|--------------|----------|
+| **Full Docker** | Docker | Docker | Production-like, one-command |
+| **Hybrid** | Docker | Local (pnpm) | Development, fast HMR or stable build |
+| **Full Local** | Local services | Local (pnpm) | No Docker dependency |
+
+This guide focuses on **Hybrid** mode.
+
+---
+
+## Hybrid Mode: Step by Step
+
+### 1. Start Infrastructure
+
+```bash
+pnpm run ex0 -- init
+```
+
+Or manually:
+```bash
+docker compose up -d db minio provision-minio redis meilisearch
+```
+
+For email testing (verification codes):
+```bash
+docker compose --profile dev up -d mailhog
+```
+
+### 2. Configure Environment
+
+Copy the example and set values for localhost:
+
+```bash
+cp .env.example .env
+```
+
+Ensure these point to localhost (Docker exposes ports 5432, 6379, 7700, 9000):
+
+```bash
+# Database (match POSTGRES_* from .env.docker if using ex0 init)
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/oxygenie"
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="postgres"
+POSTGRES_DB="oxygenie"
+
+# Redis, Meilisearch, MinIO
+REDIS_URL="redis://localhost:6379"
+MEILI_HOST="http://localhost:7700"
+MEILI_MASTER_KEY="changeme-master-key"
+S3_ENDPOINT="http://localhost:9000"
+S3_ACCESS_KEY_ID="minioadmin"
+S3_SECRET_ACCESS_KEY="minioadmin"
+S3_BUCKET="oxygenie-files"
+
+# Auth
+BETTER_AUTH_SECRET="your-secret-key-here"
+BETTER_AUTH_URL="http://localhost:3000"
+
+# AI (required for Claude Chat)
+ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+### 3. Run Migrations (if needed)
+
+```bash
+pnpm db:migrate
+```
+
+Skip if the database was already initialized by Docker.
+
+### 4. Start the Application
+
+Two options:
+
+#### Option A: Development (with HMR)
+
+```bash
+# Terminal 1: main app
+pnpm dev
+
+# Terminal 2: WebSocket server (for Claude Chat)
+node ws-server.mjs
+```
+
+- App: http://localhost:3000  
+- Claude Chat: http://localhost:3000/agents/claude-chat  
+
+#### Option B: Production Build (more stable, no HMR)
+
+If `pnpm dev` shows HeadersTimeoutError or page keeps loading:
+
+```bash
+# Build (with Claude Chat WebSocket URL)
+NODE_OPTIONS="--max-old-space-size=8192" VITE_WS_URL="ws://localhost:3001/ws/agent" pnpm build
+
+# Start (app + WebSocket in one process)
+pnpm start:hybrid
+```
+
+- App: http://localhost:3000  
+- Claude Chat: http://localhost:3000/agents/claude-chat  
+
+---
+
+## Port Summary
+
+| Service | Port | Exposed |
+|---------|------|---------|
+| App (Nitro) | 3000 | ✓ |
+| WebSocket | 3001 | ✓ |
+| PostgreSQL | 5432 | ✓ |
+| Redis | 6379 | ✓ |
+| Meilisearch | 7700 | ✓ |
+| MinIO | 9000, 9001 | ✓ |
+| MailHog (SMTP) | 1025 | When `--profile dev` |
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Page keeps loading | Use `pnpm start:hybrid` instead of `pnpm dev` (see [Troubleshooting](../troubleshooting.md)) |
+| Build OOM | Add `NODE_OPTIONS="--max-old-space-size=8192"` before `pnpm build` |
+| `DATABASE_URL is not defined` | Ensure `.env` exists; `start-production.mjs` loads it via dotenv |
+| Redis/Meilisearch unreachable | Ensure `docker compose` has redis/meilisearch with `ports` exposed (see main README) |
+
+See [Troubleshooting](troubleshooting.md) for more.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,87 @@
+# Troubleshooting
+
+Common issues and solutions.
+
+## Development
+
+### Page Keeps Loading / HeadersTimeoutError
+
+**Symptom**: Browser shows loading spinner, never finishes. Backend logs show `HeadersTimeoutError` or `UND_ERR_HEADERS_TIMEOUT`.
+
+**Cause**: In `pnpm dev`, Nitro uses a Vite worker that forwards requests via `fetch()`. Slow SSR or cold start can trigger undici's headers timeout.
+
+**Solution**: Use the production build instead:
+
+```bash
+NODE_OPTIONS="--max-old-space-size=8192" VITE_WS_URL="ws://localhost:3001/ws/agent" pnpm build
+pnpm start:hybrid
+```
+
+`start:hybrid` runs Nitro directly (no worker/fetch), so the timeout does not occur.
+
+---
+
+### Build Fails with "JavaScript heap out of memory"
+
+**Symptom**: Build crashes during SSR bundle step with `FATAL ERROR: ... Allocation failed - JavaScript heap out of memory`.
+
+**Solution**: Increase Node's heap size:
+
+```bash
+NODE_OPTIONS="--max-old-space-size=8192" pnpm build
+```
+
+---
+
+### DATABASE_URL is not defined
+
+**Symptom**: `Error: DATABASE_URL is not defined` when running `pnpm start` or `pnpm start:hybrid`.
+
+**Solution**:
+1. Ensure `.env` exists and contains `DATABASE_URL`
+2. `start-production.mjs` loads `.env` via `dotenv/config`; ensure the file is in the project root
+3. If using Docker infra + local app, set `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/oxygenie"` (or match your POSTGRES_* values)
+
+---
+
+### Redis / Meilisearch Connection Refused
+
+**Symptom**: App or worker cannot connect to Redis or Meilisearch when running locally.
+
+**Solution**: Ensure `docker-compose.yml` exposes ports for hybrid mode:
+
+- Redis: `ports: ['6379:6379']`
+- Meilisearch: `ports: ['7700:7700']`
+
+Then set in `.env`:
+- `REDIS_URL="redis://localhost:6379"`
+- `MEILI_HOST="http://localhost:7700"`
+
+---
+
+## Docker
+
+### database "oxygenie" does not exist
+
+**Solution**: The stack runs a `create-db` step. If it fails, reset volumes and redeploy:
+
+```bash
+docker compose --profile selfhost down -v   # ⚠️ Deletes all data!
+pnpm docker:up
+```
+
+**Warning**: `down -v` removes volumes and deletes data.
+
+---
+
+### Keeping Existing DB Data (ex0/constructa)
+
+If you have existing data, **do not** run `down -v`. In `.env`, set only:
+
+```
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="postgres"
+POSTGRES_DB="constructa"   # or ex0, match your existing DB name
+```
+
+Do **not** set `DATABASE_URL` when using Docker; it is built from `POSTGRES_*` with host `db`.


### PR DESCRIPTION
The canonical repo is **foreveryh/oxygenie** (confirmed by owner). The old `Deeptoai-com/OxyGenie` address was inherited from the template — stale, and the reason the Phase 0.5 design doc looked 'missing' (it was on the right repo, the URL pointed elsewhere). Fixes all 21 refs across 9 files (docs + app.json/package.json + marketing page + GHCR image name, lowercased to match CI's `${GITHUB_REPOSITORY}/app`). Docs/metadata only.