### PR TITLE
feat(ws): bounded worker concurrency + queue (S1)

### DIFF
--- a/src/server/concurrency/semaphore.js
+++ b/src/server/concurrency/semaphore.js
@@ -1,0 +1,60 @@
+/**
+ * Semaphore — bounds how many "permits" are held at once; extra acquire() calls
+ * queue (FIFO) until a release() frees a slot.
+ *
+ * Used by ws-server (S1) to cap simultaneously-active agent workers on a single
+ * host: a burst of concurrent chats can't spawn unbounded worker processes (each
+ * ~150–300 MB) and OOM the box — excess requests wait for a free slot instead.
+ *
+ * Plain JS ESM so ws-server.mjs can import it without a build step.
+ */
+export class Semaphore {
+  /** @param {number} max  Maximum permits held concurrently (>= 1). */
+  constructor(max) {
+    this.max = Math.max(1, Number.isFinite(max) ? Math.floor(max) : 1);
+    this.active = 0;
+    /** @type {Array<() => void>} FIFO resolvers for queued acquire() calls. */
+    this._waiters = [];
+  }
+
+  /** Permits currently held. */
+  get activeCount() {
+    return this.active;
+  }
+
+  /** Callers currently waiting for a permit. */
+  get waitingCount() {
+    return this._waiters.length;
+  }
+
+  /**
+   * Acquire a permit. Resolves immediately if one is free, else resolves later
+   * (FIFO) when a permit is released.
+   * @returns {Promise<void>}
+   */
+  acquire() {
+    if (this.active < this.max) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this._waiters.push(resolve);
+    });
+  }
+
+  /**
+   * Release a permit. If anyone is waiting, hand the permit directly to the next
+   * waiter (active count unchanged); otherwise decrement. Never goes negative.
+   * Idempotency is the caller's responsibility (don't release more than acquired).
+   */
+  release() {
+    if (this._waiters.length > 0) {
+      const next = this._waiters.shift();
+      next();
+      return;
+    }
+    if (this.active > 0) {
+      this.active--;
+    }
+  }
+}

--- a/tests/unit/semaphore.test.ts
+++ b/tests/unit/semaphore.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the worker-concurrency Semaphore (S1).
+ *
+ * Encodes the contract ws-server relies on: a hard cap on concurrent permits,
+ * FIFO queueing past the cap, permit hand-off on release, and no negative count.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - .js module without type declarations
+import { Semaphore } from '../../src/server/concurrency/semaphore.js';
+
+/** Resolve "pending" if the promise hasn't settled in a microtask turn. */
+function settledOrPending(p: Promise<unknown>): Promise<'settled' | 'pending'> {
+  return Promise.race([
+    p.then(() => 'settled' as const),
+    Promise.resolve().then(() => 'pending' as const),
+  ]);
+}
+
+describe('Semaphore', () => {
+  it('allows up to max acquires immediately', async () => {
+    const s = new Semaphore(2);
+    await s.acquire();
+    await s.acquire();
+    expect(s.activeCount).toBe(2);
+    expect(s.waitingCount).toBe(0);
+  });
+
+  it('queues acquires past max', async () => {
+    const s = new Semaphore(2);
+    await s.acquire();
+    await s.acquire();
+    const third = s.acquire();
+    expect(await settledOrPending(third)).toBe('pending');
+    expect(s.waitingCount).toBe(1);
+    expect(s.activeCount).toBe(2);
+  });
+
+  it('hands a released permit to the next waiter (FIFO), active count stays at max', async () => {
+    const s = new Semaphore(1);
+    await s.acquire(); // active=1
+    const order: number[] = [];
+    const w2 = s.acquire().then(() => order.push(2));
+    const w3 = s.acquire().then(() => order.push(3));
+    expect(s.waitingCount).toBe(2);
+
+    s.release(); // -> w2
+    await w2;
+    expect(order).toEqual([2]);
+    expect(s.activeCount).toBe(1); // permit transferred, not freed
+    expect(s.waitingCount).toBe(1);
+
+    s.release(); // -> w3
+    await w3;
+    expect(order).toEqual([2, 3]);
+    expect(s.activeCount).toBe(1);
+    expect(s.waitingCount).toBe(0);
+  });
+
+  it('decrements when nobody is waiting', async () => {
+    const s = new Semaphore(2);
+    await s.acquire();
+    await s.acquire();
+    s.release();
+    expect(s.activeCount).toBe(1);
+    s.release();
+    expect(s.activeCount).toBe(0);
+  });
+
+  it('never goes negative on extra release', () => {
+    const s = new Semaphore(2);
+    s.release();
+    s.release();
+    expect(s.activeCount).toBe(0);
+  });
+
+  it('coerces a bad max to >= 1', () => {
+    expect(new Semaphore(0).max).toBe(1);
+    expect(new Semaphore(-5).max).toBe(1);
+    expect(new Semaphore(NaN).max).toBe(1);
+    expect(new Semaphore(8).max).toBe(8);
+  });
+
+  it('end-to-end: 3 slots, 10 tasks, never exceeds the cap', async () => {
+    const s = new Semaphore(3);
+    let running = 0;
+    let peak = 0;
+    const run = async () => {
+      await s.acquire();
+      running++;
+      peak = Math.max(peak, running);
+      await Promise.resolve();
+      running--;
+      s.release();
+    };
+    await Promise.all(Array.from({ length: 10 }, run));
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(s.activeCount).toBe(0);
+    expect(s.waitingCount).toBe(0);
+  });
+});

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -20,6 +20,7 @@ import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { WebSocketServer, WebSocket } from 'ws';
+import { Semaphore } from './src/server/concurrency/semaphore.js';
 
 // Get directory of current module
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -39,6 +40,18 @@ function summarizeMessage(msg) {
 // Configuration
 const WS_PORT = parseInt(process.env.WS_PORT || '3001', 10);
 const APP_URL = process.env.APP_URL || 'http://localhost:5000';
+
+// S1 — single-host worker concurrency cap. Each active agent worker is a Node +
+// Claude Agent SDK child (~150–300 MB). Cap how many run at once so a burst of
+// concurrent chats queues instead of spawning unboundedly and OOM-ing the box.
+// Default 8 (tuned for a 16 GB / 8-core VPS targeting ~50 concurrent sessions —
+// most sessions are idle/awaiting the model, so a few parallel workers suffice).
+const MAX_CONCURRENT_WORKERS = Math.max(
+  1,
+  parseInt(process.env.MAX_CONCURRENT_WORKERS || '8', 10) || 8,
+);
+const workerSemaphore = new Semaphore(MAX_CONCURRENT_WORKERS);
+console.log(`[WS Server] Max concurrent workers: ${MAX_CONCURRENT_WORKERS}`);
 
 /**
  * Resolve SESSIONS_ROOT with same logic as manager.ts getUserClaudeHome()
@@ -789,12 +802,34 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     const disallowedTools = resolveDisallowedTools(permissionMode, allowBash);
     workerEnv.CLAUDE_PERMISSION_MODE = permissionMode;
 
+    // S1 — acquire a worker permit before spawning. If all slots are busy, this
+    // awaits a free one (FIFO) instead of spawning unboundedly; tell the client
+    // it's queued so the UI can show a waiting state. The window between acquire()
+    // and spawn() below is synchronous (no await), so a held permit always maps to
+    // a spawned worker; the permit is released exactly once in worker 'close'.
+    if (workerSemaphore.activeCount >= workerSemaphore.max && !silentInit) {
+      sendMessage(ws, {
+        type: 'queued',
+        position: workerSemaphore.waitingCount + 1,
+        message: 'Server busy — your request is queued and will start shortly.',
+      });
+    }
+    await workerSemaphore.acquire();
+
     // Spawn worker process with user-specific CLAUDE_HOME
     const worker = spawn('node', [WORKER_PATH], {
       env: workerEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     ws.workerProcess = worker;
+    // S1: release this worker's concurrency permit exactly once (in 'close').
+    worker.__permitReleased = false;
+    const releaseWorkerPermit = () => {
+      if (!worker.__permitReleased) {
+        worker.__permitReleased = true;
+        workerSemaphore.release();
+      }
+    };
     // Risk #10: track whether this run already delivered a terminal frame
     // (done/error/aborted). If the worker dies without one (e.g. a crash), the
     // close handler emits a terminal error so the client never hangs "running".
@@ -932,6 +967,8 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
 
     // Handle worker exit
     worker.on('close', (code, signal) => {
+      // S1: free the concurrency slot so a queued request can start. Idempotent.
+      releaseWorkerPermit();
       try {
         console.log('[WS Server] ========== WORKER CLOSE EVENT ==========');
         console.log('[WS Server] Worker PID:', worker.pid);
@@ -976,6 +1013,8 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     });
 
     worker.on('error', (error) => {
+      // S1: on spawn failure 'close' may not fire — release here too (idempotent).
+      releaseWorkerPermit();
       try {
         console.error('[WS Server] ========== WORKER ERROR EVENT ==========');
         console.error('[WS Server] Worker PID:', worker.pid);


### PR DESCRIPTION
First step toward **single 16G/8-core VPS, ~50 concurrent sessions.** Caps simultaneously-active agent workers (each ~150–300 MB); excess chats queue FIFO instead of unbounded spawning (OOM fix).

- `semaphore.js` — small FIFO Semaphore (unit-tested).
- `ws-server.mjs` — `MAX_CONCURRENT_WORKERS` (default 8); acquire before spawn (+ 'queued' frame to client), release exactly once in worker close/error (idempotent).
- `.env.example` — documents the knob.

**Verified (real runtime):** boots clean (logs cap=8, listens, no ReferenceError), `MAX_CONCURRENT_WORKERS=3` honored, `test:unit` 20/20.

Next: S2 per-worker resource caps, S3 idle reaping, S5 capacity bench.