### PR TITLE
feat(ws): backpressure for the agent stream (C4)

### DIFF
--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -598,8 +598,16 @@ async function authenticateRequest(request) {
 function sendMessage(ws, msg) {
   if (ws.readyState === ws.OPEN) {
     ws.send(JSON.stringify(msg));
+    return ws.bufferedAmount;
   }
+  return 0;
 }
+
+// C4 backpressure (consumer side): bytes queued on the WS socket above/below
+// which we pause/resume reading the worker's stdout, so a fast agent stream +
+// slow client can't grow the server's send buffer without bound.
+const WS_BACKPRESSURE_HIGH = Number(process.env.WS_BACKPRESSURE_HIGH_BYTES) || 8 * 1024 * 1024;
+const WS_BACKPRESSURE_LOW = Number(process.env.WS_BACKPRESSURE_LOW_BYTES) || 1 * 1024 * 1024;
 
 /**
  * Create a new empty session without requiring a user message
@@ -866,7 +874,7 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
             }
           }
           if (!silentInit) {
-            sendMessage(ws, { type: 'message', event });
+            applyBackpressure(sendMessage(ws, { type: 'message', event }));
           }
         } else if (msg.type === 'done') {
           worker.__terminalSent = true;


### PR DESCRIPTION
Folds in the Phase-1 C4 item. Prevents unbounded memory when a fast agent stream meets a slow WS client, on both halves of the pipe:

- **Worker (producer):** `send()` awaits stdout `drain` when `write()` returns false; the streaming loop `await send(event)` — stops the SDK pump instead of buffering.
- **ws-server (consumer):** `sendMessage()` returns `ws.bufferedAmount`; pauses `worker.stdout` above `WS_BACKPRESSURE_HIGH_BYTES` (8MB), resumes below `WS_BACKPRESSURE_LOW_BYTES` (1MB) or on close. Timer cleared on `rl 'close'`.

**Verified (real output):** smoke-agent PASS (18 events, tool_use, result.txt, exit 0 — no streaming regression); standalone primitive test BACKPRESSURE_WORKS; `node --check` both; `test:unit` 13/13.

This completes the Phase 0.5 PR sequence (PR-1 interface, PR-2 DockerBackend, PR-3 B3 path-guard, PR-4 C4 backpressure).