### PR TITLE
fix(ws): complete C4 backpressure — PR #43 shipped a broken half (P0)

### DIFF
--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -566,8 +566,14 @@ Example bad operations:
         }
       }
 
-      // Send each event as a JSON line
-      process.stdout.write(JSON.stringify({ type: 'event', event }) + '\n');
+      // Send each event as a JSON line. C4 backpressure (producer side): if the
+      // pipe to the parent is full (parent paused reading because the WS client is
+      // slow), await 'drain' before continuing so the SDK event pump stops instead
+      // of buffering unboundedly in this worker.
+      const ok = process.stdout.write(JSON.stringify({ type: 'event', event }) + '\n');
+      if (!ok) {
+        await new Promise((resolve) => process.stdout.once('drain', resolve));
+      }
     }
 
     // Signal completion (only if not terminating)

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -821,12 +821,33 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     // Read responses line by line
     const rl = createInterface({ input: worker.stdout });
 
+    // C4 backpressure (consumer side): when the WS send buffer grows past HIGH,
+    // pause reading the worker's stdout; resume once it drains below LOW (or the
+    // socket closes). Pausing fills the OS pipe, which (via the worker's drain-await)
+    // throttles the producer — so a fast stream + slow client can't grow memory.
+    let bpTimer = null;
+    const applyBackpressure = (buffered) => {
+      if (bpTimer || buffered <= WS_BACKPRESSURE_HIGH) return;
+      try { worker.stdout.pause(); } catch { /* ignore */ }
+      bpTimer = setInterval(() => {
+        if (ws.readyState !== ws.OPEN || ws.bufferedAmount <= WS_BACKPRESSURE_LOW) {
+          clearInterval(bpTimer);
+          bpTimer = null;
+          try { worker.stdout.resume(); } catch { /* ignore */ }
+        }
+      }, 50);
+    };
+    const clearBackpressure = () => {
+      if (bpTimer) { clearInterval(bpTimer); bpTimer = null; }
+    };
+
     // Handle readline errors (e.g., when worker is killed abruptly)
     rl.on('error', (error) => {
       console.log('[WS Server] Readline error (expected on abort):', error.message);
     });
 
     rl.on('close', () => {
+      clearBackpressure();
       // Readline closed, worker output ended
     });
 


### PR DESCRIPTION
**P0 fix.** PR #43 landed only part of C4: `ws-server.mjs` called `applyBackpressure()`/`clearBackpressure()` that were never defined, and the worker drain-await was missing. `node --check` passes but the first streamed message would throw `ReferenceError`, crashing every chat. (Edits silently no-op'd during a tool glitch; the smoke test only exercises the worker, not the ws-server path, so it didn't catch it.)

Completes both halves and verifies with **real runtime checks**: ws-server boots clean on :3199 (listening, /health ok, no ReferenceError), smoke-agent PASS (46 events/done/exit 0), backpressure state-machine logic test STATE_MACHINE_OK, both files node --check PASS.