### PR TITLE
feat(loadtest): S5 capacity load-test harness (Phase A, local)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ test-advanced-features.log
 test-advanced-features-results.json
 # Intlayer
 .intlayer
+
+# S5 load-test output (local results, never committed)
+loadtest-results/

--- a/docs/project/research/2026-05-s5-capacity-loadtest-design.md
+++ b/docs/project/research/2026-05-s5-capacity-loadtest-design.md
@@ -1,0 +1,82 @@
+# S5 设计:容量压测 + 默认值校准 + 部署文档
+
+> 日期:2026-05-30 · 作者:agent · 状态:**设计稿,待负责人确认后进 Phase A**
+> 目标:S 系列收官。用模拟客户端压测,量内存/延迟/排队曲线,**校准** S1/S2/S3 的默认值
+> (`MAX_CONCURRENT_WORKERS` / `WORKER_MAX_OLD_SPACE_MB` / `WS_IDLE_TIMEOUT_MS`),写进部署文档。
+> 关联:[`2026-05-single-host-50-concurrency.md`](./2026-05-single-host-50-concurrency.md)(S 系列母文档)
+
+## 0. 负责人已确认的决定(影响实施,落档)
+1. **先本地跑通流程**:先在本地 Mac 验证压测工具能跑、能出图。
+   ⚠️ **本地数字不代表生产**(Mac ARM64 ≠ 16G/8核 AMD64);真·校准默认值必须等上代表性真机。
+   本地阶段产出 = 「可复现的压测工具 + 方法学」,不是「生产默认值」。
+2. **LLM 走真实 Ark**(不做 mock stub)。
+   ⚠️ 因此本地验证**刻意压小规模 + 短 prompt + 短输出**,控制 token 花费、避免触发云端限流。
+3. **时序**:S3 已合并(PR #52),现进入 S5。
+4. **压测鉴权**:`auth-setup.mjs` **走 Better Auth 注册 API** 批量造临时测试用户 + 收 cookie
+   (不改运行时鉴权代码、不加测试旁路;最贴近真实链路)。
+
+## 1. 被测系统关键事实(已核实)
+- WS 端点 `ws://host:PORT/ws/agent`;鉴权靠 cookie → `${APP_URL}/api/auth/get-session` 必须返回 `{user:{id}}`。
+- 帧协议(压测客户端据此驱动):
+  - `create_session` → 回 `session_init`(带新 `sessionId`)。
+  - `chat {content, sessionId}` → 流式 `session_metadata` / `message`(首 token)→ `done`(终态);
+    失败 `error`;满载 `queued {position}`;中止 `aborted`。
+  - S3:长期空闲 → `idle_timeout` 帧 + close 4002。
+- 三个待校准旋钮(默认值):`MAX_CONCURRENT_WORKERS=8`、`WORKER_MAX_OLD_SPACE_MB=1536`、`WS_IDLE_TIMEOUT_MS=900000`。
+- worker 每 `chat` 即起即退(per-message),所以「并发执行」由 S1 信号量限到 ≤N。
+
+## 2. Phase A — 压测工具 + 埋点(本地可开发,小 PR)
+产物放 `scripts/loadtest/`(新目录,不碰运行时代码):
+- **`auth-setup.mjs`**:env-gated 批量造临时测试用户 + 收 cookie(走 Better Auth signup API)。
+  仅在显式 `LOADTEST=1` 下可用;绝不进生产路径。**(touches auth/DB,实现前需单独确认范围)**
+- **`load-client.mjs`**:N 个虚拟用户。每个 connect→鉴权→`create_session`→循环{`chat`→等 `done`→think-time}。
+  可配:`USERS`、`RAMP`(爬坡秒)、`THINK_MS`、`PROMPT`(短)、`DURATION`。
+  记录:发出→首 `message`(首 token 延迟)、发出→`done`(完成延迟)、`queued` 等待、错误/断连。
+- **`metrics.mjs`**:每 Ns 采样 server 主进程 RSS + 子 worker 数 + 各 worker RSS(`ps`/`pidusage`);
+  汇总 p50/p95/p99 延迟、吞吐、错误率、峰值内存、最大队列深度;输出 CSV + 简单图(可选)。
+- **`README.md`**:一键跑法 + 各 env 含义 + 「数字仅在真机有校准意义」的醒目提示。
+- 先翻 `references/` 看有无现成压测骨架可借(hermes-agent/deer-flow 有 batch_runner 类工具)。
+
+**本地验收(省钱版)**:`USERS=3 DURATION=60s PROMPT="say hi in 3 words"`——证明工具链通、能出 CSV/图,
+而非压出生产数字。
+
+## 3. Phase B — 真机测试矩阵(等真机,本设计先就位)
+在代表性 16G/8核 AMD64 上(随完整 docker 栈 pg/redis/minio/meili,贴近生产内存预算):
+| 场景 | 目的 | 关注指标 |
+|---|---|---|
+| 基线:50 空闲连接 | 内存地板 | 主进程 RSS |
+| 稳态:50 并发 + 真实 think-time | 校准 `MAX_CONCURRENT_WORKERS ∈ {4,6,8,10,12}` | 峰值 RSS / p95 延迟 / 排队等待 / 错误 |
+| 压力:50 同时发(惊群) | 验排队(S1)+ 背压(S4) | 队列深度 / 缓冲 / 无 OOM |
+| worker 内存:近失控 worker | 验 `WORKER_MAX_OLD_SPACE_MB`(S2)在 cap 处杀而非拖垮整机 | worker 被杀 / 主机存活 |
+| idle 回收 | 验 S3 回收空闲连接、释放槽位/内存 | 连接数/内存回落 |
+
+## 4. Phase C — 校准 + 文档
+- 选默认值:峰值 RSS 压在 ~12–13G 内(给 pg/redis/minio/meili + OS 留余量),同时满足目标 p95 延迟。
+- README/部署文档加「容量与调优」章:实测表 + 按机器规格的推荐 env 值 + 可复现方法。
+- 回填母文档 §5「给用户的承诺」用实测数替换估算。
+
+## 5. 风险 / 边界
+- **真实 Ark 成本/限流**:Phase A 严格压小;Phase B 在真机若用真 Ark,需预算 token 或临时切短输出模型。
+- **本地 ≠ 生产**:所有本地数字在文档里标注「非校准基线」。
+- **auth-setup 触碰认证**:env-gated + 仅测试用户 + 不进生产构建;实现前单独确认。
+- **同机服务争内存**:Phase B 必须带完整栈测,否则内存预算偏乐观。
+
+## 5.5 Phase A 已完成(本地跑通,2026-05-31)
+工具落在 `scripts/loadtest/`:`auth-setup.mjs`(真 Better Auth 注册收 cookie)、
+`metrics.mjs`(**按 WS 端口** lsof 定位服务进程——兼容 standalone `ws-server.mjs` 与
+集成式 `start-production.mjs`;附 RSS 采样 + 延迟分位)、`load-client.mjs`(N 虚拟用户驱动
+create_session→chat→等 done)、`README.md`。结果写 `loadtest-results/`(已 gitignore)。
+
+**本地小规模实跑结论(非校准基线)**:1 用户 / 75s / 短 prompt:7 完成 0 失败;
+完成延迟 p50 ≈ **12s**,首 token p50 ≈ **8s**;peak RSS ≈ 337MB / 1 worker。
+**关键发现**:per-message worker 即起即退 → **每条消息都付一次冷启动**,本地首 token ≈8s;
+Phase B 真机校准要把「冷启动占比」单列(它直接影响用户感知延迟,且与 `MAX_CONCURRENT_WORKERS`
+排队叠加)。
+
+**踩坑记录**:① 集成式部署里 WS 在 `start-production.mjs` 进程内(非独立 `ws-server.mjs`),
+按端口定位才对;② 客户端勿在每个 `session_init` 重启循环(`chat` 自身也会发 `session_init`);
+③ 窗口要给足冷启动(短窗口会把在途请求误判为失败)。
+
+## 6. 待确认
+- [ ] Phase A 是否现在就开工?(尤其 `auth-setup.mjs` 触碰 Better Auth 注册路径,需你点头范围)
+- [ ] 真机什么时候/在哪有?(决定 Phase B 何时能拿到可校准数据)

--- a/scripts/loadtest/README.md
+++ b/scripts/loadtest/README.md
@@ -1,0 +1,60 @@
+# S5 — Capacity load-test harness
+
+Local tooling to drive concurrent `/ws/agent` sessions, measure latency + memory,
+and (on a real host) calibrate the single-host concurrency knobs.
+
+> ⚠️ **Local numbers are NOT a calibration baseline.** A dev Mac (ARM64) is not a
+> 16 GB / 8-core AMD64 VPS. Locally this harness only proves the tooling works
+> and the protocol is driven correctly. Real default-value calibration must run on
+> a representative host with the full stack (see `docs/project/research/2026-05-s5-capacity-loadtest-design.md`).
+
+> ⚠️ **Real LLM cost.** This harness talks to the real model (per the S5 decision —
+> no mock). Keep `USERS` small and `PROMPT` short locally to limit token spend and
+> avoid provider rate limits.
+
+## Files
+- `auth-setup.mjs` — provisions throwaway users via the real Better Auth sign-up
+  endpoint and harvests session cookies (no runtime auth code touched).
+- `metrics.mjs` — samples ws-server main + worker RSS via `ps`; latency percentiles.
+- `load-client.mjs` — orchestrator: N virtual users, drives create_session → chat →
+  await done → think-time; emits a summary + CSVs to `loadtest-results/` (gitignored).
+
+## Prerequisites
+1. The app + ws-server running locally with the full stack (DB etc.), e.g. `./scripts/dev-up.sh`.
+   - App (auth) on `:3000`, WS on `:3001` by default (adjust `APP_URL` / `WS_URL` otherwise).
+2. **Email verification OFF**: `ENABLE_EMAIL_VERIFICATION` unset or `false`, so sign-up
+   returns an active session cookie.
+3. A working model config in `.env` (real Ark).
+
+## Run (small, cheap smoke)
+```bash
+LOADTEST=1 \
+APP_URL=http://localhost:3000 \
+WS_URL=ws://localhost:3001/ws/agent \
+USERS=3 DURATION_MS=60000 THINK_MS=2000 PROMPT="say hi in 3 words" \
+node scripts/loadtest/load-client.mjs
+```
+
+### Knobs (env)
+| Var | Default | Meaning |
+|---|---|---|
+| `USERS` | 3 | concurrent virtual users (= ws connections) |
+| `DURATION_MS` | 60000 | total run length |
+| `THINK_MS` | 2000 | pause between a user's messages |
+| `RAMP_MS` | 0 | stagger between connection starts |
+| `PROMPT` | "say hi in 3 words" | chat content (keep short for cost) |
+| `SAMPLE_MS` | 1000 | memory sampling interval |
+| `OUT_DIR` | loadtest-results | where CSV/JSON land |
+
+## Output
+- `loadtest-results/summary-<ts>.json` — latency p50/p95/p99, throughput, errors,
+  queue depth (S1), idle reaps (S3), **peak RSS** + peak worker count.
+- `loadtest-results/memory-<ts>.csv` — memory/worker-count time series.
+
+## What each scenario validates (Phase B, on a real host)
+- Sweep `MAX_CONCURRENT_WORKERS ∈ {4,6,8,10,12}` → peak RSS vs p95 latency curve.
+- Thundering herd (all send at once) → S1 queueing + S4 backpressure.
+- Runaway worker → S2 `WORKER_MAX_OLD_SPACE_MB` caps it (worker dies, host survives).
+- Idle connections → S3 reaps them, memory/slots recover.
+
+The harness is safe to re-run; test users are reused on subsequent runs.

--- a/scripts/loadtest/auth-setup.mjs
+++ b/scripts/loadtest/auth-setup.mjs
@@ -1,0 +1,110 @@
+/**
+ * S5 load-test auth provisioner.
+ *
+ * Mints throwaway test users via the real Better Auth sign-up endpoint and
+ * harvests their session cookies, so the load client can connect to /ws/agent
+ * through the genuine auth path (ws-server validates the cookie against
+ * ${APP_URL}/api/auth/get-session). No runtime auth code is touched and no
+ * test-only bypass is added.
+ *
+ * Gated behind LOADTEST=1 to make accidental use obvious. Local dev only:
+ * requires email verification to be OFF (ENABLE_EMAIL_VERIFICATION unset/false),
+ * otherwise sign-up won't return an active session.
+ *
+ * Endpoint (Better Auth): POST {appUrl}/api/auth/sign-up/email
+ *   body { email, password, name } -> Set-Cookie: <session cookie(s)>
+ *
+ * Note: Better Auth rate-limits (default ~300 req / 60s window), so provisioning
+ * is throttled; for large N raise the limit or the spacing.
+ */
+
+/** Join all Set-Cookie pairs into a single Cookie header value. */
+function setCookiesToHeader(setCookies) {
+  // setCookies: array of raw "name=value; Path=/; HttpOnly; ..." strings.
+  return setCookies
+    .map((c) => c.split(';')[0].trim()) // keep only name=value
+    .filter(Boolean)
+    .join('; ');
+}
+
+/**
+ * Provision N test users and return their cookies.
+ * @param {object} opts
+ * @param {number} opts.count       Number of users to create.
+ * @param {string} opts.appUrl      Base app URL (e.g. http://localhost:3000).
+ * @param {string} [opts.password]  Shared password for all test users.
+ * @param {string} [opts.tag]       Unique run tag to keep emails distinct.
+ * @param {number} [opts.spacingMs] Delay between sign-ups (rate-limit safety).
+ * @returns {Promise<Array<{email:string, cookie:string}>>}
+ */
+export async function provisionUsers({
+  count,
+  appUrl,
+  password = 'LoadTest!2026',
+  tag = String(Date.now()),
+  spacingMs = 150,
+}) {
+  if (process.env.LOADTEST !== '1') {
+    throw new Error('auth-setup is gated: set LOADTEST=1 to provision test users');
+  }
+  const base = appUrl.replace(/\/+$/, '');
+  const users = [];
+
+  for (let i = 0; i < count; i++) {
+    const email = `loadtest+${tag}-${i}@example.com`;
+    let cookie = '';
+
+    // 1) Try sign-up (fresh user -> active session in its Set-Cookie).
+    let res = await fetch(`${base}/api/auth/sign-up/email`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password, name: `LoadTest ${i}` }),
+    });
+
+    if (res.ok) {
+      cookie = setCookiesToHeader(res.headers.getSetCookie?.() ?? []);
+    } else {
+      // 2) User may already exist from a prior run -> sign in instead.
+      res = await fetch(`${base}/api/auth/sign-in/email`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        cookie = setCookiesToHeader(res.headers.getSetCookie?.() ?? []);
+      } else {
+        const body = await res.text().catch(() => '');
+        throw new Error(
+          `provision user ${i} failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
+        );
+      }
+    }
+
+    if (!cookie) {
+      throw new Error(
+        `provision user ${i}: no Set-Cookie returned — is email verification enabled? ` +
+          `(set ENABLE_EMAIL_VERIFICATION=false for load tests)`,
+      );
+    }
+    users.push({ email, cookie });
+    if (spacingMs > 0 && i < count - 1) {
+      await new Promise((r) => setTimeout(r, spacingMs));
+    }
+  }
+  return users;
+}
+
+// Standalone: `LOADTEST=1 node scripts/loadtest/auth-setup.mjs <count> <appUrl>`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const count = parseInt(process.argv[2] || '3', 10);
+  const appUrl = process.argv[3] || process.env.APP_URL || 'http://localhost:3000';
+  provisionUsers({ count, appUrl })
+    .then((users) => {
+      console.log(`Provisioned ${users.length} users against ${appUrl}:`);
+      for (const u of users) console.log(`  ${u.email}  cookie_len=${u.cookie.length}`);
+    })
+    .catch((err) => {
+      console.error('auth-setup failed:', err.message);
+      process.exit(1);
+    });
+}

--- a/scripts/loadtest/load-client.mjs
+++ b/scripts/loadtest/load-client.mjs
@@ -1,0 +1,229 @@
+/**
+ * S5 load-test orchestrator.
+ *
+ * Spins up N virtual users that each authenticate (via auth-setup), open a real
+ * /ws/agent connection, and loop: create_session -> chat -> await done ->
+ * think-time -> repeat, until DURATION elapses. Meanwhile samples ws-server
+ * memory + worker count. Emits a summary (latency percentiles, throughput,
+ * errors, peak memory, max queue depth) and writes CSVs.
+ *
+ * Drives the verified frame protocol:
+ *   create_session            -> session_init { sessionId }
+ *   chat { content,sessionId } -> session_metadata / message (first token)
+ *                                 -> done  (terminal)  | error | aborted
+ *   (S1) at capacity           -> queued { position }   (then terminal later)
+ *   (S3) long idle             -> idle_timeout + close 4002
+ *
+ * ⚠️ With real Ark, keep USERS small and PROMPT short to limit token cost.
+ * ⚠️ Local numbers only prove the tooling — calibrate defaults on a real host.
+ *
+ * Usage:
+ *   LOADTEST=1 APP_URL=http://localhost:3000 WS_URL=ws://localhost:3001/ws/agent \
+ *   USERS=3 DURATION_MS=60000 THINK_MS=2000 PROMPT="say hi in 3 words" \
+ *   node scripts/loadtest/load-client.mjs
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { WebSocket } from 'ws';
+import { provisionUsers } from './auth-setup.mjs';
+import { findWsServerPids, sampleMemory, summarizeLatencies } from './metrics.mjs';
+
+const CFG = {
+  appUrl: process.env.APP_URL || 'http://localhost:3000',
+  wsUrl: process.env.WS_URL || 'ws://localhost:3001/ws/agent',
+  users: parseInt(process.env.USERS || '3', 10),
+  durationMs: parseInt(process.env.DURATION_MS || '60000', 10),
+  thinkMs: parseInt(process.env.THINK_MS || '2000', 10),
+  rampMs: parseInt(process.env.RAMP_MS || '0', 10), // spread connection starts
+  prompt: process.env.PROMPT || 'say hi in 3 words',
+  sampleMs: parseInt(process.env.SAMPLE_MS || '1000', 10),
+  outDir: process.env.OUT_DIR || path.join('loadtest-results'),
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const now = () => Date.now();
+
+/** Drive one virtual user over a single ws connection until the deadline. */
+function runUser({ cookie, deadline, stats }) {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(CFG.wsUrl, { headers: { cookie } });
+    let sessionId = null;
+    let loopStarted = false; // a `chat` also emits session_init — start loop once
+    let inflight = null; // { startedAt, firstTokenAt, resolve }
+
+    const finishInflight = (outcome) => {
+      if (!inflight) return;
+      const end = now();
+      if (outcome === 'done') {
+        stats.completionLatencies.push(end - inflight.startedAt);
+        if (inflight.firstTokenAt) {
+          stats.firstTokenLatencies.push(inflight.firstTokenAt - inflight.startedAt);
+        }
+        stats.completed++;
+      } else {
+        stats.errors++;
+      }
+      const r = inflight.resolve;
+      inflight = null;
+      r();
+    };
+
+    const sendChatAndWait = () =>
+      new Promise((res) => {
+        inflight = { startedAt: now(), firstTokenAt: null, resolve: res };
+        ws.send(JSON.stringify({ type: 'chat', content: CFG.prompt, sessionId }));
+      });
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify({ type: 'create_session' }));
+    });
+
+    ws.on('message', async (data) => {
+      let msg;
+      try { msg = JSON.parse(data.toString()); } catch { return; }
+      stats.frameCounts[msg.type] = (stats.frameCounts[msg.type] || 0) + 1;
+      // Capture the first error payload to surface why requests fail.
+      if (msg.type === 'error' && !stats.firstErrorFrame) {
+        stats.firstErrorFrame = JSON.stringify(msg).slice(0, 300);
+      }
+      switch (msg.type) {
+        case 'session_init':
+          sessionId = msg.sessionId || sessionId;
+          // A `chat` also emits session_init (on SDK init) — only the first one
+          // (from create_session) should kick off the loop, else loops overlap.
+          if (loopStarted) break;
+          loopStarted = true;
+          // begin the chat loop
+          (async () => {
+            while (now() < deadline && ws.readyState === ws.OPEN) {
+              await sendChatAndWait();
+              if (now() >= deadline) break;
+              await sleep(CFG.thinkMs);
+            }
+            try { ws.close(1000, 'done'); } catch { /* noop */ }
+          })();
+          break;
+        case 'queued':
+          stats.queuedEvents++;
+          stats.maxQueueDepth = Math.max(stats.maxQueueDepth, msg.position || 0);
+          break;
+        case 'message':
+        case 'session_metadata':
+          if (inflight && !inflight.firstTokenAt) inflight.firstTokenAt = now();
+          break;
+        case 'done':
+          finishInflight('done');
+          break;
+        case 'error':
+          finishInflight('error');
+          break;
+        case 'aborted':
+          finishInflight('error');
+          break;
+        case 'idle_timeout':
+          stats.idleReaped++;
+          break;
+        default:
+          break; // pong, messages_loaded, etc.
+      }
+    });
+
+    ws.on('close', () => { finishInflight('error'); resolve(); });
+    ws.on('error', (err) => { stats.connErrors++; stats.lastConnError = err.message; finishInflight('error'); });
+  });
+}
+
+async function main() {
+  if (process.env.LOADTEST !== '1') {
+    console.error('Refusing to run: set LOADTEST=1 (provisions throwaway users + drives load).');
+    process.exit(1);
+  }
+  console.log('[loadtest] config:', JSON.stringify(CFG, null, 0));
+
+  // 1) Provision users via real Better Auth sign-up.
+  console.log(`[loadtest] provisioning ${CFG.users} users against ${CFG.appUrl} ...`);
+  const users = await provisionUsers({ count: CFG.users, appUrl: CFG.appUrl });
+  console.log(`[loadtest] provisioned ${users.length} users.`);
+
+  // 2) Start memory sampler — detect the WS server by who listens on the WS port
+  // (works for standalone ws-server.mjs and integrated start-production.mjs).
+  let wsPort = null;
+  try { wsPort = Number(new URL(CFG.wsUrl).port) || null; } catch { /* noop */ }
+  const mainPids = await findWsServerPids({ port: wsPort });
+  console.log(`[loadtest] WS server PIDs (port ${wsPort}): ${mainPids.join(',') || '(none found — memory sampling off)'}`);
+  const memSamples = [];
+  let peakTotalKb = 0;
+  let peakWorkers = 0;
+  const startedAt = now();
+  const sampler = setInterval(async () => {
+    if (!mainPids.length) return;
+    const m = await sampleMemory(mainPids);
+    memSamples.push({ t: now() - startedAt, ...m });
+    peakTotalKb = Math.max(peakTotalKb, m.totalKb);
+    peakWorkers = Math.max(peakWorkers, m.workerCount);
+  }, CFG.sampleMs);
+
+  // 3) Run virtual users (optionally ramped).
+  const deadline = now() + CFG.durationMs;
+  const stats = {
+    completed: 0, errors: 0, connErrors: 0, queuedEvents: 0, maxQueueDepth: 0,
+    idleReaped: 0, lastConnError: '', frameCounts: {}, firstErrorFrame: '',
+    completionLatencies: [], firstTokenLatencies: [],
+  };
+  const runners = [];
+  for (let i = 0; i < users.length; i++) {
+    runners.push(runUser({ cookie: users[i].cookie, deadline, stats }));
+    if (CFG.rampMs > 0 && i < users.length - 1) await sleep(CFG.rampMs);
+  }
+  await Promise.all(runners);
+  clearInterval(sampler);
+
+  // 4) Summarize.
+  const wallMs = now() - startedAt;
+  const comp = summarizeLatencies(stats.completionLatencies);
+  const ftt = summarizeLatencies(stats.firstTokenLatencies);
+  const throughput = (stats.completed / (wallMs / 1000)).toFixed(2);
+
+  const summary = {
+    config: CFG,
+    wall_seconds: +(wallMs / 1000).toFixed(1),
+    requests_completed: stats.completed,
+    requests_failed: stats.errors,
+    conn_errors: stats.connErrors,
+    last_conn_error: stats.lastConnError,
+    throughput_req_per_s: +throughput,
+    queued_events: stats.queuedEvents,
+    max_queue_depth: stats.maxQueueDepth,
+    idle_reaped: stats.idleReaped,
+    frame_counts: stats.frameCounts,
+    first_error_frame: stats.firstErrorFrame,
+    completion_latency_ms: comp,
+    first_token_latency_ms: ftt,
+    peak_total_rss_mb: +(peakTotalKb / 1024).toFixed(1),
+    peak_worker_count: peakWorkers,
+    mem_samples: memSamples.length,
+  };
+
+  console.log('\n[loadtest] ===== SUMMARY =====');
+  console.log(JSON.stringify(summary, null, 2));
+
+  // 5) Write CSVs.
+  await mkdir(CFG.outDir, { recursive: true });
+  const stamp = `${startedAt}`;
+  await writeFile(
+    path.join(CFG.outDir, `summary-${stamp}.json`),
+    JSON.stringify(summary, null, 2),
+  );
+  const memCsv = ['t_ms,main_kb,worker_kb,total_kb,worker_count']
+    .concat(memSamples.map((s) => `${s.t},${s.mainKb},${s.workerKb},${s.totalKb},${s.workerCount}`))
+    .join('\n');
+  await writeFile(path.join(CFG.outDir, `memory-${stamp}.csv`), memCsv);
+  console.log(`[loadtest] wrote results to ${CFG.outDir}/ (summary-${stamp}.json, memory-${stamp}.csv)`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[loadtest] fatal:', err.stack || err.message);
+  process.exit(1);
+});

--- a/scripts/loadtest/metrics.mjs
+++ b/scripts/loadtest/metrics.mjs
@@ -1,0 +1,122 @@
+/**
+ * S5 load-test metrics helpers: server memory sampling + latency aggregation.
+ *
+ * Memory: samples the ws-server main process RSS plus its child workers (the
+ * per-message agent subprocesses S1 bounds), so we can watch peak memory vs
+ * concurrency. Uses `ps` (portable on macOS + Linux) — no extra deps.
+ *
+ * The point of the whole S5 exercise is to plot peak RSS / latency against
+ * MAX_CONCURRENT_WORKERS so the defaults can be calibrated on a real 16G/8-core
+ * host. Locally these numbers only prove the tooling works (Mac ARM != prod).
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Find the server PID(s) that actually handle the WS traffic. We detect by
+ * *who listens on the WS port* (via lsof), which is topology-agnostic: it works
+ * whether the WS server is standalone (`node ws-server.mjs`) or integrated into
+ * the app process (`start-production.mjs` serving both HTTP + WS). This avoids
+ * matching stray `ws-server.mjs` test processes by command line.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.port]  WS port to resolve the listener for (preferred).
+ * @returns {Promise<number[]>}
+ */
+export async function findWsServerPids(opts = {}) {
+  // Explicit override wins (e.g. WS_SERVER_PID for unusual setups).
+  if (process.env.WS_SERVER_PID) {
+    return process.env.WS_SERVER_PID.split(',').map((s) => parseInt(s.trim(), 10)).filter(Boolean);
+  }
+  const port = opts.port;
+  if (port) {
+    try {
+      const { stdout } = await execFileAsync('lsof', [
+        '-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t',
+      ]);
+      const pids = stdout.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean);
+      if (pids.length) return [...new Set(pids)];
+    } catch {
+      /* fall through to command-line match */
+    }
+  }
+  // Fallback: standalone ws-server.mjs by command line.
+  try {
+    const { stdout } = await execFileAsync('pgrep', ['-f', 'ws-server.mjs']);
+    return stdout.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean);
+  } catch {
+    return []; // pgrep exits non-zero when nothing matches
+  }
+}
+
+/** RSS (KB) for a set of pids via `ps`; returns total KB and per-pid map. */
+async function rssForPids(pids) {
+  if (!pids.length) return { totalKb: 0, perPid: {} };
+  try {
+    const { stdout } = await execFileAsync('ps', ['-o', 'pid=,rss=', '-p', pids.join(',')]);
+    const perPid = {};
+    let totalKb = 0;
+    for (const line of stdout.split('\n')) {
+      const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+      if (m) {
+        const kb = parseInt(m[2], 10);
+        perPid[m[1]] = kb;
+        totalKb += kb;
+      }
+    }
+    return { totalKb, perPid };
+  } catch {
+    return { totalKb: 0, perPid: {} };
+  }
+}
+
+/** Child PIDs of a parent (one level) via `pgrep -P`. */
+async function childPids(parentPid) {
+  try {
+    const { stdout } = await execFileAsync('pgrep', ['-P', String(parentPid)]);
+    return stdout.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * One memory sample: ws-server main + its worker children.
+ * @param {number[]} mainPids  ws-server main PIDs (from findWsServerPids()).
+ */
+export async function sampleMemory(mainPids) {
+  const allChildren = [];
+  for (const pid of mainPids) allChildren.push(...(await childPids(pid)));
+  const main = await rssForPids(mainPids);
+  const workers = await rssForPids(allChildren);
+  return {
+    mainKb: main.totalKb,
+    workerKb: workers.totalKb,
+    totalKb: main.totalKb + workers.totalKb,
+    workerCount: Object.keys(workers.perPid).length,
+  };
+}
+
+/** Percentile (nearest-rank) of a numeric array. */
+export function percentile(arr, p) {
+  if (!arr.length) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+/** Summarize an array of latencies (ms) into p50/p95/p99/max/avg. */
+export function summarizeLatencies(arr) {
+  if (!arr.length) return { count: 0, p50: 0, p95: 0, p99: 0, max: 0, avg: 0 };
+  const sum = arr.reduce((a, b) => a + b, 0);
+  return {
+    count: arr.length,
+    p50: percentile(arr, 50),
+    p95: percentile(arr, 95),
+    p99: percentile(arr, 99),
+    max: Math.max(...arr),
+    avg: Math.round(sum / arr.length),
+  };
+}


### PR DESCRIPTION
## What
**S5 Phase A** — local tooling to drive concurrent `/ws/agent` sessions and measure latency + memory, so the single-host concurrency knobs (S1 `MAX_CONCURRENT_WORKERS`, S2 `WORKER_MAX_OLD_SPACE_MB`, S3 `WS_IDLE_TIMEOUT_MS`) can be **calibrated on a real host** (Phase B).

**No runtime code touched** — only `scripts/loadtest/` + docs + `.gitignore`.

## Files
- `scripts/loadtest/auth-setup.mjs` — provisions throwaway users via the **real Better Auth sign-up** endpoint and harvests session cookies (`LOADTEST=1` gated; no auth bypass added).
- `scripts/loadtest/metrics.mjs` — locates the WS server by **who listens on the WS port** (works for standalone `ws-server.mjs` *and* integrated `start-production.mjs`); samples main + worker RSS via `ps`; latency percentiles.
- `scripts/loadtest/load-client.mjs` — N virtual users drive `create_session → chat → await done → think-time`; emits summary (latency p50/p95/p99, throughput, queue depth, idle reaps, peak RSS, worker count, frame tally) + CSV/JSON to `loadtest-results/` (gitignored).
- `scripts/loadtest/README.md` + design note `docs/project/research/2026-05-s5-capacity-loadtest-design.md`.

## Decisions recorded (from lead)
- **Local-first** — local numbers are **NOT** a calibration baseline (Mac ARM ≠ 16G/8-core AMD64); they only prove the tooling.
- **Real Ark** (no mock) — keep `USERS` small + `PROMPT` short to limit token cost.
- **Auth via real Better Auth sign-up** (no runtime bypass).

## Verification (local, small, real Ark)
- 1 user / 75s / short prompt → **7 completed, 0 failed**; completion p50 ~12s, first-token p50 ~8s; peak RSS ~337 MB / 1 worker; CSV/JSON written.
- Port-based detection found the **real integrated server**, not stray test procs.
- `pnpm test:unit` still **26/26** (harness adds no runtime code).

### Key finding (for Phase B calibration)
Per-message worker (spawn-per-message) pays **cold start on every message** (~8s first token locally). Phase B should isolate cold-start share — it compounds with S1 queueing on user-perceived latency.

## Not in this PR (Phase B/C)
Running the matrix on a representative 16G/8-core host (sweep `MAX_CONCURRENT_WORKERS`, thundering herd, runaway-worker, idle-reap) and writing calibrated defaults to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)