### PR TITLE
feat(execution): ExecutionRuntime + LocalProcessBackend (Phase 0.5 PR-1)

### DIFF
--- a/src/claude/execution/index.js
+++ b/src/claude/execution/index.js
@@ -1,0 +1,48 @@
+/**
+ * Execution runtime factory.
+ *
+ * Returns a process-wide singleton ExecutionRuntime chosen by `EXEC_RUNTIME`:
+ *   - 'local'  (default) → LocalProcessBackend (today's behavior; Phase 0.5 PR-1)
+ *   - 'docker'           → per-session container backend (added in PR-2)
+ *
+ * Unknown / not-yet-implemented values fall back to 'local' with a warning, so a
+ * misconfiguration degrades safely instead of breaking the agent loop.
+ *
+ * @see ./types.js, ./local-process-backend.js
+ */
+import { LocalProcessBackend } from './local-process-backend.js';
+
+let singleton = null;
+let resolvedName = null;
+
+/** @returns {import('./types.js').ExecutionRuntime} */
+export function getExecutionRuntime() {
+  if (singleton) return singleton;
+
+  const requested = (process.env.EXEC_RUNTIME || 'local').toLowerCase();
+  switch (requested) {
+    case 'local':
+      singleton = new LocalProcessBackend();
+      break;
+    // case 'docker':  // PR-2: DockerBackend
+    default:
+      if (requested !== 'local') {
+        console.warn(`[execution] EXEC_RUNTIME='${requested}' not available; falling back to 'local'.`);
+      }
+      singleton = new LocalProcessBackend();
+      break;
+  }
+  resolvedName = singleton.name;
+  return singleton;
+}
+
+/** The active backend's name, or null before first use. Useful for diagnostics. */
+export function activeRuntimeName() {
+  return resolvedName;
+}
+
+/** Test-only: drop the cached singleton so the next get re-reads EXEC_RUNTIME. */
+export function __resetExecutionRuntimeForTests() {
+  singleton = null;
+  resolvedName = null;
+}

--- a/src/claude/execution/local-process-backend.js
+++ b/src/claude/execution/local-process-backend.js
@@ -1,0 +1,173 @@
+/**
+ * LocalProcessBackend — runs tool commands as a local child process.
+ *
+ * This is today's execution behavior, moved behind the ExecutionRuntime interface
+ * (Phase 0.5, PR-1) with NO behavior change:
+ *   - secrets are stripped from the child env (buildSafeEnv); always, every platform
+ *   - on Linux (or ENABLE_EXEC_SANDBOX=1) the command is wrapped with srt
+ *     (deny-network + workspace-fenced FS); on macOS/Windows it runs directly
+ *   - structured {file,args} runs WITHOUT a shell when the sandbox is inactive
+ *   - per-stream output cap (kill on overflow) + hard wall-clock timeout (SIGKILL)
+ *
+ * @see ./types.js for the ExecutionRuntime / ExecResult contracts.
+ */
+import { spawn } from 'node:child_process';
+import {
+  buildSafeEnv,
+  ensureSandbox,
+  wrapCommand,
+  cleanupAfterCommand,
+  shQuote,
+} from './sandbox.js';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 512_000;
+
+/** Bounded output collector: stops appending (and flags truncation) past `limitBytes`. */
+function createCollector(limitBytes) {
+  let total = 0;
+  let truncated = false;
+  let content = '';
+
+  const append = (chunk) => {
+    if (truncated) return;
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    const remaining = limitBytes - total;
+    if (remaining <= 0) {
+      truncated = true;
+      return;
+    }
+    if (buffer.length > remaining) {
+      content += buffer.subarray(0, remaining).toString('utf-8');
+      total += remaining;
+      truncated = true;
+      return;
+    }
+    content += buffer.toString('utf-8');
+    total += buffer.length;
+  };
+
+  return {
+    append,
+    get content() {
+      return content;
+    },
+    get truncated() {
+      return truncated;
+    },
+  };
+}
+
+export class LocalProcessBackend {
+  name = 'local';
+
+  /**
+   * @param {import('./types.js').ExecCommand} cmd
+   * @param {import('./types.js').ExecOptions} opts
+   * @returns {Promise<import('./types.js').ExecResult>}
+   */
+  async exec(cmd, opts = {}) {
+    const cwd = opts.cwd;
+    const timeout = Number(opts.timeoutMs) || DEFAULT_TIMEOUT_MS;
+    const outputLimit = Number(opts.maxOutputBytes) || DEFAULT_MAX_OUTPUT_BYTES;
+
+    // Secret-stripping lives in the runtime: overrides are merged over the
+    // allowlisted base, so callers can never widen the child's env to leak keys.
+    const safeEnv = buildSafeEnv(opts.env || {});
+
+    // Decide sandbox vs direct, exactly as the python runner did.
+    const sandboxActive = await ensureSandbox(cwd);
+    let spawnFile;
+    let spawnArgs;
+    if (sandboxActive) {
+      const raw =
+        typeof cmd.command === 'string'
+          ? cmd.command
+          : [cmd.file, ...(cmd.args || [])].map(shQuote).join(' ');
+      const wrapped = await wrapCommand(raw);
+      spawnFile = '/bin/sh';
+      spawnArgs = ['-c', wrapped];
+    } else if (typeof cmd.command === 'string') {
+      // Raw command requested but no OS sandbox: run via shell (caller opted in).
+      spawnFile = '/bin/sh';
+      spawnArgs = ['-c', cmd.command];
+    } else {
+      // Structured form, sandbox off → spawn directly, NO shell (smaller surface).
+      spawnFile = cmd.file;
+      spawnArgs = cmd.args || [];
+    }
+
+    const stdoutCollector = createCollector(outputLimit);
+    const stderrCollector = createCollector(outputLimit);
+
+    let timedOut = false;
+    let killedByLimit = false;
+    const startedAt = Date.now();
+
+    return await new Promise((resolve) => {
+      const child = spawn(spawnFile, spawnArgs, {
+        cwd,
+        env: safeEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, timeout);
+
+      const maybeKillForLimit = () => {
+        if (stdoutCollector.truncated || stderrCollector.truncated) {
+          if (!killedByLimit) {
+            killedByLimit = true;
+            child.kill('SIGKILL');
+          }
+        }
+      };
+
+      child.stdout?.on('data', (chunk) => {
+        stdoutCollector.append(chunk);
+        maybeKillForLimit();
+      });
+
+      child.stderr?.on('data', (chunk) => {
+        stderrCollector.append(chunk);
+        maybeKillForLimit();
+      });
+
+      child.on('error', (error) => {
+        clearTimeout(timer);
+        cleanupAfterCommand();
+        resolve({
+          stdout: stdoutCollector.content,
+          stderr: `${stderrCollector.content}${stderrCollector.content ? '\n' : ''}${error.message}`,
+          exitCode: 127,
+          signal: null,
+          durationMs: Date.now() - startedAt,
+          timedOut: false,
+          truncated: stdoutCollector.truncated || stderrCollector.truncated,
+          killedByLimit,
+        });
+      });
+
+      child.on('close', (code, signal) => {
+        clearTimeout(timer);
+        cleanupAfterCommand();
+        resolve({
+          stdout: stdoutCollector.content,
+          stderr: stderrCollector.content,
+          exitCode: code,
+          signal,
+          durationMs: Date.now() - startedAt,
+          timedOut,
+          truncated: stdoutCollector.truncated || stderrCollector.truncated,
+          killedByLimit,
+        });
+      });
+    });
+  }
+
+  async stop() {
+    /* no per-session resources to release for local processes */
+  }
+}

--- a/src/claude/execution/types.js
+++ b/src/claude/execution/types.js
@@ -1,0 +1,72 @@
+/**
+ * ExecutionRuntime — the contract for *where/how* untrusted tool code runs.
+ *
+ * Phase 0.5: this abstraction makes the execution backend pluggable so the agent
+ * loop and the web tier don't hard-code "spawn a local process". Today's behavior
+ * lives in `LocalProcessBackend`; a per-session `DockerBackend` follows in PR-2.
+ *
+ * These are JSDoc typedefs only (no runtime code) — the runtime code is plain JS
+ * ESM so it can be imported unchanged by the worker (.mjs) and server (.ts) alike.
+ *
+ * @see docs/project/research/2026-05-execution-runtime-design.md
+ */
+
+/**
+ * What to run. Structured form (`file` + `args`) is preferred: when the OS sandbox
+ * is inactive the backend spawns it WITHOUT a shell (smaller attack surface, the
+ * property the python runner has always had). A raw `command` string is run via a
+ * shell and is intended for backends that always shell out (e.g. Docker `exec`).
+ *
+ * @typedef {Object} ExecCommand
+ * @property {string} [file]            Executable, e.g. 'python3'. Used with `args`.
+ * @property {string[]} [args]          Arguments for `file`.
+ * @property {string} [command]         Raw shell command string (alternative to file/args).
+ */
+
+/**
+ * @typedef {Object} ExecOptions
+ * @property {string} cwd                       Working directory (the session workspace).
+ * @property {number} [timeoutMs]               Hard wall-clock kill (SIGKILL) after this.
+ * @property {number} [maxOutputBytes]          Per-stream output cap; child is killed past it.
+ * @property {Record<string,string|undefined>} [env]
+ *        Overrides merged OVER the backend's secret-stripped base env. Secret
+ *        stripping happens inside the backend, so no caller can leak keys.
+ */
+
+/**
+ * @typedef {Object} ExecResult
+ * @property {string} stdout
+ * @property {string} stderr
+ * @property {number|null} exitCode
+ * @property {NodeJS.Signals|null} signal
+ * @property {number} durationMs
+ * @property {boolean} timedOut                 Killed by the wall-clock timeout.
+ * @property {boolean} truncated                Output hit `maxOutputBytes`.
+ * @property {boolean} killedByLimit            Child was killed because output was truncated.
+ */
+
+/**
+ * @typedef {Object} SessionContext
+ * @property {string} sessionId
+ * @property {string} userId
+ * @property {string} workspaceDir              Host path to the session workspace.
+ * @property {string} [claudeHome]
+ */
+
+/**
+ * @typedef {Object} ExecutionRuntime
+ * @property {string} name                                  Backend id, e.g. 'local'.
+ * @property {(cmd: ExecCommand, opts: ExecOptions) => Promise<ExecResult>} exec
+ *        Run a command to completion and resolve an ExecResult. Never rejects for a
+ *        non-zero exit or a spawn error — those are reported in the result.
+ * @property {() => Promise<void>} [stop]                   Release per-session resources.
+ * @property {() => {enabled:boolean,state:any,srtAvailable:boolean}} [sandboxStatus]
+ *
+ * Future (declared for the contract; not all backends implement yet):
+ * @property {(ctx: SessionContext) => Promise<void>} [start]
+ * @property {(cmd: ExecCommand, opts: ExecOptions) => AsyncGenerator} [stream]
+ * @property {() => void} [abort]
+ * @property {() => Promise<any>} [snapshot]
+ */
+
+export {};

--- a/src/claude/python/runner.js
+++ b/src/claude/python/runner.js
@@ -5,11 +5,10 @@
  * Avoids shell execution to reduce attack surface.
  */
 
-import { spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
-import { buildSafeEnv, ensureSandbox, wrapCommand, cleanupAfterCommand, shQuote } from '../execution/sandbox.js';
+import { getExecutionRuntime } from '../execution/index.js';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.PYTHON_RUNNER_TIMEOUT_MS) || 10_000;
 const DEFAULT_MAX_OUTPUT_BYTES = Number(process.env.PYTHON_RUNNER_MAX_OUTPUT_BYTES) || 512_000;
@@ -119,42 +118,6 @@ function ensureAbsoluteDir(value) {
   return path.resolve(String(value || process.cwd()));
 }
 
-function createCollector(limitBytes) {
-  let total = 0;
-  let truncated = false;
-  let content = '';
-
-  const append = (chunk) => {
-    if (truncated) return;
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
-    const remaining = limitBytes - total;
-    if (remaining <= 0) {
-      truncated = true;
-      return;
-    }
-
-    if (buffer.length > remaining) {
-      content += buffer.subarray(0, remaining).toString('utf-8');
-      total += remaining;
-      truncated = true;
-      return;
-    }
-
-    content += buffer.toString('utf-8');
-    total += buffer.length;
-  };
-
-  return {
-    append,
-    get content() {
-      return content;
-    },
-    get truncated() {
-      return truncated;
-    },
-  };
-}
-
 export async function runPython({ code, cwd, timeoutMs, maxOutputBytes, maxCodeBytes } = {}) {
   const resolvedCwd = ensureAbsoluteDir(cwd);
   const outputLimit = Number(maxOutputBytes) || DEFAULT_MAX_OUTPUT_BYTES;
@@ -184,97 +147,41 @@ export async function runPython({ code, cwd, timeoutMs, maxOutputBytes, maxCodeB
 
   await fs.writeFile(filePath, code, 'utf-8');
 
-  const stdoutCollector = createCollector(outputLimit);
-  const stderrCollector = createCollector(outputLimit);
-
-  let timedOut = false;
-  let killedByLimit = false;
-
-  const startedAt = Date.now();
   const timeout = Number(timeoutMs) || DEFAULT_TIMEOUT_MS;
 
-  // Risk #1 mitigation: always strip secrets from the child env; where the OS
-  // sandbox is available, also wrap execution with srt (deny-net + fs fenced to cwd).
-  const safeEnv = buildSafeEnv({
-    HOME: resolvedCwd,
-    PYTHONUNBUFFERED: '1',
-    PYTHONDONTWRITEBYTECODE: '1',
-    MPLBACKEND: process.env.MPLBACKEND || 'Agg',
-  });
-  const sandboxActive = await ensureSandbox(resolvedCwd);
-  let spawnFile = 'python3';
-  let spawnArgs = ['-u', filePath];
-  if (sandboxActive) {
-    const wrapped = await wrapCommand(`python3 -u ${shQuote(filePath)}`);
-    spawnFile = '/bin/sh';
-    spawnArgs = ['-c', wrapped];
-  }
-
-  return await new Promise((resolve) => {
-    const child = spawn(spawnFile, spawnArgs, {
+  // Execution backend (Phase 0.5): how/where the process runs is pluggable.
+  // The backend strips secrets from the child env (buildSafeEnv) and applies the
+  // OS sandbox (srt: deny-net + fs fenced to cwd) where available. Structured
+  // {file,args} runs without a shell when the sandbox is inactive. See
+  // src/claude/execution/.
+  const runtime = getExecutionRuntime();
+  const result = await runtime.exec(
+    { file: 'python3', args: ['-u', filePath] },
+    {
       cwd: resolvedCwd,
-      env: safeEnv,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+      timeoutMs: timeout,
+      maxOutputBytes: outputLimit,
+      env: {
+        HOME: resolvedCwd,
+        PYTHONUNBUFFERED: '1',
+        PYTHONDONTWRITEBYTECODE: '1',
+        MPLBACKEND: process.env.MPLBACKEND || 'Agg',
+      },
+    },
+  );
 
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGKILL');
-    }, timeout);
+  const fileTracking = await collectWorkspaceChanges(resolvedCwd, beforeSnapshot);
+  await fs.unlink(filePath).catch(() => {});
 
-    const maybeKillForLimit = () => {
-      if (stdoutCollector.truncated || stderrCollector.truncated) {
-        if (!killedByLimit) {
-          killedByLimit = true;
-          child.kill('SIGKILL');
-        }
-      }
-    };
-
-    child.stdout?.on('data', (chunk) => {
-      stdoutCollector.append(chunk);
-      maybeKillForLimit();
-    });
-
-    child.stderr?.on('data', (chunk) => {
-      stderrCollector.append(chunk);
-      maybeKillForLimit();
-    });
-
-    child.on('error', async (error) => {
-      clearTimeout(timer);
-      cleanupAfterCommand();
-      const fileTracking = await collectWorkspaceChanges(resolvedCwd, beforeSnapshot);
-      await fs.unlink(filePath).catch(() => {});
-      resolve({
-        stdout: stdoutCollector.content,
-        stderr: `${stderrCollector.content}${stderrCollector.content ? '\n' : ''}${error.message}`,
-        exitCode: 127,
-        signal: null,
-        durationMs: Date.now() - startedAt,
-        timedOut: false,
-        truncated: stdoutCollector.truncated || stderrCollector.truncated,
-        killedByLimit,
-        ...fileTracking,
-      });
-    });
-
-    child.on('close', async (code, signal) => {
-      clearTimeout(timer);
-      cleanupAfterCommand();
-      const fileTracking = await collectWorkspaceChanges(resolvedCwd, beforeSnapshot);
-      await fs.unlink(filePath).catch(() => {});
-      resolve({
-        stdout: stdoutCollector.content,
-        stderr: stderrCollector.content,
-        exitCode: code,
-        signal,
-        durationMs: Date.now() - startedAt,
-        timedOut,
-        truncated: stdoutCollector.truncated || stderrCollector.truncated,
-        killedByLimit,
-        ...fileTracking,
-      });
-    });
-  });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+    signal: result.signal,
+    durationMs: result.durationMs,
+    timedOut: result.timedOut,
+    truncated: result.truncated,
+    killedByLimit: result.killedByLimit,
+    ...fileTracking,
+  };
 }


### PR DESCRIPTION
First step of the execution-layer rewrite (per the approved design doc). **Pure refactor — behavior-identical.**

Makes the execution backend pluggable:
- `execution/types.js` — JSDoc contracts
- `execution/local-process-backend.js` — today's spawn + srt sandbox + secret env-strip + output cap + wall-clock timeout, behind the interface (structured {file,args} still runs without a shell when sandbox off)
- `execution/index.js` — `getExecutionRuntime()` singleton via `EXEC_RUNTIME` (default local; docker warns+falls back until PR-2)
- `python/runner.js` — `runPython` delegates to `runtime.exec()`, identical public contract & return shape

**Verified (real output):** `verify-exec-sandbox.mjs` → SANDBOX VERIFY: PASS; edge cases (compute 1024 / nonzero exit 3 / timeout / truncation+killedByLimit / file-tracking) all pass; factory default+fallback correct; `test:unit` 6/6.

Next: PR-2 DockerBackend (per-session container).