### PR TITLE
fix: actually replace stale repo URL (PR#35 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@
 
 本项目基于 **TanStack Start** 构建。
 
-**GitHub 仓库**: https://github.com/Deeptoai-com/OxyGenie
+**GitHub 仓库**: https://github.com/foreveryh/oxygenie
 
 **已完成的功能 (Phase 1-4)**:
 - Phase 1: WebSocket 服务器 + Claude Agent SDK 集成
@@ -89,7 +89,7 @@ docker-compose up -d
 ## Git 工作流
 
 - 主分支: `main`
-- 远程仓库: `origin` → https://github.com/Deeptoai-com/OxyGenie
+- 远程仓库: `origin` → https://github.com/foreveryh/oxygenie
 - 直接在 `main` 分支开发，或创建 feature 分支后合并
 
 ---
@@ -723,12 +723,12 @@ TanStack Start + Nitro 已提供的能力，**不要重新实现**：
 ```bash
 # ✅ 正确：指定目标平台为 linux/amd64
 docker buildx build --platform linux/amd64 \
-  -t ghcr.io/Deeptoai-com/OxyGenie/app:latest \
+  -t ghcr.io/foreveryh/oxygenie/app:latest \
   --push .
 
 # ❌ 错误：不指定平台（会构建本机架构 arm64）
-docker build -t ghcr.io/Deeptoai-com/OxyGenie/app:latest .
-docker push ghcr.io/Deeptoai-com/OxyGenie/app:latest
+docker build -t ghcr.io/foreveryh/oxygenie/app:latest .
+docker push ghcr.io/foreveryh/oxygenie/app:latest
 ```
 
 #### 推送前认证
@@ -745,8 +745,8 @@ echo $(gh auth token) | docker login ghcr.io -u USERNAME --password-stdin
 
 ```bash
 # 拉取并检查架构
-docker pull ghcr.io/Deeptoai-com/OxyGenie/app:latest
-docker inspect ghcr.io/Deeptoai-com/OxyGenie/app:latest | jq '.[0].Architecture'
+docker pull ghcr.io/foreveryh/oxygenie/app:latest
+docker inspect ghcr.io/foreveryh/oxygenie/app:latest | jq '.[0].Architecture'
 # 应输出: "amd64"
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Use [.env.docker](.env.docker) and `.env`; `.env` is loaded last and overrides `
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/Deeptoai-com/OxyGenie.git
+   git clone https://github.com/foreveryh/oxygenie.git
    cd OxyGenie
    ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Built with Claude Agent SDK and TanStack Start, OxyGenie provides a web-first al
 ### Build from Source
 
 ```bash
-git clone https://github.com/Deeptoai-com/OxyGenie.git
+git clone https://github.com/foreveryh/oxygenie.git
 cd OxyGenie
 pnpm install
 ```
@@ -59,7 +59,7 @@ pnpm install
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/Deeptoai-com/OxyGenie.git
+   git clone https://github.com/foreveryh/oxygenie.git
    cd OxyGenie
    ```
 
@@ -110,7 +110,7 @@ pnpm install
 
 1. **Clone and install:**
    ```bash
-   git clone https://github.com/Deeptoai-com/OxyGenie.git
+   git clone https://github.com/foreveryh/oxygenie.git
    cd OxyGenie
    pnpm install
    ```
@@ -448,7 +448,7 @@ To report security vulnerabilities, please see [SECURITY.md](SECURITY.md).
 
 ## Links
 
-- **GitHub**: https://github.com/Deeptoai-com/OxyGenie
+- **GitHub**: https://github.com/foreveryh/oxygenie
 - **Claude Agent SDK**: https://github.com/anthropics/claude-agent-sdk
 - **Mastra Docs**: https://mastra.ai
 - **Assistant UI**: https://assistant-ui.com

--- a/README_CN.md
+++ b/README_CN.md
@@ -45,7 +45,7 @@ OxyGenie 是一个**面向中小团队的可扩展企业级 AI Agent 平台**。
 
 1. **克隆并安装:**
    ```bash
-   git clone https://github.com/Deeptoai-com/OxyGenie.git
+   git clone https://github.com/foreveryh/oxygenie.git
    cd OxyGenie
    pnpm install
    ```
@@ -351,7 +351,7 @@ pnpm test            # 运行测试
 
 ## 链接
 
-- **GitHub**: https://github.com/Deeptoai-com/OxyGenie
+- **GitHub**: https://github.com/foreveryh/oxygenie
 - **Claude Agent SDK**: https://github.com/anthropics/claude-agent-sdk
 - **Mastra 文档**: https://mastra.ai
 - **Assistant UI**: https://assistant-ui.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ We take security seriously. If you discover a security vulnerability in OxyGenie
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Instead, please use [GitHub Security Advisories](https://github.com/Deeptoai-com/OxyGenie/security/advisories/new) to report vulnerabilities.
+Instead, please use [GitHub Security Advisories](https://github.com/foreveryh/oxygenie/security/advisories/new) to report vulnerabilities.
 
 Include the following information:
 - Description of the vulnerability

--- a/app.json
+++ b/app.json
@@ -2,8 +2,8 @@
   "name": "oxygenie",
   "description": "OxyGenie - Enterprise AI Agent Platform",
   "keywords": ["tanstack", "react", "typescript", "ai", "agent"],
-  "website": "https://github.com/Deeptoai-com/OxyGenie",
-  "repository": "https://github.com/Deeptoai-com/OxyGenie",
+  "website": "https://github.com/foreveryh/oxygenie",
+  "repository": "https://github.com/foreveryh/oxygenie",
   "scripts": {
     "dokku": {
       "predeploy": "pnpm run db:migrate"

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -13,7 +13,7 @@ Deploy OxyGenie on a single server using Docker Compose. Best for self-hosted, V
 ## Step 1: Clone and Configure
 
 ```bash
-git clone https://github.com/Deeptoai-com/OxyGenie.git
+git clone https://github.com/foreveryh/oxygenie.git
 cd OxyGenie
 pnpm install
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oxygenie",
   "description": "OxyGenie - Extensible enterprise AI agent platform, based on Constructa scaffold",
-  "repository": "https://github.com/Deeptoai-com/OxyGenie",
+  "repository": "https://github.com/foreveryh/oxygenie",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/src/routes/(marketing)/index.tsx
+++ b/src/routes/(marketing)/index.tsx
@@ -53,7 +53,7 @@ function RouteComponent() {
           </Button>
           <Button size="lg" variant="outline" className="rounded-full px-8" asChild>
             <a
-              href="https://github.com/Deeptoai-com/OxyGenie"
+              href="https://github.com/foreveryh/oxygenie"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -317,7 +317,7 @@ function RouteComponent() {
           </p>
           <p className="text-center text-sm text-muted-foreground">
             <a
-              href="https://github.com/Deeptoai-com/OxyGenie"
+              href="https://github.com/foreveryh/oxygenie"
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-primary underline-offset-4 hover:underline"


### PR DESCRIPTION
PR #35 was supposed to fix the stale `Deeptoai-com/OxyGenie` -> `foreveryh/oxygenie` URL but the replacement silently no-op'd (bash-only `mapfile` in a zsh shell) — so 0 URLs changed, and it accidentally committed 7 unrelated in-flight docs. This does the real replacement across all 9 files (incl. GHCR image name, lowercased). Verified 0 stale refs remain. Docs/metadata only.