### PR TITLE
feat(p3): Wave 0 + Wave 1 — design language redo + agent workbench (Todo / Sub-agents)

### DIFF
--- a/docs/project/wave0-design/preview.html
+++ b/docs/project/wave0-design/preview.html
@@ -1,0 +1,348 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OxyGenie · Phase 3 · Wave 0 风格方向预览 (A 暖 / B 冷)</title>
+<style>
+/* ============================================================
+   这是 Wave 0 的设计预览 — 完全独立，不依赖项目代码、不碰 app.css。
+   每个 board 用一组 CSS 变量模拟未来 app.css 的 token 值。
+   两个方向：A = 暖雾奶油 (Coze-leaning) / B = 晨雾克制 (Cowork-leaning)
+   每个方向各出 亮 + 暗 两版。
+   ============================================================ */
+
+/* ---------- 方向 A · 暖雾奶油 · 亮 ---------- */
+.A.light{
+  --bg: oklch(0.992 0.008 80);
+  --surface: oklch(1 0 0);
+  --fg: oklch(0.26 0.02 60);
+  --fg-muted: oklch(0.52 0.02 60);
+  --primary: oklch(0.62 0.14 48);
+  --primary-fg: oklch(0.99 0.01 80);
+  --accent-soft: oklch(0.95 0.035 62);
+  --muted: oklch(0.955 0.008 70);
+  --border: oklch(0.905 0.01 70);
+  --ring: oklch(0.62 0.14 48);
+  --ok: oklch(0.62 0.13 150);
+  --warn: oklch(0.75 0.14 70);
+  --danger: oklch(0.60 0.20 28);
+  --radius: 20px;
+  --radius-sm: 12px;
+  --shadow: 0 4px 18px -6px rgba(120,72,36,.16), 0 1px 3px -1px rgba(120,72,36,.10);
+  --shadow-sm: 0 1px 2px rgba(120,72,36,.08);
+  --font: "Inter","PingFang SC","Microsoft YaHei",system-ui,sans-serif;
+  --font-serif: "Source Serif 4",Georgia,"Songti SC",serif;
+}
+/* ---------- 方向 A · 暖雾奶油 · 暗 ---------- */
+.A.dark{
+  --bg: oklch(0.205 0.012 60);
+  --surface: oklch(0.245 0.014 60);
+  --fg: oklch(0.93 0.012 70);
+  --fg-muted: oklch(0.70 0.015 65);
+  --primary: oklch(0.72 0.13 52);
+  --primary-fg: oklch(0.20 0.02 60);
+  --accent-soft: oklch(0.30 0.04 55);
+  --muted: oklch(0.28 0.012 60);
+  --border: oklch(0.34 0.012 60);
+  --ring: oklch(0.72 0.13 52);
+  --ok: oklch(0.72 0.12 150);
+  --warn: oklch(0.80 0.13 72);
+  --danger: oklch(0.68 0.17 28);
+  --radius: 20px;
+  --radius-sm: 12px;
+  --shadow: 0 6px 22px -8px rgba(0,0,0,.55);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4);
+  --font: "Inter","PingFang SC","Microsoft YaHei",system-ui,sans-serif;
+  --font-serif: "Source Serif 4",Georgia,"Songti SC",serif;
+}
+/* ---------- 方向 B · 晨雾克制 · 亮 ---------- */
+.B.light{
+  --bg: oklch(0.990 0.003 240);
+  --surface: oklch(1 0 0);
+  --fg: oklch(0.23 0.014 250);
+  --fg-muted: oklch(0.50 0.015 250);
+  --primary: oklch(0.55 0.10 250);
+  --primary-fg: oklch(0.99 0.005 250);
+  --accent-soft: oklch(0.955 0.018 250);
+  --muted: oklch(0.962 0.005 250);
+  --border: oklch(0.908 0.006 250);
+  --ring: oklch(0.55 0.10 250);
+  --ok: oklch(0.58 0.11 160);
+  --warn: oklch(0.74 0.12 75);
+  --danger: oklch(0.58 0.18 25);
+  --radius: 14px;
+  --radius-sm: 9px;
+  --shadow: 0 2px 10px -3px rgba(28,40,64,.12), 0 1px 2px -1px rgba(28,40,64,.08);
+  --shadow-sm: 0 1px 2px rgba(28,40,64,.07);
+  --font: "Inter","PingFang SC","Microsoft YaHei",system-ui,sans-serif;
+  --font-serif: "Source Serif 4",Georgia,"Songti SC",serif;
+}
+/* ---------- 方向 B · 晨雾克制 · 暗 ---------- */
+.B.dark{
+  --bg: oklch(0.175 0.012 250);
+  --surface: oklch(0.215 0.014 250);
+  --fg: oklch(0.93 0.008 250);
+  --fg-muted: oklch(0.68 0.012 250);
+  --primary: oklch(0.66 0.11 250);
+  --primary-fg: oklch(0.16 0.02 250);
+  --accent-soft: oklch(0.27 0.03 250);
+  --muted: oklch(0.25 0.012 250);
+  --border: oklch(0.31 0.012 250);
+  --ring: oklch(0.66 0.11 250);
+  --ok: oklch(0.68 0.10 160);
+  --warn: oklch(0.78 0.12 75);
+  --danger: oklch(0.66 0.16 25);
+  --radius: 14px;
+  --radius-sm: 9px;
+  --shadow: 0 4px 16px -6px rgba(0,0,0,.55);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,.4);
+  --font: "Inter","PingFang SC","Microsoft YaHei",system-ui,sans-serif;
+  --font-serif: "Source Serif 4",Georgia,"Songti SC",serif;
+}
+
+/* ============================================================
+   页面骨架 + 组件（消费上面的 token 变量）
+   ============================================================ */
+*{box-sizing:border-box}
+html,body{margin:0;background:#e9eaee;font-family:"Inter","PingFang SC",system-ui,sans-serif;color:#1c2024}
+.page{max-width:1320px;margin:0 auto;padding:28px 24px 64px}
+.page>h1{font-size:20px;margin:0 0 4px}
+.page>p.sub{margin:0 0 22px;color:#5b6068;font-size:13px}
+
+.board{margin:0 0 30px;border-radius:18px;overflow:hidden;border:1px solid #d8dade;box-shadow:0 8px 30px -12px rgba(0,0,0,.18)}
+.board-head{display:flex;align-items:center;gap:10px;padding:10px 16px;background:#fff;border-bottom:1px solid #e3e5e9;font-size:13px;font-weight:600}
+.board-head .tag{font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px}
+.tag.warm{background:#fbe7d8;color:#a3521f}
+.tag.cool{background:#e1e8f7;color:#3a5aa6}
+.tag.mode{background:#eceef2;color:#5b6068}
+.board-head .desc{font-weight:400;color:#6b7078}
+
+.app{display:flex;background:var(--bg);color:var(--fg);font-family:var(--font);height:560px}
+
+/* ---- 色板条 ---- */
+.swatches{display:flex;flex-wrap:wrap;gap:8px;padding:12px 16px;background:var(--bg);border-bottom:1px solid var(--border)}
+.sw{display:flex;flex-direction:column;gap:4px;align-items:center;font-size:9.5px;color:var(--fg-muted);width:74px}
+.sw .chip{width:100%;height:30px;border-radius:8px;border:1px solid var(--border)}
+.sw code{font-size:8.5px;color:var(--fg-muted);opacity:.8}
+.meta-row{display:flex;gap:18px;padding:8px 16px;background:var(--bg);border-bottom:1px solid var(--border);font-size:10.5px;color:var(--fg-muted)}
+.meta-row b{color:var(--fg)}
+.dot{display:inline-block;width:10px;height:10px;border-radius:3px;vertical-align:-1px;margin-right:4px}
+
+/* ---- 左：图标导航 + 会话列表 ---- */
+.nav{width:60px;flex:0 0 60px;background:var(--surface);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;padding:14px 0;gap:14px}
+.icon3d{width:38px;height:38px;border-radius:12px;border:1.5px dashed var(--border);display:flex;align-items:center;justify-content:center;font-size:8px;color:var(--fg-muted);background:linear-gradient(160deg,var(--accent-soft),transparent)}
+.icon3d.active{border-style:solid;border-color:var(--primary);color:var(--primary);background:var(--accent-soft)}
+.nav .spacer{flex:1}
+.nav .avatar{width:34px;height:34px;border-radius:50%;background:var(--primary);color:var(--primary-fg);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:13px}
+
+.sessions{width:230px;flex:0 0 230px;background:var(--bg);border-right:1px solid var(--border);display:flex;flex-direction:column}
+.sessions .s-head{padding:14px 16px 8px;display:flex;align-items:center;justify-content:space-between}
+.sessions .s-head .title{font-weight:700;font-size:15px}
+.newbtn{background:var(--primary);color:var(--primary-fg);border:none;border-radius:999px;padding:6px 12px;font-size:11px;font-weight:600;cursor:default}
+.s-search{margin:0 16px 10px;background:var(--muted);border:1px solid var(--border);border-radius:10px;padding:7px 10px;font-size:11px;color:var(--fg-muted)}
+.s-list{padding:0 10px;display:flex;flex-direction:column;gap:4px;overflow:hidden}
+.s-item{display:flex;gap:9px;padding:9px 10px;border-radius:12px;align-items:flex-start}
+.s-item.active{background:var(--accent-soft)}
+.s-item .ic{width:30px;height:30px;border-radius:9px;flex:0 0 30px;border:1.5px dashed var(--border);display:flex;align-items:center;justify-content:center;font-size:7px;color:var(--fg-muted);background:linear-gradient(160deg,var(--accent-soft),transparent)}
+.s-item.active .ic{border-style:solid;border-color:var(--primary);color:var(--primary)}
+.s-item .tx{min-width:0;flex:1}
+.s-item .tx .l1{font-size:12.5px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.s-item .tx .l2{font-size:10.5px;color:var(--fg-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px}
+
+/* ---- 中：对话流 ---- */
+.chat{flex:1;display:flex;flex-direction:column;min-width:0;background:var(--bg)}
+.chat-head{padding:14px 22px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px}
+.chat-head .agentface{width:30px;height:30px;border-radius:10px;border:1.5px dashed var(--border);display:flex;align-items:center;justify-content:center;font-size:7px;color:var(--fg-muted);background:linear-gradient(160deg,var(--accent-soft),transparent)}
+.chat-head h2{font-family:var(--font-serif);font-size:16px;margin:0;font-weight:600}
+.chat-head .status{font-size:10.5px;color:var(--ok);margin-left:auto;display:flex;align-items:center;gap:5px}
+.chat-head .status::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--ok)}
+.stream{flex:1;padding:22px 26px;display:flex;flex-direction:column;gap:18px;overflow:hidden}
+.msg{max-width:78%;font-size:13px;line-height:1.6}
+.msg.user{align-self:flex-end;background:var(--accent-soft);padding:11px 15px;border-radius:var(--radius);border-bottom-right-radius:6px}
+.msg.bot{align-self:flex-start;color:var(--fg)}
+.msg.bot .who{font-size:10.5px;color:var(--fg-muted);margin-bottom:5px;font-weight:600}
+/* 工具调用 = 可展开卡片 */
+.toolcard{align-self:flex-start;width:78%;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);box-shadow:var(--shadow-sm);overflow:hidden}
+.toolcard .tc-head{display:flex;align-items:center;gap:8px;padding:9px 12px;font-size:11.5px}
+.toolcard .tc-head .chev{color:var(--fg-muted)}
+.toolcard .tc-head .nm{font-weight:600;font-family:var(--font)}
+.toolcard .tc-head .badge{font-size:9.5px;padding:1px 7px;border-radius:999px;background:var(--accent-soft);color:var(--primary);font-weight:600}
+.toolcard .tc-head .ms{margin-left:auto;font-size:10px;color:var(--fg-muted)}
+.toolcard .tc-body{border-top:1px solid var(--border);padding:9px 12px;font-family:"SF Mono",ui-monospace,monospace;font-size:10.5px;color:var(--fg-muted);background:var(--muted)}
+/* 底部输入框 = 焦点 */
+.composer{margin:14px 26px 22px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);padding:12px 14px}
+.composer .ci{font-size:13px;color:var(--fg-muted);min-height:30px}
+.composer .crow{display:flex;align-items:center;gap:8px;margin-top:10px}
+.pill{border:1px solid var(--border);border-radius:999px;padding:5px 11px;font-size:10.5px;color:var(--fg-muted);display:flex;align-items:center;gap:5px;background:var(--bg)}
+.pill.plus{font-size:14px;padding:4px 10px}
+.modeswitch{display:flex;border:1px solid var(--border);border-radius:999px;overflow:hidden;font-size:10.5px}
+.modeswitch span{padding:5px 11px;color:var(--fg-muted)}
+.modeswitch span.on{background:var(--primary);color:var(--primary-fg);font-weight:600}
+.composer .credits{margin-left:auto;font-size:10px;color:var(--fg-muted)}
+.sendbtn{background:var(--primary);color:var(--primary-fg);border:none;border-radius:999px;width:32px;height:32px;font-size:14px;display:flex;align-items:center;justify-content:center}
+
+/* ---- 右：常驻工作台 ---- */
+.work{width:312px;flex:0 0 312px;background:var(--surface);border-left:1px solid var(--border);display:flex;flex-direction:column}
+.work .tabs{display:flex;gap:2px;padding:10px 12px 0;border-bottom:1px solid var(--border)}
+.work .tabs .t{font-size:11px;padding:7px 10px;color:var(--fg-muted);border-bottom:2px solid transparent;display:flex;gap:5px;align-items:center}
+.work .tabs .t.on{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+.work .wbody{padding:14px;overflow:hidden;flex:1}
+.wsec-title{font-size:10.5px;text-transform:uppercase;letter-spacing:.08em;color:var(--fg-muted);margin:0 0 10px;font-weight:700}
+/* Progress / Todo */
+.todo{display:flex;flex-direction:column;gap:9px}
+.todo .ti{display:flex;gap:9px;align-items:flex-start;font-size:12px}
+.todo .ck{width:16px;height:16px;border-radius:5px;border:1.5px solid var(--border);flex:0 0 16px;margin-top:1px}
+.todo .ti.done .ck{background:var(--ok);border-color:var(--ok);position:relative}
+.todo .ti.done .ck::after{content:"✓";color:#fff;font-size:11px;position:absolute;left:2.5px;top:-1px}
+.todo .ti.done .lbl{color:var(--fg-muted);text-decoration:line-through}
+.todo .ti.now .ck{border-color:var(--primary)}
+.todo .ti.now .lbl{font-weight:600}
+.todo .ti .lbl{line-height:1.4}
+.progbar{height:6px;border-radius:999px;background:var(--muted);margin:14px 0 4px;overflow:hidden}
+.progbar i{display:block;height:100%;width:60%;background:var(--primary)}
+.progcap{font-size:10px;color:var(--fg-muted)}
+/* Sub-agents tree */
+.tree{font-size:12px;display:flex;flex-direction:column;gap:7px;margin-top:4px}
+.tree .node{display:flex;gap:8px;align-items:center}
+.tree .node .ic{width:22px;height:22px;border-radius:7px;border:1.5px dashed var(--border);flex:0 0 22px;display:flex;align-items:center;justify-content:center;font-size:6px;color:var(--fg-muted)}
+.tree .child{margin-left:16px;padding-left:12px;border-left:1.5px solid var(--border);display:flex;flex-direction:column;gap:7px}
+.tree .node .nm{font-weight:600}
+.tree .node .st{margin-left:auto;font-size:9.5px;color:var(--ok)}
+.tree .node .st.run{color:var(--warn)}
+/* Context */
+.ctx{display:flex;flex-direction:column;gap:12px}
+.ctx .card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);padding:11px 12px}
+.ctx .card .k{font-size:10px;color:var(--fg-muted)}
+.ctx .card .v{font-size:18px;font-weight:700;margin-top:2px}
+.ctx .card .v small{font-size:11px;font-weight:500;color:var(--fg-muted)}
+.usagebar{height:6px;border-radius:999px;background:var(--muted);margin-top:8px;overflow:hidden}
+.usagebar i{display:block;height:100%;width:38%;background:var(--primary)}
+</style>
+</head>
+<body>
+<div class="page">
+  <h1>OxyGenie · Phase 3 · Wave 0 风格方向预览</h1>
+  <p class="sub">同一个三栏工作台布局，两套 design token。A=暖雾奶油（Coze 暖玩具感）/ B=晨雾克制（Cowork 专业可观测）。每方向亮+暗各一版。虚线圆角方块=3D 拟物图标的预留槽位（素材到位后替换）。</p>
+
+  <!-- 用脚本生成 4 个 board，避免重复 HTML -->
+  <div id="mount"></div>
+</div>
+
+<script>
+const SW_KEYS = [
+  ['--bg','background'],['--surface','card'],['--fg','foreground'],['--primary','primary'],
+  ['--accent-soft','accent'],['--muted','muted'],['--border','border'],['--danger','destructive']
+];
+
+function boardMarkup(){return `
+  <div class="meta-row">
+    <span><span class="dot" style="background:var(--primary)"></span><b>圆角</b> var(--radius)</span>
+    <span><b>字体</b> Inter / PingFang（标题可衬线）</span>
+    <span><b>阴影</b> 柔和扩散</span>
+    <span><b>密度</b> 对话低 · 工作台中高</span>
+  </div>
+  <div class="swatches">
+    ${SW_KEYS.map(([v,n])=>`<div class="sw"><div class="chip" style="background:var(${v})"></div><span>${n}</span></div>`).join('')}
+  </div>
+  <div class="app">
+    <!-- 左：图标导航 -->
+    <div class="nav">
+      <div class="icon3d active">3D<br>chat</div>
+      <div class="icon3d">3D<br>skill</div>
+      <div class="icon3d">3D<br>files</div>
+      <div class="icon3d">3D<br>kb</div>
+      <div class="spacer"></div>
+      <div class="avatar">P</div>
+    </div>
+    <!-- 左：会话列表 -->
+    <div class="sessions">
+      <div class="s-head"><span class="title">会话</span><button class="newbtn">+ 新建</button></div>
+      <div class="s-search">🔍 搜索会话…</div>
+      <div class="s-list">
+        <div class="s-item active"><div class="ic">3D</div><div class="tx"><div class="l1">数据清洗与图表生成</div><div class="l2">已生成 result.csv · 2 分钟前</div></div></div>
+        <div class="s-item"><div class="ic">3D</div><div class="tx"><div class="l1">爬取竞品定价</div><div class="l2">等待审批 1 个工具调用</div></div></div>
+        <div class="s-item"><div class="ic">3D</div><div class="tx"><div class="l1">周报草稿</div><div class="l2">昨天</div></div></div>
+        <div class="s-item"><div class="ic">3D</div><div class="tx"><div class="l1">PDF 摘要</div><div class="l2">5月28日</div></div></div>
+      </div>
+    </div>
+    <!-- 中：对话流 -->
+    <div class="chat">
+      <div class="chat-head">
+        <div class="agentface">3D</div>
+        <h2>Genie 工作台</h2>
+        <div class="status">在线 · Act 模式</div>
+      </div>
+      <div class="stream">
+        <div class="msg user">帮我把 data.csv 清洗后算出每个品类的均价，画成柱状图。</div>
+        <div class="msg bot"><div class="who">Genie</div>好的，我先读取文件、清洗缺失值，再按品类聚合并绘图。</div>
+        <div class="toolcard">
+          <div class="tc-head"><span class="chev">▾</span><span class="nm">python · 运行脚本</span><span class="badge">成功</span><span class="ms">1.8s</span></div>
+          <div class="tc-body">df = pd.read_csv("data.csv").dropna()<br>g = df.groupby("category")["price"].mean()<br># → 写出 chart.png</div>
+        </div>
+        <div class="msg bot"><div class="who">Genie</div>已生成 <b>chart.png</b> 与 <b>summary.csv</b>，结果在右侧 Files 面板。</div>
+      </div>
+      <div class="composer">
+        <div class="ci">继续提问，或拖入文件…</div>
+        <div class="crow">
+          <span class="pill plus">＋</span>
+          <div class="modeswitch"><span>Ask</span><span class="on">Act</span></div>
+          <span class="pill">模型 Auto ▾</span>
+          <span class="credits">本月已用 1,240 / 5,000 积分</span>
+          <button class="sendbtn">↑</button>
+        </div>
+      </div>
+    </div>
+    <!-- 右：常驻工作台 -->
+    <div class="work">
+      <div class="tabs">
+        <div class="t on">◷ Progress</div>
+        <div class="t">⌥ Sub-agents</div>
+        <div class="t">⎘ Files</div>
+        <div class="t">◧ Context</div>
+      </div>
+      <div class="wbody">
+        <p class="wsec-title">当前任务 · Todo</p>
+        <div class="todo">
+          <div class="ti done"><span class="ck"></span><span class="lbl">读取并校验 data.csv</span></div>
+          <div class="ti done"><span class="ck"></span><span class="lbl">清洗缺失值与异常行</span></div>
+          <div class="ti now"><span class="ck"></span><span class="lbl">按品类聚合计算均价</span></div>
+          <div class="ti"><span class="ck"></span><span class="lbl">绘制柱状图并导出 PNG</span></div>
+          <div class="ti"><span class="ck"></span><span class="lbl">汇总写出 summary.csv</span></div>
+        </div>
+        <div class="progbar"><i></i></div>
+        <div class="progcap">3 / 5 已完成</div>
+
+        <p class="wsec-title" style="margin-top:20px">子 Agent</p>
+        <div class="tree">
+          <div class="node"><div class="ic">3D</div><span class="nm">主任务</span><span class="st run">运行中</span></div>
+          <div class="child">
+            <div class="node"><div class="ic">3D</div><span class="nm">data-cleaner</span><span class="st">完成</span></div>
+            <div class="node"><div class="ic">3D</div><span class="nm">chart-maker</span><span class="st run">运行中</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>`;
+}
+
+const defs = [
+  {cls:'A light', tag:'warm', tagtx:'A · 暖雾奶油', mode:'亮 Light', desc:'Coze-leaning · 奶油暖白 + 杏陶土品牌色 + 大圆角 + 柔暖阴影'},
+  {cls:'A dark',  tag:'warm', tagtx:'A · 暖雾奶油', mode:'暗 Dark',  desc:'暖炭底（非纯黑），保持温度'},
+  {cls:'B light', tag:'cool', tagtx:'B · 晨雾克制', mode:'亮 Light', desc:'Cowork-leaning · 近纸白冷中性 + 收敛靛蓝 + 发丝边框 + 轻阴影'},
+  {cls:'B dark',  tag:'cool', tagtx:'B · 晨雾克制', mode:'暗 Dark',  desc:'冷石板底，专业可观测'},
+];
+const ONLY = parseInt(localStorage.getItem('b')||'-1',10);
+const shown = (ONLY>=0 && ONLY<defs.length) ? [defs[ONLY]] : defs;
+document.getElementById('mount').innerHTML = shown.map(d=>`
+  <div class="board ${d.cls}">
+    <div class="board-head">
+      <span class="tag ${d.tag}">${d.tagtx}</span>
+      <span class="tag mode">${d.mode}</span>
+      <span class="desc">${d.desc}</span>
+    </div>
+    ${boardMarkup()}
+  </div>`).join('');
+</script>
+</body>
+</html>

--- a/src/components/claude-chat/workbench-panel.tsx
+++ b/src/components/claude-chat/workbench-panel.tsx
@@ -20,8 +20,9 @@
  */
 
 import { useState, type FC, type ReactNode } from 'react';
-import { ListChecks, GitBranch, FolderOpen, Gauge } from 'lucide-react';
+import { ListChecks, GitBranch, FolderOpen, Gauge, Check, Loader2 } from 'lucide-react';
 import { cn } from '~/lib/utils';
+import { useSessionTodos, type TodoItem } from '~/lib/hooks/use-session-workbench';
 
 type WorkbenchTab = 'progress' | 'subagents' | 'files' | 'context';
 
@@ -67,6 +68,69 @@ const EmptyState: FC<{ title: string; hint: string; children?: ReactNode }> = ({
   </div>
 );
 
+/** ① Progress — live TodoWrite checklist (Cowork-style). */
+const TodoRow: FC<{ item: TodoItem }> = ({ item }) => {
+  const done = item.status === 'completed';
+  const running = item.status === 'in_progress';
+  return (
+    <li className="flex items-start gap-2.5 text-sm">
+      <span
+        className={cn(
+          'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[5px] border',
+          done && 'border-primary bg-primary text-primary-foreground',
+          running && 'border-primary text-primary',
+          !done && !running && 'border-border',
+        )}
+        aria-hidden
+      >
+        {done && <Check className="h-3 w-3" strokeWidth={3} />}
+        {running && <Loader2 className="h-3 w-3 animate-spin" />}
+      </span>
+      <span
+        className={cn(
+          'leading-snug',
+          done && 'text-muted-foreground line-through',
+          running && 'font-medium text-foreground',
+          !done && !running && 'text-foreground',
+        )}
+      >
+        {running && item.activeForm ? item.activeForm : item.content}
+      </span>
+    </li>
+  );
+};
+
+const TodoList: FC<{
+  todos: TodoItem[];
+  total: number;
+  completed: number;
+}> = ({ todos, total, completed }) => {
+  const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+  return (
+    <div className="flex h-full flex-col">
+      <p className="px-4 pt-4 pb-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Current plan · Todo
+      </p>
+      <ul className="flex flex-col gap-2.5 px-4">
+        {todos.map((item, i) => (
+          <TodoRow key={`${i}-${item.content}`} item={item} />
+        ))}
+      </ul>
+      <div className="mt-auto px-4 pb-4 pt-4">
+        <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <p className="mt-1.5 text-[10px] text-muted-foreground">
+          {completed} / {total} completed
+        </p>
+      </div>
+    </div>
+  );
+};
+
 export interface WorkbenchPanelProps {
   currentSessionId: string | null;
   className?: string;
@@ -74,6 +138,7 @@ export interface WorkbenchPanelProps {
 
 export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, className }) => {
   const [activeTab, setActiveTab] = useState<WorkbenchTab>('progress');
+  const todoSummary = useSessionTodos();
 
   return (
     <aside
@@ -107,12 +172,19 @@ export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, clas
 
       {/* Section body — Wave 0 empty states */}
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {activeTab === 'progress' && (
-          <EmptyState
-            title="No active plan"
-            hint="The agent's TodoWrite plan will appear here, with steps checked off live as the task runs."
-          />
-        )}
+        {activeTab === 'progress' &&
+          (todoSummary ? (
+            <TodoList
+              todos={todoSummary.todos}
+              total={todoSummary.total}
+              completed={todoSummary.completed}
+            />
+          ) : (
+            <EmptyState
+              title="No active plan"
+              hint="The agent's TodoWrite plan will appear here, with steps checked off live as the task runs."
+            />
+          ))}
         {activeTab === 'subagents' && (
           <EmptyState
             title="No sub-agents yet"

--- a/src/components/claude-chat/workbench-panel.tsx
+++ b/src/components/claude-chat/workbench-panel.tsx
@@ -22,7 +22,12 @@
 import { useState, type FC, type ReactNode } from 'react';
 import { ListChecks, GitBranch, FolderOpen, Gauge, Check, Loader2 } from 'lucide-react';
 import { cn } from '~/lib/utils';
-import { useSessionTodos, type TodoItem } from '~/lib/hooks/use-session-workbench';
+import {
+  useSessionTodos,
+  useSessionSubAgents,
+  type TodoItem,
+  type SubAgentItem,
+} from '~/lib/hooks/use-session-workbench';
 
 type WorkbenchTab = 'progress' | 'subagents' | 'files' | 'context';
 
@@ -131,6 +136,51 @@ const TodoList: FC<{
   );
 };
 
+/** ② Sub-agents — flat list of Task delegations with live status. */
+const SubAgentRow: FC<{ item: SubAgentItem }> = ({ item }) => {
+  const statusColor =
+    item.status === 'completed'
+      ? 'text-primary'
+      : item.status === 'error'
+        ? 'text-destructive'
+        : 'text-muted-foreground';
+  const statusLabel =
+    item.status === 'completed' ? 'Done' : item.status === 'error' ? 'Failed' : 'Running';
+  return (
+    <li className="flex items-start gap-2.5 rounded-lg border border-border bg-background px-3 py-2.5">
+      <IconSlot className="mt-0.5 h-7 w-7 shrink-0 rounded-lg text-[8px]" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-xs font-semibold text-foreground">
+            {item.subagentType ?? 'agent'}
+          </span>
+          <span className={cn('ml-auto flex items-center gap-1 text-[10px]', statusColor)}>
+            {item.status === 'running' && <Loader2 className="h-3 w-3 animate-spin" />}
+            {item.status === 'completed' && <Check className="h-3 w-3" strokeWidth={3} />}
+            {statusLabel}
+          </span>
+        </div>
+        <p className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-muted-foreground">
+          {item.description}
+        </p>
+      </div>
+    </li>
+  );
+};
+
+const SubAgentList: FC<{ subAgents: SubAgentItem[] }> = ({ subAgents }) => (
+  <div className="flex h-full flex-col">
+    <p className="px-4 pt-4 pb-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      Sub-agents · {subAgents.length}
+    </p>
+    <ul className="flex flex-col gap-2 px-4 pb-4">
+      {subAgents.map((item) => (
+        <SubAgentRow key={item.id} item={item} />
+      ))}
+    </ul>
+  </div>
+);
+
 export interface WorkbenchPanelProps {
   currentSessionId: string | null;
   className?: string;
@@ -139,6 +189,7 @@ export interface WorkbenchPanelProps {
 export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, className }) => {
   const [activeTab, setActiveTab] = useState<WorkbenchTab>('progress');
   const todoSummary = useSessionTodos();
+  const subAgents = useSessionSubAgents();
 
   return (
     <aside
@@ -185,12 +236,15 @@ export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, clas
               hint="The agent's TodoWrite plan will appear here, with steps checked off live as the task runs."
             />
           ))}
-        {activeTab === 'subagents' && (
-          <EmptyState
-            title="No sub-agents yet"
-            hint="When the agent spawns sub-agents, they'll show here as a nested tree with live status."
-          />
-        )}
+        {activeTab === 'subagents' &&
+          (subAgents.length > 0 ? (
+            <SubAgentList subAgents={subAgents} />
+          ) : (
+            <EmptyState
+              title="No sub-agents yet"
+              hint="When the agent delegates work via the Task tool, each sub-agent shows here with live status."
+            />
+          ))}
         {activeTab === 'files' && (
           <EmptyState
             title="No files yet"

--- a/src/components/claude-chat/workbench-panel.tsx
+++ b/src/components/claude-chat/workbench-panel.tsx
@@ -1,0 +1,148 @@
+/**
+ * WorkbenchPanel — Phase 3 Wave 0 skeleton (right-side resident workbench).
+ *
+ * The "agent workbench" rail that turns the chat from a chat-box into a
+ * workbench: switchable sections (Progress / Sub-agents / Files / Context).
+ *
+ * Wave 0 scope: STRUCTURE ONLY. Every section renders an empty state with a
+ * placeholder 3D-icon slot. No data wiring yet — each section is filled in a
+ * later wave:
+ *   · Progress    → ① TodoWrite live checklist          (Wave 1)
+ *   · Sub-agents  → ② nested tree via parent_tool_use_id (Wave 1)
+ *   · Files       → existing session-files / artifacts    (Wave 1)
+ *   · Context     → ⑤ memory + Phase 2 usage_record       (Wave 2/3)
+ *
+ * Multi-tenant boundary: takes `currentSessionId` so future data reads are
+ * scoped per session (and, server-side, per user). Holds no cross-session state.
+ *
+ * i18n: labels are intentionally hardcoded (English) for the skeleton; they get
+ * moved into intlayer content when the sections are actually wired up.
+ */
+
+import { useState, type FC, type ReactNode } from 'react';
+import { ListChecks, GitBranch, FolderOpen, Gauge } from 'lucide-react';
+import { cn } from '~/lib/utils';
+
+type WorkbenchTab = 'progress' | 'subagents' | 'files' | 'context';
+
+interface TabDef {
+  id: WorkbenchTab;
+  label: string;
+  icon: typeof ListChecks;
+}
+
+const TABS: TabDef[] = [
+  { id: 'progress', label: 'Progress', icon: ListChecks },
+  { id: 'subagents', label: 'Sub-agents', icon: GitBranch },
+  { id: 'files', label: 'Files', icon: FolderOpen },
+  { id: 'context', label: 'Context', icon: Gauge },
+];
+
+/** Placeholder slot for the owner-supplied 3D skeuomorphic icons (Wave 0). */
+const IconSlot: FC<{ className?: string }> = ({ className }) => (
+  <div
+    className={cn(
+      'flex items-center justify-center rounded-xl border border-dashed border-border',
+      'bg-gradient-to-b from-accent/60 to-transparent text-[9px] font-medium text-muted-foreground',
+      className,
+    )}
+    aria-hidden
+  >
+    3D
+  </div>
+);
+
+const EmptyState: FC<{ title: string; hint: string; children?: ReactNode }> = ({
+  title,
+  hint,
+  children,
+}) => (
+  <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+    <IconSlot className="h-12 w-12" />
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p>
+    </div>
+    {children}
+  </div>
+);
+
+export interface WorkbenchPanelProps {
+  currentSessionId: string | null;
+  className?: string;
+}
+
+export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, className }) => {
+  const [activeTab, setActiveTab] = useState<WorkbenchTab>('progress');
+
+  return (
+    <aside
+      className={cn('flex h-full w-full flex-col bg-card', className)}
+      aria-label="Agent workbench"
+    >
+      {/* Tab switcher */}
+      <div className="flex items-center gap-1 border-b border-border px-2 pt-2">
+        {TABS.map(({ id, label, icon: Icon }) => {
+          const active = id === activeTab;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => setActiveTab(id)}
+              aria-pressed={active}
+              className={cn(
+                'flex items-center gap-1.5 rounded-t-md px-2.5 py-2 text-xs font-medium transition-colors',
+                'border-b-2 -mb-px',
+                active
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              <span>{label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Section body — Wave 0 empty states */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {activeTab === 'progress' && (
+          <EmptyState
+            title="No active plan"
+            hint="The agent's TodoWrite plan will appear here, with steps checked off live as the task runs."
+          />
+        )}
+        {activeTab === 'subagents' && (
+          <EmptyState
+            title="No sub-agents yet"
+            hint="When the agent spawns sub-agents, they'll show here as a nested tree with live status."
+          />
+        )}
+        {activeTab === 'files' && (
+          <EmptyState
+            title="No files yet"
+            hint="Files and artifacts produced in this session's workspace will be listed here."
+          />
+        )}
+        {activeTab === 'context' && (
+          <EmptyState
+            title="Context & usage"
+            hint="Session memory, connectors, and this month's token usage will surface here."
+          />
+        )}
+      </div>
+
+      {/* Session-scope footer marker (skeleton — confirms per-session boundary) */}
+      <div className="border-t border-border px-3 py-2 text-[10px] text-muted-foreground">
+        {currentSessionId ? (
+          <span>Session · {currentSessionId.slice(0, 8)}</span>
+        ) : (
+          <span>No active session</span>
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default WorkbenchPanel;

--- a/src/lib/hooks/use-session-workbench.ts
+++ b/src/lib/hooks/use-session-workbench.ts
@@ -82,3 +82,59 @@ export function useSessionTodos(): TodoSummary | null {
     };
   }, [messages]);
 }
+
+// ───────────────────────── ② Sub-agents ─────────────────────────
+
+export type SubAgentStatus = 'running' | 'completed' | 'error';
+
+export interface SubAgentItem {
+  id: string;
+  /** Claude Code Task tool's subagent_type, when provided. */
+  subagentType?: string;
+  /** Human description / intent of the delegated work. */
+  description: string;
+  status: SubAgentStatus;
+}
+
+function readString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Sub-agent invocations in the current session, in call order. Each Claude Code
+ * `Task` tool-call is one delegated sub-agent. Flat list (Wave 1); a nested tree
+ * of the sub-agent's own child tool calls needs the adapter to persist
+ * parent_tool_use_id onto tool-call parts (follow-up).
+ */
+export function selectSubAgents(messages: ThreadMessage[]): SubAgentItem[] {
+  const out: SubAgentItem[] = [];
+  for (const message of messages) {
+    for (const part of message.content) {
+      if (part.type !== 'tool-call' || part.toolName?.toLowerCase() !== 'task') continue;
+      const args = (part.args ?? {}) as Record<string, unknown>;
+      // Error wins over any other status — never show a failed delegation as "Done".
+      const status: SubAgentStatus =
+        part.toolStatus === 'error' || part.isError
+          ? 'error'
+          : part.toolStatus === 'completed'
+            ? 'completed'
+            : 'running';
+      out.push({
+        id: part.toolCallId,
+        subagentType: readString(args.subagent_type),
+        description:
+          readString(args.description) ??
+          readString(part.intent) ??
+          readString((args as { _intent?: unknown })._intent) ??
+          'Sub-agent task',
+        status,
+      });
+    }
+  }
+  return out;
+}
+
+export function useSessionSubAgents(): SubAgentItem[] {
+  const messages = useChatSessionStore((s) => s.messages);
+  return useMemo(() => selectSubAgents(messages), [messages]);
+}

--- a/src/lib/hooks/use-session-workbench.ts
+++ b/src/lib/hooks/use-session-workbench.ts
@@ -1,0 +1,84 @@
+/**
+ * Workbench selectors — Phase 3 Wave 1.
+ *
+ * Derives the right-side workbench's live data from the chat session store.
+ * The store only ever holds the CURRENT session's messages (it is replaced on
+ * session switch), so everything here is inherently scoped to the active
+ * session — no cross-session bleed. Server-side user scoping is enforced when
+ * messages are loaded; this layer adds no new data access.
+ */
+
+import { useMemo } from 'react';
+import { useChatSessionStore, type ThreadMessage } from '~/lib/chat-session-store';
+
+export type TodoStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface TodoItem {
+  content: string;
+  status: TodoStatus;
+  /** Present-tense form Claude Code emits (e.g. "Reading file"); optional. */
+  activeForm?: string;
+}
+
+export interface TodoSummary {
+  todos: TodoItem[];
+  total: number;
+  completed: number;
+  inProgress: number;
+  pending: number;
+}
+
+const VALID_STATUS: Record<string, TodoStatus> = {
+  pending: 'pending',
+  in_progress: 'in_progress',
+  completed: 'completed',
+};
+
+function coerceTodos(raw: unknown): TodoItem[] | null {
+  if (!Array.isArray(raw)) return null;
+  const items: TodoItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const content = typeof e.content === 'string' ? e.content : '';
+    if (!content) continue;
+    const status = VALID_STATUS[String(e.status)] ?? 'pending';
+    const activeForm = typeof e.activeForm === 'string' ? e.activeForm : undefined;
+    items.push({ content, status, activeForm });
+  }
+  return items.length > 0 ? items : null;
+}
+
+/**
+ * The most recent TodoWrite call's list in the current session. TodoWrite is
+ * called repeatedly with the full updated list, so the latest call IS the
+ * current plan. Returns null when the agent hasn't produced a plan yet.
+ */
+export function selectLatestTodos(messages: ThreadMessage[]): TodoItem[] | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const parts = messages[i].content;
+    for (let j = parts.length - 1; j >= 0; j--) {
+      const part = parts[j];
+      if (part.type === 'tool-call' && part.toolName?.toLowerCase() === 'todowrite') {
+        const todos = coerceTodos((part.args as Record<string, unknown> | undefined)?.todos);
+        if (todos) return todos;
+      }
+    }
+  }
+  return null;
+}
+
+export function useSessionTodos(): TodoSummary | null {
+  const messages = useChatSessionStore((s) => s.messages);
+  return useMemo(() => {
+    const todos = selectLatestTodos(messages);
+    if (!todos) return null;
+    return {
+      todos,
+      total: todos.length,
+      completed: todos.filter((t) => t.status === 'completed').length,
+      inProgress: todos.filter((t) => t.status === 'in_progress').length,
+      pending: todos.filter((t) => t.status === 'pending').length,
+    };
+  }, [messages]);
+}

--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -45,6 +45,7 @@ import { ImagePreviewOverlay } from '~/components/claude-chat/overlay/image-prev
 import { type PermissionInfo } from '~/components/claude-chat/permission-badge';
 import { ChatComposerWithRef, type ChatComposerRef } from '~/components/claude-chat/chat-composer';
 import { A2ComposerPanel } from '~/components/claude-chat/a2composer-panel';
+import { WorkbenchPanel } from '~/components/claude-chat/workbench-panel';
 import { SkillChip } from '~/components/claude-chat/skill-chip';
 import { cn, toLocalizedString } from '~/lib/utils';
 import { parseSkillMarker } from '~/lib/skills/skill-marker';
@@ -532,18 +533,23 @@ function RouteComponent() {
             <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
           </div>
           <div
-            className={cn('h-full shrink-0 overflow-hidden', activeArtifactId && 'border-l')}
-            style={{
-              flexBasis: 0,
-              flexGrow: activeArtifactId ? 1 - artifactSplitRatio : 0,
-              maxWidth: activeArtifactId ? 'none' : 0,
-            }}
+            className={cn(
+              'h-full shrink-0 overflow-hidden border-l',
+              !activeArtifactId && 'hidden lg:block'
+            )}
+            style={
+              activeArtifactId
+                ? { flexBasis: 0, flexGrow: 1 - artifactSplitRatio, maxWidth: 'none' }
+                : { width: 360 }
+            }
           >
-            {activeArtifactId && (
+            {activeArtifactId ? (
               <ArtifactsPanel
                 artifactId={activeArtifactId}
                 onClose={() => setActiveArtifact(null)}
               />
+            ) : (
+              <WorkbenchPanel currentSessionId={currentSessionId} />
             )}
           </div>
         </div>
@@ -801,18 +807,23 @@ const MainContent: FC<{
           <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border" />
         </div>
         <div
-          className={cn('h-full shrink-0 overflow-hidden', activeArtifactId && 'border-l')}
-          style={{
-            flexBasis: 0,
-            flexGrow: activeArtifactId ? 1 - artifactSplitRatio : 0,
-            maxWidth: activeArtifactId ? 'none' : 0,
-          }}
+          className={cn(
+            'h-full shrink-0 overflow-hidden border-l',
+            !activeArtifactId && 'hidden lg:block'
+          )}
+          style={
+            activeArtifactId
+              ? { flexBasis: 0, flexGrow: 1 - artifactSplitRatio, maxWidth: 'none' }
+              : { width: 360 }
+          }
         >
-          {activeArtifactId && (
+          {activeArtifactId ? (
             <ArtifactsPanel
               artifactId={activeArtifactId}
               onClose={() => setActiveArtifact(null)}
             />
+          ) : (
+            <WorkbenchPanel currentSessionId={currentSessionId} />
           )}
         </div>
       </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3,108 +3,111 @@
 @import "./tokens.css";
 
 @custom-variant dark (&:is(.dark *));
+/* Phase 3 · Wave 0 design tokens — Direction A "暖雾奶油" (warm cream, Coze-leaning).
+   换皮不换骨：仅改 token 值，保留全部 shadcn 变量名 / @theme / Radix。
+   品牌色与 tokens.css 的陶土 accent 同源。设计依据见 docs/project/wave0-design/. */
 :root {
-    --background: oklch(1.0 0 0);
-    --foreground: oklch(0.19 0.01 248.51);
-    --card: oklch(0.98 0.0 197.14);
-    --card-foreground: oklch(0.19 0.01 248.51);
+    --background: oklch(0.992 0.008 80);
+    --foreground: oklch(0.24 0.02 60);
+    --card: oklch(0.998 0.004 80);
+    --card-foreground: oklch(0.24 0.02 60);
     --popover: oklch(1.0 0 0);
-    --popover-foreground: oklch(0.19 0.01 248.51);
-    --primary: oklch(0.67 0.16 245.0);
-    --primary-foreground: oklch(1.0 0 0);
-    --secondary: oklch(0.19 0.01 248.51);
-    --secondary-foreground: oklch(1.0 0 0);
-    --muted: oklch(0.92 0.0 286.37);
-    --muted-foreground: oklch(0.19 0.01 248.51);
-    --accent: oklch(0.94 0.02 250.85);
-    --accent-foreground: oklch(0.67 0.16 245.0);
-    --destructive: oklch(0.62 0.24 25.77);
+    --popover-foreground: oklch(0.24 0.02 60);
+    --primary: oklch(0.62 0.14 48);
+    --primary-foreground: oklch(0.99 0.01 80);
+    --secondary: oklch(0.28 0.02 55);
+    --secondary-foreground: oklch(0.98 0.01 80);
+    --muted: oklch(0.955 0.008 70);
+    --muted-foreground: oklch(0.50 0.02 60);
+    --accent: oklch(0.95 0.035 62);
+    --accent-foreground: oklch(0.55 0.13 48);
+    --destructive: oklch(0.60 0.20 28);
     --destructive-foreground: oklch(1.0 0 0);
-    --border: oklch(0.93 0.01 231.66);
-    --input: oklch(0.98 0.0 228.78);
-    --ring: oklch(0.68 0.16 243.35);
-    --chart-1: oklch(0.67 0.16 245.0);
-    --chart-2: oklch(0.69 0.16 160.35);
-    --chart-3: oklch(0.82 0.16 82.53);
-    --chart-4: oklch(0.71 0.18 151.71);
-    --chart-5: oklch(0.59 0.22 10.58);
-    --sidebar: oklch(0.98 0.0 197.14);
-    --sidebar-foreground: oklch(0.19 0.01 248.51);
-    --sidebar-primary: oklch(0.67 0.16 245.0);
-    --sidebar-primary-foreground: oklch(1.0 0 0);
-    --sidebar-accent: oklch(0.94 0.02 250.85);
-    --sidebar-accent-foreground: oklch(0.67 0.16 245.0);
-    --sidebar-border: oklch(0.93 0.01 238.52);
-    --sidebar-ring: oklch(0.68 0.16 243.35);
-    --font-sans: Open Sans, sans-serif;
-    --font-serif: Georgia, serif;
+    --border: oklch(0.905 0.01 70);
+    --input: oklch(0.965 0.006 75);
+    --ring: oklch(0.62 0.14 48);
+    --chart-1: oklch(0.62 0.14 48);
+    --chart-2: oklch(0.70 0.10 150);
+    --chart-3: oklch(0.80 0.12 75);
+    --chart-4: oklch(0.68 0.12 30);
+    --chart-5: oklch(0.60 0.16 20);
+    --sidebar: oklch(0.985 0.006 80);
+    --sidebar-foreground: oklch(0.24 0.02 60);
+    --sidebar-primary: oklch(0.62 0.14 48);
+    --sidebar-primary-foreground: oklch(0.99 0.01 80);
+    --sidebar-accent: oklch(0.95 0.035 62);
+    --sidebar-accent-foreground: oklch(0.55 0.13 48);
+    --sidebar-border: oklch(0.905 0.01 70);
+    --sidebar-ring: oklch(0.62 0.14 48);
+    --font-sans: Inter, "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+    --font-serif: "Source Serif 4", Georgia, "Songti SC", serif;
     --font-mono: Menlo, monospace;
-    --radius: 1.3rem;
-    --shadow-2xs: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-xs: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-sm: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 1px 2px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 1px 2px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-md: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 2px 4px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-lg: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 4px 6px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-xl: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 8px 10px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-2xl: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0);
+    --radius: 1.25rem;
+    --shadow-2xs: 0 1px 2px 0 hsl(28 35% 28% / 0.04);
+    --shadow-xs: 0 1px 2px 0 hsl(28 35% 28% / 0.05);
+    --shadow-sm: 0 1px 2px 0 hsl(28 35% 28% / 0.07), 0 1px 1px -1px
+        hsl(28 35% 28% / 0.06);
+    --shadow: 0 1px 3px 0 hsl(28 35% 28% / 0.08), 0 1px 2px -1px
+        hsl(28 35% 28% / 0.07);
+    --shadow-md: 0 2px 6px -1px hsl(28 35% 28% / 0.09), 0 2px 4px -2px
+        hsl(28 35% 28% / 0.07);
+    --shadow-lg: 0 4px 14px -3px hsl(28 35% 28% / 0.12), 0 4px 6px -4px
+        hsl(28 35% 28% / 0.08);
+    --shadow-xl: 0 8px 24px -6px hsl(28 35% 28% / 0.14), 0 8px 10px -6px
+        hsl(28 35% 28% / 0.08);
+    --shadow-2xl: 0 16px 40px -8px hsl(28 35% 28% / 0.20);
 }
 
 .dark {
-    --background: oklch(0 0 0);
-    --foreground: oklch(0.93 0.0 228.79);
-    --card: oklch(0.21 0.01 274.53);
-    --card-foreground: oklch(0.89 0 0);
-    --popover: oklch(0 0 0);
-    --popover-foreground: oklch(0.93 0.0 228.79);
-    --primary: oklch(0.67 0.16 245.01);
-    --primary-foreground: oklch(1.0 0 0);
-    --secondary: oklch(0.96 0.0 219.53);
-    --secondary-foreground: oklch(0.19 0.01 248.51);
-    --muted: oklch(0.25 0.01 247.97);
-    --muted-foreground: oklch(0.65 0.01 247.97);
-    --accent: oklch(0.19 0.03 242.55);
-    --accent-foreground: oklch(0.67 0.16 245.01);
-    --destructive: oklch(0.62 0.24 25.77);
+    --background: oklch(0.205 0.012 60);
+    --foreground: oklch(0.93 0.012 70);
+    --card: oklch(0.245 0.014 60);
+    --card-foreground: oklch(0.92 0.01 70);
+    --popover: oklch(0.245 0.014 60);
+    --popover-foreground: oklch(0.93 0.012 70);
+    --primary: oklch(0.72 0.13 52);
+    --primary-foreground: oklch(0.20 0.02 60);
+    --secondary: oklch(0.92 0.01 70);
+    --secondary-foreground: oklch(0.22 0.02 60);
+    --muted: oklch(0.28 0.012 60);
+    --muted-foreground: oklch(0.70 0.015 65);
+    --accent: oklch(0.30 0.04 55);
+    --accent-foreground: oklch(0.80 0.11 52);
+    --destructive: oklch(0.68 0.17 28);
     --destructive-foreground: oklch(1.0 0 0);
-    --border: oklch(0.27 0.0 248.0);
-    --input: oklch(0.3 0.03 244.82);
-    --ring: oklch(0.68 0.16 243.35);
-    --chart-1: oklch(0.67 0.16 245.0);
-    --chart-2: oklch(0.69 0.16 160.35);
-    --chart-3: oklch(0.82 0.16 82.53);
-    --chart-4: oklch(0.71 0.18 151.71);
-    --chart-5: oklch(0.59 0.22 10.58);
-    --sidebar: oklch(0.21 0.01 274.53);
-    --sidebar-foreground: oklch(0.89 0 0);
-    --sidebar-primary: oklch(0.68 0.16 243.35);
-    --sidebar-primary-foreground: oklch(1.0 0 0);
-    --sidebar-accent: oklch(0.19 0.03 242.55);
-    --sidebar-accent-foreground: oklch(0.67 0.16 245.01);
-    --sidebar-border: oklch(0.38 0.02 240.59);
-    --sidebar-ring: oklch(0.68 0.16 243.35);
-    --font-sans: Open Sans, sans-serif;
-    --font-serif: Georgia, serif;
+    --border: oklch(0.34 0.012 60);
+    --input: oklch(0.33 0.014 60);
+    --ring: oklch(0.72 0.13 52);
+    --chart-1: oklch(0.72 0.13 52);
+    --chart-2: oklch(0.72 0.10 150);
+    --chart-3: oklch(0.80 0.12 75);
+    --chart-4: oklch(0.70 0.12 30);
+    --chart-5: oklch(0.64 0.16 20);
+    --sidebar: oklch(0.225 0.013 60);
+    --sidebar-foreground: oklch(0.92 0.01 70);
+    --sidebar-primary: oklch(0.72 0.13 52);
+    --sidebar-primary-foreground: oklch(0.20 0.02 60);
+    --sidebar-accent: oklch(0.30 0.04 55);
+    --sidebar-accent-foreground: oklch(0.80 0.11 52);
+    --sidebar-border: oklch(0.34 0.012 60);
+    --sidebar-ring: oklch(0.72 0.13 52);
+    --font-sans: Inter, "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+    --font-serif: "Source Serif 4", Georgia, "Songti SC", serif;
     --font-mono: Menlo, monospace;
-    --radius: 1.3rem;
-    --shadow-2xs: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-xs: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-sm: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 1px 2px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 1px 2px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-md: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 2px 4px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-lg: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 4px 6px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-xl: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0), 0px 8px 10px -1px
-        hsl(202.82 89.12% 53.14% / 0.0);
-    --shadow-2xl: 0px 2px 0px 0px hsl(202.82 89.12% 53.14% / 0.0);
+    --radius: 1.25rem;
+    --shadow-2xs: 0 1px 2px 0 hsl(30 20% 3% / 0.30);
+    --shadow-xs: 0 1px 2px 0 hsl(30 20% 3% / 0.34);
+    --shadow-sm: 0 1px 2px 0 hsl(30 20% 3% / 0.40), 0 1px 1px -1px
+        hsl(30 20% 3% / 0.36);
+    --shadow: 0 1px 3px 0 hsl(30 20% 3% / 0.44), 0 1px 2px -1px
+        hsl(30 20% 3% / 0.40);
+    --shadow-md: 0 2px 6px -1px hsl(30 20% 3% / 0.46), 0 2px 4px -2px
+        hsl(30 20% 3% / 0.40);
+    --shadow-lg: 0 4px 14px -3px hsl(30 20% 3% / 0.50), 0 4px 6px -4px
+        hsl(30 20% 3% / 0.42);
+    --shadow-xl: 0 8px 24px -6px hsl(30 20% 3% / 0.55), 0 8px 10px -6px
+        hsl(30 20% 3% / 0.45);
+    --shadow-2xl: 0 16px 40px -8px hsl(30 20% 3% / 0.62);
 }
 
 @theme inline {

--- a/tests/unit/session-workbench-subagents.test.ts
+++ b/tests/unit/session-workbench-subagents.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for selectSubAgents (Phase 3 Wave 1, ② Sub-agents panel).
+ *
+ * Contract: each Claude Code `Task` tool-call in the current session is one
+ * sub-agent, surfaced in call order with subagent_type + description + a status
+ * mapped from the tool-call status. Non-Task tool calls are ignored.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectSubAgents } from '~/lib/hooks/use-session-workbench';
+import type { ThreadMessage, ToolStatus } from '~/lib/chat-session-store';
+
+function taskMsg(
+  id: string,
+  args: Record<string, unknown>,
+  toolStatus?: ToolStatus,
+  isError?: boolean,
+): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: `tc-${id}`,
+        toolName: 'Task',
+        args,
+        argsText: '',
+        ...(toolStatus ? { toolStatus } : {}),
+        ...(isError ? { isError } : {}),
+      },
+    ],
+  };
+}
+
+describe('selectSubAgents', () => {
+  it('returns [] when there are no Task calls', () => {
+    const messages: ThreadMessage[] = [
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'a', toolName: 'Bash', args: {}, argsText: '' },
+        ],
+      },
+    ];
+    expect(selectSubAgents(messages)).toEqual([]);
+  });
+
+  it('maps a Task call to a sub-agent with type, description and status', () => {
+    const messages = [
+      taskMsg('m1', { subagent_type: 'researcher', description: 'Research pricing' }, 'completed'),
+    ];
+    expect(selectSubAgents(messages)).toEqual([
+      { id: 'tc-m1', subagentType: 'researcher', description: 'Research pricing', status: 'completed' },
+    ]);
+  });
+
+  it('maps tool status to running/completed/error and honours isError', () => {
+    const messages = [
+      taskMsg('a', { description: 'one' }, 'executing'),
+      taskMsg('b', { description: 'two' }, 'backgrounded'),
+      taskMsg('c', { description: 'three' }, 'error'),
+      taskMsg('d', { description: 'four' }, 'completed', true),
+      taskMsg('e', { description: 'five' }), // no status → running
+    ];
+    expect(selectSubAgents(messages).map((s) => s.status)).toEqual([
+      'running',
+      'running',
+      'error',
+      'error',
+      'running',
+    ]);
+  });
+
+  it('preserves call order across messages', () => {
+    const messages = [taskMsg('first', { description: 'A' }), taskMsg('second', { description: 'B' })];
+    expect(selectSubAgents(messages).map((s) => s.description)).toEqual(['A', 'B']);
+  });
+
+  it('falls back to intent then a default when description is missing', () => {
+    const withIntent: ThreadMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'tc1',
+          toolName: 'Task',
+          args: {},
+          argsText: '',
+          intent: 'Summarise the doc',
+        },
+      ],
+    };
+    expect(selectSubAgents([withIntent])[0].description).toBe('Summarise the doc');
+    expect(selectSubAgents([taskMsg('m2', {})])[0].description).toBe('Sub-agent task');
+  });
+});

--- a/tests/unit/session-workbench-todos.test.ts
+++ b/tests/unit/session-workbench-todos.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for selectLatestTodos (Phase 3 Wave 1, ① Progress panel).
+ *
+ * Encodes the contract the WorkbenchPanel relies on: the *latest* TodoWrite call
+ * in the current session is the current plan; statuses are coerced safely; and
+ * non-TodoWrite tool calls / malformed entries never leak into the list.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectLatestTodos } from '~/lib/hooks/use-session-workbench';
+import type { ThreadMessage } from '~/lib/chat-session-store';
+
+function todoWriteMsg(id: string, todos: unknown): ThreadMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: `tc-${id}`,
+        toolName: 'TodoWrite',
+        args: { todos },
+        argsText: '',
+      },
+    ],
+  };
+}
+
+describe('selectLatestTodos', () => {
+  it('returns null when there is no TodoWrite call', () => {
+    const messages: ThreadMessage[] = [
+      {
+        id: 'm1',
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'a', toolName: 'Write', args: { file: 'x' }, argsText: '' },
+        ],
+      },
+    ];
+    expect(selectLatestTodos(messages)).toBeNull();
+  });
+
+  it('extracts content + status from a TodoWrite call', () => {
+    const messages = [
+      todoWriteMsg('m1', [
+        { content: 'Read file', status: 'completed' },
+        { content: 'Compute', status: 'in_progress' },
+        { content: 'Write result', status: 'pending' },
+      ]),
+    ];
+    expect(selectLatestTodos(messages)).toEqual([
+      { content: 'Read file', status: 'completed', activeForm: undefined },
+      { content: 'Compute', status: 'in_progress', activeForm: undefined },
+      { content: 'Write result', status: 'pending', activeForm: undefined },
+    ]);
+  });
+
+  it('uses the LATEST TodoWrite call when several exist (the live plan)', () => {
+    const messages = [
+      todoWriteMsg('m1', [{ content: 'Step A', status: 'pending' }]),
+      todoWriteMsg('m2', [
+        { content: 'Step A', status: 'completed' },
+        { content: 'Step B', status: 'in_progress' },
+      ]),
+    ];
+    const todos = selectLatestTodos(messages);
+    expect(todos).toHaveLength(2);
+    expect(todos?.[0]).toMatchObject({ content: 'Step A', status: 'completed' });
+  });
+
+  it('defaults unknown status to pending and drops empty-content entries', () => {
+    const messages = [
+      todoWriteMsg('m1', [
+        { content: 'Valid', status: 'frobnicate' },
+        { content: '', status: 'completed' },
+        { status: 'pending' },
+      ]),
+    ];
+    expect(selectLatestTodos(messages)).toEqual([
+      { content: 'Valid', status: 'pending', activeForm: undefined },
+    ]);
+  });
+
+  it('returns null for a TodoWrite call whose todos is not an array', () => {
+    const messages = [todoWriteMsg('m1', 'not-an-array')];
+    expect(selectLatestTodos(messages)).toBeNull();
+  });
+
+  it('preserves activeForm when present', () => {
+    const messages = [
+      todoWriteMsg('m1', [{ content: 'Run script', status: 'in_progress', activeForm: 'Running script' }]),
+    ];
+    expect(selectLatestTodos(messages)?.[0]).toEqual({
+      content: 'Run script',
+      status: 'in_progress',
+      activeForm: 'Running script',
+    });
+  });
+});


### PR DESCRIPTION
Phase 3, Waves 0–1. **换皮不换骨** + front-end-only (no adapter/backend/isolation changes).

## Wave 0 — design language + workbench skeleton
- **Design tokens → Direction A "暖雾奶油"** (owner-locked): warm-cream light bg, terracotta/apricot brand primary (same hue family as the existing `tokens.css` `#ae5630`), radius `1.25rem`, soft warm shadows, Inter/Source-Serif. Only `app.css` token values change; every shadcn variable / `@theme` / Radix kept. Preview: `docs/project/wave0-design/preview.html`.
- **Three-column workbench skeleton** — new `WorkbenchPanel` resident right rail with switchable sections (Progress / Sub-agents / Files / Context) + placeholder 3D-icon slots. Fills the right column when no artifact is open; existing `ArtifactsPanel` + split-resize untouched. Hidden below `lg`.

## Wave 1 — workbench content (front-end line)
- **① Progress** = live TodoWrite checklist (`selectLatestTodos` / `useSessionTodos`).
- **② Sub-agents** = flat Task-delegation list with live status (`selectSubAgents` / `useSessionSubAgents`).
- Both derive purely from the current session's store messages (no adapter change); inherently per-session.

## Verification
- `pnpm build` ✓; `vitest run tests/unit/session-workbench-*` → **11/11**.
- Real app (`:3000`, hybrid local): three columns render light + dark, tab switching works, mobile (375px) degrades cleanly. Progress + Sub-agents rendered with real data (injected via a temporary, reverted store-exposure — `chat-session-store.ts` unchanged in this PR).

## Known follow-ups (not in this PR)
- Nested sub-agent tree needs the adapter/store to persist `parent_tool_use_id` on tool-call parts (② is flat for now).
- Responsive workbench drawer below `lg`; Inter/Source-Serif font files; owner-supplied 3D icons (placeholder slots in place).
- `ark-code-latest` doesn't emit TodoWrite/Task on its own, so the live-model path for ①② is unverified with this model (verified via unit tests + injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)