### PR TITLE
docs(env): document MAX_CONCURRENT_WORKERS (S1 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,12 @@ PYTHON_RUNNER_MAX_CODE_BYTES="200000"
 # AGENT_MAX_TURNS="40"
 # AGENT_WALLCLOCK_TIMEOUT_MS="600000"
 
+# S1 — Max concurrently-active agent worker processes (each ~150-300 MB). Extra
+# chat requests queue (FIFO) until a slot frees, instead of spawning unboundedly
+# and risking OOM. Default 8 (tuned for a 16 GB / 8-core host ~ 50 concurrent
+# sessions). Raise on bigger hosts; lower on small ones (e.g. 4 on an 8 GB box).
+# MAX_CONCURRENT_WORKERS="8"
+
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================


### PR DESCRIPTION
PR #48 shipped the S1 worker cap but its .env.example doc edit silently no-op'd. This documents the knob for operators. Docs only.