### PR TITLE
feat(billing): token metering + quota mechanism, OFF by default (P2-3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,16 @@ VITE_POLAR_PRODUCT_CREDITS_100="prod_..."
 VITE_POLAR_PRODUCT_PRO_MONTHLY="prod_..."
 VITE_POLAR_PRODUCT_BUSINESS_MONTHLY="prod_..."
 
+# --- P2-3 token metering (OFF by default) ---------------------------------
+# Charge credits per run based on token usage. Keep DISABLED until real P2-1
+# usage data is collected AND the owner confirms the rate (¥200/mo ≈ N tokens).
+# See src/config/credit-rates.ts and docs/project/research/2026-05-billing-design.md.
+# BILLING_METERING_ENABLED="false"
+# Global token→credit rate (1 credit ≈ N tokens). Placeholder default: 10000.
+# CREDIT_TOKENS_PER_CREDIT="10000"
+# Per-model override (suffix with the model name):
+# CREDIT_TOKENS_PER_CREDIT__ark-code-latest="20000"
+
 # =============================================================================
 # OBSERVABILITY / SENTRY
 # =============================================================================

--- a/src/config/credit-rates.ts
+++ b/src/config/credit-rates.ts
@@ -1,0 +1,89 @@
+/**
+ * Credit conversion rates + metering flag (P2-3).
+ *
+ * ⚠️ THE RATES BELOW ARE PLACEHOLDERS — they are NOT calibrated.
+ *
+ * Do NOT enable metering until:
+ *   1. P2-1 has accumulated real usage data, and
+ *   2. the owner confirms the budget mapping (¥200/month ≈ how many tokens),
+ * then back-solve `tokensPerCredit` from that data.
+ *
+ * Rationale (docs/project/research/2026-05-billing-design.md §3):
+ *  - Metering basis is TOKEN COUNT (real), not the SDK's USD estimate.
+ *  - A credit is primarily a FAIR-USE quota unit, not exact cost pass-through.
+ *  - The rate is config (env-overridable) so price changes don't need a release.
+ *
+ * Metering is OFF by default. Flip BILLING_METERING_ENABLED=true only after the
+ * above gate is cleared.
+ */
+
+// Placeholder: 1 credit ≈ this many tokens. Intentionally round and uncalibrated.
+const DEFAULT_TOKENS_PER_CREDIT = 10_000;
+
+/**
+ * Per-model token→credit rate. Resolution order:
+ *   1. env CREDIT_TOKENS_PER_CREDIT__<model>  (e.g. CREDIT_TOKENS_PER_CREDIT__ark-code-latest=20000)
+ *   2. env CREDIT_TOKENS_PER_CREDIT          (global override)
+ *   3. DEFAULT_TOKENS_PER_CREDIT             (placeholder)
+ * A non-positive/invalid value falls through to the next source.
+ */
+export function tokensPerCreditFor(model: string, env: NodeJS.ProcessEnv = process.env): number {
+  const perModelKey = `CREDIT_TOKENS_PER_CREDIT__${model}`;
+  const candidates = [env[perModelKey], env.CREDIT_TOKENS_PER_CREDIT];
+  for (const raw of candidates) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return DEFAULT_TOKENS_PER_CREDIT;
+}
+
+/** Whether token→credit metering/charging is active. Default false. */
+export function isMeteringEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.BILLING_METERING_ENABLED === 'true';
+}
+
+export type ModelUsageTokens = {
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+const tokensOf = (mu: ModelUsageTokens | undefined): number => {
+  const i = Number(mu?.inputTokens);
+  const o = Number(mu?.outputTokens);
+  return (Number.isFinite(i) ? i : 0) + (Number.isFinite(o) ? o : 0);
+};
+
+/**
+ * Credits for a single-model run: ceil(tokens / rate), minimum 1.
+ */
+export function creditsForTokens(
+  tokens: number,
+  model = 'unknown',
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const rate = tokensPerCreditFor(model, env);
+  const t = Number.isFinite(tokens) && tokens > 0 ? tokens : 0;
+  return Math.max(1, Math.ceil(t / rate));
+}
+
+/**
+ * Credits for a multi-model run. Each model's tokens are divided by ITS rate,
+ * the fractional results are summed, then ceil'd once (minimum 1) — this avoids
+ * over-charging tiny sub-agent calls that a per-model `min 1` would inflate.
+ * Falls back to a single 'unknown' bucket when modelUsage is empty.
+ */
+export function creditsForModelUsage(
+  modelUsage: Record<string, ModelUsageTokens> | null | undefined,
+  fallbackTokens = 0,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const entries = Object.entries(modelUsage ?? {});
+  if (entries.length === 0) {
+    return creditsForTokens(fallbackTokens, 'unknown', env);
+  }
+  let credits = 0;
+  for (const [model, mu] of entries) {
+    credits += tokensOf(mu) / tokensPerCreditFor(model, env);
+  }
+  return Math.max(1, Math.ceil(credits));
+}

--- a/src/routes/api/usage/index.ts
+++ b/src/routes/api/usage/index.ts
@@ -1,14 +1,17 @@
 /**
- * Usage API (P2-1, observation-only)
+ * Usage API (P2-1 observation + P2-3 metering)
  *
- * POST /api/usage - Record per-run token/turn/cost usage (internal use by WS server).
+ * POST /api/usage - Record per-run token/turn/cost usage (internal use by WS server)
+ * and, when metering is enabled, charge the corresponding credits.
  *
  * The WS server forwards the SDK `result` event's usage data here after each run.
  * One run may use multiple models (modelUsage); we insert one row per model, all
- * sharing a generated runId. This does NOT charge credits — metering is P2-3.
+ * sharing a generated runId.
  *
- * See docs/project/research/2026-05-billing-design.md for why costUsd is stored
- * for internal reference only and is NOT a billing basis.
+ * Metering (P2-3) is OFF by default and gated behind BILLING_METERING_ENABLED.
+ * The conversion rate is an uncalibrated placeholder until real P2-1 data + owner
+ * sign-off — see src/config/credit-rates.ts and
+ * docs/project/research/2026-05-billing-design.md.
  */
 
 import { createFileRoute } from '@tanstack/react-router';
@@ -17,6 +20,12 @@ import { db } from '~/db/db-config';
 import { usageRecord } from '~/db/schema';
 import { requireUser } from '~/server/require-user';
 import { buildUsageRows, type UsageBody } from '~/server/usage/build-usage-rows';
+import { creditsForModelUsage, isMeteringEnabled } from '~/config/credit-rates';
+import { spendCredits, InsufficientCreditsError } from '~/server/credits';
+
+type Metering =
+  | { enabled: false }
+  | { enabled: true; credits: number; charged: boolean; insufficient?: boolean };
 
 export const Route = createFileRoute('/api/usage/')({
   server: {
@@ -30,7 +39,26 @@ export const Route = createFileRoute('/api/usage/')({
 
         await db.insert(usageRecord).values(rows);
 
-        return Response.json({ recorded: rows.length, runId });
+        // P2-3: charge credits for this run when metering is enabled. Recording
+        // always happens above; charging is additive and flag-gated.
+        let metering: Metering = { enabled: false };
+        if (isMeteringEnabled()) {
+          const fallbackTokens =
+            (Number(body.usage?.input_tokens) || 0) + (Number(body.usage?.output_tokens) || 0);
+          const credits = creditsForModelUsage(body.modelUsage, fallbackTokens);
+          try {
+            await spendCredits(user.id, credits, { runId, kind: 'run_usage' });
+            metering = { enabled: true, credits, charged: true };
+          } catch (error) {
+            if (error instanceof InsufficientCreditsError) {
+              metering = { enabled: true, credits, charged: false, insufficient: true };
+            } else {
+              throw error;
+            }
+          }
+        }
+
+        return Response.json({ recorded: rows.length, runId, metering });
       },
     },
   },

--- a/src/server/credits.ts
+++ b/src/server/credits.ts
@@ -43,7 +43,34 @@ export async function ensureDailyRefill(userId: string, client: QueryClient = db
   }
 }
 
-export async function spendOneCredit(userId: string) {
+/** Thrown by spendCredits when the user lacks enough credits to cover the spend. */
+export class InsufficientCreditsError extends Error {
+  constructor(
+    public readonly requested: number,
+    public readonly available: number,
+  ) {
+    super(`Insufficient credits: requested ${requested}, available ${available}`);
+    this.name = 'InsufficientCreditsError';
+  }
+}
+
+/**
+ * Spend `amount` credits for a user (allotment first, then purchased extras).
+ *
+ * Throws InsufficientCreditsError if the combined balance can't cover `amount`
+ * (atomic: nothing is deducted in that case). `meta` is attached to the ledger
+ * row (e.g. usage breakdown). spendOneCredit is the n=1 special case.
+ */
+export async function spendCredits(
+  userId: string,
+  amount: number,
+  meta?: Record<string, unknown>,
+) {
+  const n = Math.trunc(amount);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`spendCredits: amount must be a positive integer (got ${amount})`);
+  }
+
   return db.transaction(async (tx) => {
     await ensureDailyRefill(userId, tx);
 
@@ -55,22 +82,39 @@ export async function spendOneCredit(userId: string) {
 
     if (!balance) throw new Error('No credit balance');
 
+    const fromAllotment = Math.min(n, Math.max(0, balance.monthlyAllotment - balance.allotmentUsed));
+    const fromExtra = n - fromAllotment;
+
+    if (fromExtra > balance.extraCredits) {
+      const available = Math.max(0, balance.monthlyAllotment - balance.allotmentUsed) + balance.extraCredits;
+      throw new InsufficientCreditsError(n, available);
+    }
+
     const now = new Date();
-    if (balance.allotmentUsed < balance.monthlyAllotment) {
+    if (fromAllotment > 0) {
       await tx
         .update(creditBalances)
-        .set({ allotmentUsed: sql`${creditBalances.allotmentUsed} + 1`, updatedAt: now })
+        .set({ allotmentUsed: sql`${creditBalances.allotmentUsed} + ${fromAllotment}`, updatedAt: now })
         .where(eq(creditBalances.userId, userId));
-    } else {
-      if (balance.extraCredits <= 0) throw new Error('No credits left');
+    }
+    if (fromExtra > 0) {
       await tx
         .update(creditBalances)
-        .set({ extraCredits: sql`${creditBalances.extraCredits} - 1`, updatedAt: now })
+        .set({ extraCredits: sql`${creditBalances.extraCredits} - ${fromExtra}`, updatedAt: now })
         .where(eq(creditBalances.userId, userId));
     }
 
-    await tx.insert(creditLedger).values({ userId, delta: -1, kind: 'usage' });
+    await tx.insert(creditLedger).values({
+      userId,
+      delta: -n,
+      kind: 'usage',
+      ...(meta ? { meta } : {}),
+    });
   });
+}
+
+export async function spendOneCredit(userId: string) {
+  return spendCredits(userId, 1);
 }
 
 export async function addPurchasedCredits(userId: string, amount: number, sourceId?: string) {

--- a/tests/unit/credit-rates.test.ts
+++ b/tests/unit/credit-rates.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for P2-3 credit-rate math + the metering flag.
+ *
+ * Rates are uncalibrated placeholders; these tests pin the *formula*, not any
+ * particular price. The default placeholder rate is 10_000 tokens/credit.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  creditsForTokens,
+  creditsForModelUsage,
+  tokensPerCreditFor,
+  isMeteringEnabled,
+} from '~/config/credit-rates';
+
+describe('isMeteringEnabled', () => {
+  it('is OFF by default and only true for the exact "true" string', () => {
+    expect(isMeteringEnabled({})).toBe(false);
+    expect(isMeteringEnabled({ BILLING_METERING_ENABLED: 'false' })).toBe(false);
+    expect(isMeteringEnabled({ BILLING_METERING_ENABLED: '1' })).toBe(false);
+    expect(isMeteringEnabled({ BILLING_METERING_ENABLED: 'true' })).toBe(true);
+  });
+});
+
+describe('tokensPerCreditFor', () => {
+  it('uses the placeholder default when no env override', () => {
+    expect(tokensPerCreditFor('ark-code-latest', {})).toBe(10_000);
+  });
+  it('prefers a per-model override over the global override', () => {
+    const env = {
+      CREDIT_TOKENS_PER_CREDIT: '5000',
+      'CREDIT_TOKENS_PER_CREDIT__ark-code-latest': '20000',
+    } as NodeJS.ProcessEnv;
+    expect(tokensPerCreditFor('ark-code-latest', env)).toBe(20_000);
+    expect(tokensPerCreditFor('other-model', env)).toBe(5000);
+  });
+  it('ignores invalid/non-positive values and falls through', () => {
+    expect(tokensPerCreditFor('m', { CREDIT_TOKENS_PER_CREDIT: '0' })).toBe(10_000);
+    expect(tokensPerCreditFor('m', { CREDIT_TOKENS_PER_CREDIT: 'abc' })).toBe(10_000);
+  });
+});
+
+describe('creditsForTokens', () => {
+  it('is ceil(tokens / rate) with a floor of 1', () => {
+    expect(creditsForTokens(0, 'm', {})).toBe(1); // min 1
+    expect(creditsForTokens(1, 'm', {})).toBe(1);
+    expect(creditsForTokens(10_000, 'm', {})).toBe(1);
+    expect(creditsForTokens(10_001, 'm', {})).toBe(2);
+    expect(creditsForTokens(25_000, 'm', {})).toBe(3);
+  });
+});
+
+describe('creditsForModelUsage', () => {
+  it('sums per-model fractional credits then ceils once (min 1)', () => {
+    // real Ark run: 14071 + 1480 = 15551 tokens at 10k rate -> ceil(1.5551) = 2
+    const credits = creditsForModelUsage(
+      {
+        'claude-haiku-4-5-20251001': { inputTokens: 1378, outputTokens: 102 },
+        'ark-code-latest': { inputTokens: 14067, outputTokens: 4 },
+      },
+      0,
+      {},
+    );
+    expect(credits).toBe(2);
+  });
+
+  it('honours per-model rates when summing', () => {
+    const env = {
+      'CREDIT_TOKENS_PER_CREDIT__cheap': '100000',
+      'CREDIT_TOKENS_PER_CREDIT__pricey': '1000',
+    } as NodeJS.ProcessEnv;
+    // cheap: 50000/100000 = 0.5 ; pricey: 2000/1000 = 2 ; sum 2.5 -> ceil 3
+    const credits = creditsForModelUsage(
+      {
+        cheap: { inputTokens: 50000, outputTokens: 0 },
+        pricey: { inputTokens: 2000, outputTokens: 0 },
+      },
+      0,
+      env,
+    );
+    expect(credits).toBe(3);
+  });
+
+  it('falls back to top-level tokens when modelUsage is empty', () => {
+    expect(creditsForModelUsage({}, 25_000, {})).toBe(3);
+    expect(creditsForModelUsage(null, 0, {})).toBe(1);
+  });
+});

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -315,25 +315,28 @@ async function persistSession(cookie, workspaceSessionId, realSdkSessionId, clau
 }
 
 /**
- * P2-1: Record per-run usage (observation-only, does NOT charge credits).
+ * P2-1/P2-3: Record per-run usage and (when metering is enabled) charge credits.
  *
  * Extracts token/turn/cost data from the SDK `result` event and posts it to
  * /api/usage. Fire-and-forget — usage logging must never block or break a run.
  *
- * @param {string} cookie - Auth cookie for the run's user
- * @param {string} workspaceSessionId - Our workspace session id
+ * P2-3: when metering is enabled server-side, the response reports whether the
+ * run was charged; if the user is out of credits we forward a non-fatal warning
+ * frame to the client (metering is OFF by default, so this is normally dormant).
+ *
+ * @param {object} ws - The client WebSocket (provides cookie + workspaceSessionId)
  * @param {object} event - The SDK `result` event
  */
-async function recordUsage(cookie, workspaceSessionId, event) {
+async function recordUsage(ws, event) {
   try {
     const response = await fetch(`${APP_URL}/api/usage`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        cookie,
+        cookie: ws.cookie,
       },
       body: JSON.stringify({
-        sessionId: workspaceSessionId ?? null,
+        sessionId: ws.workspaceSessionId ?? null,
         usage: event.usage ?? null,
         numTurns: event.num_turns ?? 0,
         totalCostUsd: event.total_cost_usd ?? 0,
@@ -350,6 +353,16 @@ async function recordUsage(cookie, workspaceSessionId, event) {
 
     const result = await response.json();
     console.log(`[WS Server] Usage recorded: run ${result.runId} (${result.recorded} model rows)`);
+
+    // P2-3: metering is gated server-side; warn the client when out of credits.
+    if (result.metering?.enabled && result.metering.insufficient) {
+      sendMessage(ws, {
+        type: 'credit_warning',
+        code: 'insufficient_credits',
+        credits: result.metering.credits,
+        message: 'You are out of credits — this run was not charged. Top up to continue.',
+      });
+    }
   } catch (error) {
     console.error('[WS Server] Error recording usage:', error);
   }
@@ -1055,7 +1068,7 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
           // P2-1: record per-run usage on the terminal `result` event. Fire-and-
           // forget; applies to silent runs too (they still consume tokens).
           if (event.type === 'result') {
-            recordUsage(ws.cookie, ws.workspaceSessionId, event);
+            recordUsage(ws, event);
           }
           if (!silentInit) {
             applyBackpressure(sendMessage(ws, { type: 'message', event }));


### PR DESCRIPTION
## What & why (P2-3)

Wire token→credit metering. The **mechanism is complete and tested, but charging is OFF by default** behind `BILLING_METERING_ENABLED`, using an **uncalibrated placeholder rate**. Per the plan (§4) the rate must be back-solved from real P2-1 data and **confirmed by the owner** before enabling — "不要拍脑袋定，用数据反推". Plan: `docs/project/PHASE2-PLAN.md`; rationale: `docs/project/research/2026-05-billing-design.md`.

## Changes
- `src/config/credit-rates.ts`: `tokensPerCreditFor` (env-overridable per-model + global; placeholder 10k), `creditsForTokens` / `creditsForModelUsage` (`ceil(Σ tokens_m / rate_m)`, min 1), `isMeteringEnabled` (default false).
- `src/server/credits.ts`: **`spendCredits(userId, n, meta?)`** — allotment first then purchased extras, atomic, throws `InsufficientCreditsError` (nothing deducted) when short. `spendOneCredit` now delegates to it.
- `POST /api/usage`: after recording, when metering is on, charge credits and report `{metering:{enabled,credits,charged,insufficient?}}`. **Recording is unchanged when metering is off.**
- `ws-server.mjs`: `recordUsage(ws, event)` forwards a non-fatal `credit_warning` frame to the client when a run couldn't be charged.
- `.env.example`: documents the flag + rate overrides.

## Owner action required before enabling
1. Collect 1–2 weeks of P2-1 usage. 2. Confirm ¥200/mo ≈ N tokens budget. 3. Set `CREDIT_TOKENS_PER_CREDIT*` from that data. 4. Flip `BILLING_METERING_ENABLED=true`.

## Verification
- ✅ Rate math: 8 unit tests.
- ✅ `spendCredits` exercised against the local DB: allotment→extra split, **atomic insufficient** (balance + ledger untouched), `spendOneCredit` delegation, ledger -7/-5/-1.
- ✅ `test:unit` 42/42; ws-server boots clean; oxlint + tsc clean on new/changed files. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)