### PR TITLE
fix(sandbox): PR-C step 0 — enable srt sandbox in production

### DIFF
--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -213,6 +213,13 @@ services:
   app:
     <<: *app_build
     container_name: ${APP_NAME:-OxyGenie}-app
+    # PR-C Step 0: enable srt (bubblewrap) sandbox for tool execution.
+    # srt requires unprivileged user namespaces → seccomp=unconfined.
+    # bubblewrap/socat/ripgrep are already installed in the Dockerfile (line 72-74).
+    # Verify active: docker logs <app-container> | grep '\[sandbox\]'
+    # Should show "srt: initialized" not "env-strip only".
+    security_opt:
+      - seccomp=unconfined
     depends_on:
       db:
         condition: service_healthy
@@ -277,7 +284,10 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       CLAUDE_SESSIONS_ROOT: /data/users
       APP_URL: http://localhost:5000
-      SANDBOX_ENABLED: ${SANDBOX_ENABLED:-false}
+      # srt sandbox: explicitly ON (requires seccomp=unconfined above).
+      # SANDBOX_ENABLED was a legacy unused var; ENABLE_EXEC_SANDBOX is what the
+      # code actually reads (src/claude/execution/sandbox.js isEnabled()).
+      ENABLE_EXEC_SANDBOX: '1'
       CLAUDE_MCP_STORE_DIR: ${CLAUDE_MCP_STORE_DIR:-src/mcp-store}
       MCP_STORE_DIR: ${MCP_STORE_DIR:-src/mcp-store}
       # Skills Store (must use persistent volume; otherwise installed skills are lost on redeploy)


### PR DESCRIPTION
## Summary

Production `docker-compose.dokploy.yml` was missing `seccomp=unconfined`, so srt
(bubblewrap) was silently degrading to env-strip only — no network isolation, no
filesystem fencing. This PR turns the sandbox on.

## Changes

- `app` service: `security_opt: seccomp=unconfined` (required by bubblewrap)
- `app` service: `ENABLE_EXEC_SANDBOX=1` explicit (replaces unused `SANDBOX_ENABLED=false`)

Dependencies already in place: bubblewrap/socat/ripgrep installed in `Dockerfile:72-74`.

## How to verify after deploy

```bash
docker logs <app-container-name> | grep '\[sandbox\]'
# Expected: srt: initialized
# Bad:      env-strip only
```

## Test plan
- [x] YAML syntax valid
- [x] Local docker-compose.yml already had seccomp=unconfined (reference)
- [ ] Deploy to production and verify srt log line

## Note
This is a prerequisite for PR-C main (sandboxed bash tool). Without this, the
sandbox infrastructure exists in code but doesn't run in production.

🤖 Generated with Claude Code