### PR TITLE
refactor(security): unify route path-traversal guard (B3)

### DIFF
--- a/src/routes/api/session/$sessionId.file.$filePath.ts
+++ b/src/routes/api/session/$sessionId.file.$filePath.ts
@@ -14,6 +14,7 @@ import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { requireUser } from '~/server/require-user';
 import { getWorkspaceSession } from '~/server/workspace-session';
+import { validateRelativePath } from '~/server/security/validate-relative-path';
 
 /**
  * Get MIME type from file extension
@@ -54,22 +55,6 @@ function isBinaryExtension(filePath: string): boolean {
 }
 
 /**
- * Validate file path to prevent path traversal attacks
- */
-function validateFilePath(filePath: string): boolean {
-  if (filePath.includes('..') || filePath.includes('~') || path.isAbsolute(filePath)) {
-    return false;
-  }
-
-  const normalized = path.normalize(filePath);
-  if (normalized.includes('..') || normalized.startsWith('/') || normalized.startsWith('\\')) {
-    return false;
-  }
-
-  return true;
-}
-
-/**
  * Decode URL-encoded file path
  */
 function decodeFilePath(encodedPath: string): string {
@@ -95,7 +80,7 @@ export const Route = createFileRoute('/api/session/$sessionId/file/$filePath')({
         // Decode URL-encoded file path
         const filePath = decodeFilePath(encodedFilePath);
 
-        if (!validateFilePath(filePath)) {
+        if (!validateRelativePath(filePath)) {
           return new Response(
             JSON.stringify({ error: 'Invalid file path' }),
             { status: 400, headers: { 'content-type': 'application/json' } }

--- a/src/routes/api/session/$sessionId.files.ts
+++ b/src/routes/api/session/$sessionId.files.ts
@@ -137,22 +137,6 @@ async function scanSessionFiles(
   return files;
 }
 
-/**
- * Validate file path to prevent path traversal attacks
- */
-function validateFilePath(filePath: string): boolean {
-  if (filePath.includes('..') || filePath.includes('~') || path.isAbsolute(filePath)) {
-    return false;
-  }
-
-  const normalized = path.normalize(filePath);
-  if (normalized.includes('..') || normalized.startsWith('/') || normalized.startsWith('\\')) {
-    return false;
-  }
-
-  return true;
-}
-
 export const Route = createFileRoute('/api/session/$sessionId/files')({
   server: {
     handlers: {

--- a/src/routes/api/workspace/$sessionId.artifacts.ts
+++ b/src/routes/api/workspace/$sessionId.artifacts.ts
@@ -14,6 +14,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { requireUser } from '~/server/require-user';
 import { getWorkspaceSession } from '~/server/workspace-session';
+import { validateRelativePath } from '~/server/security/validate-relative-path';
 
 // P16: Version tracking types
 type ArtifactVersion = {
@@ -58,19 +59,6 @@ const MAX_VERSIONS = 10; // P16: Maximum versions to keep per artifact
  * Keep in sync with frontend flag in artifact-registry.ts
  */
 const ENABLE_VERSION_RECORDING = false;
-
-function validateFilePath(filePath: string): boolean {
-  if (filePath.includes('..') || filePath.includes('~') || path.isAbsolute(filePath)) {
-    return false;
-  }
-
-  const normalized = path.normalize(filePath);
-  if (normalized.includes('..') || normalized.startsWith('/') || normalized.startsWith('\\')) {
-    return false;
-  }
-
-  return true;
-}
 
 async function readRegistry(workspacePath: string): Promise<RegistryPayload> {
   const registryPath = path.join(workspacePath, REGISTRY_FILENAME);
@@ -134,7 +122,7 @@ export const Route = createFileRoute('/api/workspace/$sessionId/artifacts')({
           );
         }
 
-        if (!validateFilePath(payload.filePath)) {
+        if (!validateRelativePath(payload.filePath)) {
           return new Response(
             JSON.stringify({ error: 'Invalid file path' }),
             { status: 400, headers: { 'content-type': 'application/json' } }

--- a/src/routes/api/workspace/$sessionId.file.$filePath.ts
+++ b/src/routes/api/workspace/$sessionId.file.$filePath.ts
@@ -9,33 +9,7 @@ import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { requireUser } from '~/server/require-user';
 import { getWorkspaceSession } from '~/server/workspace-session';
-
-/**
- * Validate file path to prevent path traversal attacks
- */
-function validateFilePath(filePath: string): boolean {
-  if (!filePath || filePath.trim().length === 0) {
-    return false;
-  }
-
-  // Reject paths with path traversal patterns
-  if (filePath.includes('..') || filePath.includes('~') || path.isAbsolute(filePath)) {
-    return false;
-  }
-
-  // Normalize and check again
-  const normalized = path.normalize(filePath);
-  if (
-    normalized === '.' ||
-    normalized.includes('..') ||
-    normalized.startsWith('/') ||
-    normalized.startsWith('\\')
-  ) {
-    return false;
-  }
-
-  return true;
-}
+import { validateRelativePath } from '~/server/security/validate-relative-path';
 
 function resolveFilePathFromRequest(
   request: Request,
@@ -112,7 +86,7 @@ export const Route = createFileRoute('/api/workspace/$sessionId/file/$filePath')
         const { raw, download } = parseRawOptions(request);
 
         // Validate file path
-        if (!validateFilePath(filePath)) {
+        if (!validateRelativePath(filePath)) {
           return new Response(
             JSON.stringify({ error: 'Invalid file path' }),
             { status: 400, headers: { 'content-type': 'application/json' } }

--- a/src/routes/api/workspace/$sessionId.files.ts
+++ b/src/routes/api/workspace/$sessionId.files.ts
@@ -9,6 +9,7 @@ import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { requireUser } from '~/server/require-user';
 import { getWorkspaceSession } from '~/server/workspace-session';
+import { validateRelativePath } from '~/server/security/validate-relative-path';
 
 /**
  * System files to exclude from workspace listings
@@ -95,24 +96,6 @@ async function listFilesRecursive(dirPath: string, basePath: string = ''): Promi
   return files;
 }
 
-/**
- * Validate file path to prevent path traversal attacks
- */
-function validateFilePath(filePath: string): boolean {
-  // Reject paths with path traversal patterns
-  if (filePath.includes('..') || filePath.includes('~') || path.isAbsolute(filePath)) {
-    return false;
-  }
-
-  // Normalize and check again
-  const normalized = path.normalize(filePath);
-  if (normalized.includes('..') || normalized.startsWith('/') || normalized.startsWith('\\')) {
-    return false;
-  }
-
-  return true;
-}
-
 export const Route = createFileRoute('/api/workspace/$sessionId/files')({
   server: {
     handlers: {
@@ -166,7 +149,7 @@ export const Route = createFileRoute('/api/workspace/$sessionId/files')({
           );
         }
 
-        if (!validateFilePath(filePath)) {
+        if (!validateRelativePath(filePath)) {
           return new Response(
             JSON.stringify({ error: 'Invalid file path' }),
             { status: 400, headers: { 'content-type': 'application/json' } }

--- a/src/server/security/validate-relative-path.ts
+++ b/src/server/security/validate-relative-path.ts
@@ -1,0 +1,55 @@
+import path from 'node:path';
+
+/**
+ * Validate a caller-supplied **relative** file path before joining it onto a
+ * server-side workspace root, to prevent path-traversal escapes.
+ *
+ * Shared by the workspace/session file & artifact API routes (B3 — previously each
+ * route defined its own near-identical copy). This is the STRICTEST of those copies:
+ * it rejects empty/whitespace and a bare "." in addition to the common checks.
+ *
+ * Rejects: empty/whitespace, `..` segments, `~`, absolute paths (POSIX or Windows),
+ * and anything that still looks absolute or contains `..` after normalization.
+ *
+ * NOTE: this is the route-layer guard for URL/relative inputs. It is intentionally
+ * separate from `src/claude/path-security.js` `canUseTool`, which guards the agent
+ * SDK's tools against *absolute* paths with realpath + cross-user checks.
+ *
+ * @returns true if the path is safe to join onto a trusted base directory.
+ */
+export function validateRelativePath(filePath: string): boolean {
+  if (!filePath || filePath.trim().length === 0) {
+    return false;
+  }
+
+  // Backslashes never appear in a legitimate POSIX relative path (they are Windows
+  // separators / UNC prefixes). On a POSIX server `path.isAbsolute('C:\\x')` is false,
+  // so reject these explicitly for correct cross-platform behavior.
+  if (filePath.includes('\\')) {
+    return false;
+  }
+  // Windows drive-letter prefix (e.g. "C:/Windows") — also not absolute on POSIX.
+  if (/^[a-zA-Z]:/.test(filePath)) {
+    return false;
+  }
+
+  // Reject obvious traversal / absolute / home markers up front.
+  if (filePath.includes('..') || filePath.includes('~') || path.isAbsolute(filePath)) {
+    return false;
+  }
+
+  // Normalize and re-check (collapses things like "a/./../b"). Reject paths that
+  // resolve to the directory itself (".", "./") or that still look absolute/traversing.
+  const normalized = path.normalize(filePath);
+  if (
+    normalized === '.' ||
+    normalized === './' ||
+    normalized.includes('..') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('\\')
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/tests/unit/validate-relative-path.test.ts
+++ b/tests/unit/validate-relative-path.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the shared route-layer relative-path guard (B3).
+ *
+ * This guard is used by the workspace/session file & artifact API routes to reject
+ * traversal/absolute inputs before joining onto a trusted workspace root. It is the
+ * strictest of the 5 previously-duplicated copies (also rejects empty + bare ".").
+ */
+import { describe, it, expect } from 'vitest';
+import { validateRelativePath } from '../../src/server/security/validate-relative-path';
+
+describe('validateRelativePath', () => {
+  it('accepts safe relative paths', () => {
+    for (const p of ['file.txt', 'dir/file.txt', 'a/b/c.md', 'sub/./file.txt', 'name with spaces.txt']) {
+      expect(validateRelativePath(p)).toBe(true);
+    }
+  });
+
+  it('rejects empty / whitespace / bare dot', () => {
+    for (const p of ['', '   ', '.', './']) {
+      expect(validateRelativePath(p)).toBe(false);
+    }
+  });
+
+  it('rejects parent-traversal sequences', () => {
+    for (const p of ['..', '../etc/passwd', 'a/../../b', 'dir/..', 'foo/../../bar']) {
+      expect(validateRelativePath(p)).toBe(false);
+    }
+  });
+
+  it('rejects home (~) references', () => {
+    for (const p of ['~', '~/secrets', 'a/~/b']) {
+      expect(validateRelativePath(p)).toBe(false);
+    }
+  });
+
+  it('rejects POSIX absolute paths', () => {
+    for (const p of ['/etc/passwd', '/', '/data/users/x']) {
+      expect(validateRelativePath(p)).toBe(false);
+    }
+  });
+
+  it('rejects Windows absolute paths', () => {
+    for (const p of ['C:\\Windows\\System32', 'C:/Windows', '\\\\server\\share']) {
+      expect(validateRelativePath(p)).toBe(false);
+    }
+  });
+
+  it('rejects backslash-rooted paths', () => {
+    expect(validateRelativePath('\\etc')).toBe(false);
+  });
+});


### PR DESCRIPTION
Folds in the Phase-1 B3 item. The 5 file/artifact API routes each had a near-identical `validateFilePath()` (one was dead code). Replaced with a single shared `src/server/security/validate-relative-path.ts`, using the strictest variant + hardening (reject backslashes, `C:/` drive prefixes, `./` — none legitimate on a POSIX server). Behavior-preserving for legitimate inputs.

**Verified (real output):** `test:unit` 13/13 (7 new guard tests + 6 existing path-security); standalone regression ALL_CORRECT (7 allow / 16 deny incl. C:/Windows→false); 0 residual `validateFilePath`.

Next: PR-4 (C4 backpressure).