### PR TITLE
docs: accuracy review of onboarding docs + link one-command dev-up.sh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Documentation hub for developers and deployers.
 
 | Document | Description |
 |----------|-------------|
-| [Local Development Setup](development/local-setup.md) | pnpm + Docker hybrid mode, portable dev environment |
+| [Local Development Setup](development/local-setup.md) | pnpm + Docker hybrid mode (incl. the `./scripts/dev-up.sh` one-command flow) |
 | [Deployment Overview](deployment/overview.md) | Deployment options: Docker Compose, Dokploy, Dokku |
 | [Docker Compose Deployment](deployment/docker-compose.md) | Single-server self-host with Docker Compose |
 | [Dokploy Deployment](deployment/dokploy.md) | Deploy on Dokploy with Traefik |

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -19,6 +19,18 @@ This guide describes how to run OxyGenie in a **portable development environment
 
 This guide focuses on **Hybrid** mode.
 
+> **⭐ Fastest path:** the repo ships a one-command script that automates the entire
+> Hybrid flow below (start deps → migrate → build → start). See
+> [README → Option C: One-command hybrid dev](../../README.md#option-c-one-command-hybrid-dev-recommended-for-local):
+> ```bash
+> ./scripts/dev-up.sh             # deps + migrate + build + start  → http://localhost:3000
+> ./scripts/dev-up.sh --no-build  # faster: reuse the existing build
+> ./scripts/dev-up.sh --deps-only # only start deps + run migrations
+> ./scripts/dev-down.sh           # stop the dependency containers
+> ```
+> The manual steps below explain what that script does, for when you need to run the
+> pieces individually.
+
 ---
 
 ## Hybrid Mode: Step by Step


### PR DESCRIPTION
Reviewed the 7 docs from PR #35 against the real repo. **They're accurate** — ports (5050/3051 = Docker mappings, 3000/3001 = local hybrid), cross-references, and the ex0 init command all check out; 0 stale URLs. Only gap: they predate `scripts/dev-up.sh`, so this adds a pointer to the verified one-command flow in local-setup.md + the docs index. No changes to the correct manual steps.