### PR TITLE
feat(ws): per-worker V8 heap cap (S2, single-host 50-concurrency)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,13 @@ PYTHON_RUNNER_MAX_CODE_BYTES="200000"
 # sessions). Raise on bigger hosts; lower on small ones (e.g. 4 on an 8 GB box).
 # MAX_CONCURRENT_WORKERS="8"
 
+# S2 — Per-worker V8 heap cap, in MB (passed to node as --max-old-space-size).
+# S1 bounds *how many* workers run; S2 bounds *how much* each can grow, so one
+# runaway worker (infinite loop / leak) can't OOM the host. Caps the V8 old-space
+# heap only — process RSS typically runs ~20-30% higher. Default 1536 (8 parallel
+# × 1.5 G stays well under 16 GB with headroom). Set to 0 to disable the cap.
+# WORKER_MAX_OLD_SPACE_MB="1536"
+
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -53,6 +53,20 @@ const MAX_CONCURRENT_WORKERS = Math.max(
 const workerSemaphore = new Semaphore(MAX_CONCURRENT_WORKERS);
 console.log(`[WS Server] Max concurrent workers: ${MAX_CONCURRENT_WORKERS}`);
 
+// S2 — per-worker V8 heap cap. S1 bounds *how many* workers run; S2 bounds *how
+// much* each can grow, so one runaway worker (infinite loop / leak) can't eat the
+// whole 16 GB host. Passed to node as --max-old-space-size (MB). Note this caps
+// the V8 old-space heap only; process RSS typically runs ~20-30% higher. Default
+// 1536 MB (8 parallel × 1.5 G heap stays well under 16 GB with system headroom).
+// Set to 0 to disable the cap (use node's default heap sizing).
+const rawWorkerMaxOldSpaceMb = parseInt(process.env.WORKER_MAX_OLD_SPACE_MB ?? '', 10);
+const WORKER_MAX_OLD_SPACE_MB = Number.isFinite(rawWorkerMaxOldSpaceMb)
+  ? Math.max(0, rawWorkerMaxOldSpaceMb)
+  : 1536;
+console.log(
+  `[WS Server] Worker max old-space: ${WORKER_MAX_OLD_SPACE_MB ? WORKER_MAX_OLD_SPACE_MB + ' MB' : 'unbounded (node default)'}`,
+);
+
 /**
  * Resolve SESSIONS_ROOT with same logic as manager.ts getUserClaudeHome()
  * - If CLAUDE_SESSIONS_ROOT is set, use it
@@ -816,8 +830,12 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     }
     await workerSemaphore.acquire();
 
-    // Spawn worker process with user-specific CLAUDE_HOME
-    const worker = spawn('node', [WORKER_PATH], {
+    // Spawn worker process with user-specific CLAUDE_HOME.
+    // S2 — cap this worker's V8 heap so a runaway one can't OOM the host.
+    const nodeArgs = WORKER_MAX_OLD_SPACE_MB
+      ? [`--max-old-space-size=${WORKER_MAX_OLD_SPACE_MB}`, WORKER_PATH]
+      : [WORKER_PATH];
+    const worker = spawn('node', nodeArgs, {
       env: workerEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
## What
S2 of the single-host concurrency-governance series. Adds a per-worker V8 heap cap so one runaway worker (infinite loop / memory leak) can't OOM the 16 GB host.

- **S1** bounded *how many* workers run concurrently (`MAX_CONCURRENT_WORKERS`).
- **S2** bounds *how much* each worker can grow — complementary.

## Changes
- New `WORKER_MAX_OLD_SPACE_MB` env knob (**default 1536 MB**, confirmed with lead), passed to the worker process as node `--max-old-space-size`.
  - unset / non-numeric → default 1536
  - `0` → cap disabled (node default heap sizing)
- `spawn()` at the worker-launch site conditionally prepends the flag.
- Documented in `.env.example` next to `MAX_CONCURRENT_WORKERS`.
- Complements the Docker backend's existing `EXEC_DOCKER_MEMORY` (this covers the local / node-worker side).

> Note: `--max-old-space-size` caps the V8 old-space heap only; process RSS typically runs ~20-30% higher. With 8 parallel × 1.5 G heap this still stays well under 16 GB with system headroom. Final calibration deferred to S5 load testing.

## Verification (all real)
- `node --check ws-server.mjs` ✅
- `pnpm test:unit` ✅ 20/20
- `WS_PORT=… node ws-server.mjs` boots & listens cleanly:
  - default → logs `Worker max old-space: 1536 MB`
  - `WORKER_MAX_OLD_SPACE_MB=0` → logs `unbounded (node default)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)