### PR TITLE
polish(p3): permission-tier selector UI (PR-B follow-up)

### DIFF
--- a/src/components/claude-chat/permission-tier-selector.tsx
+++ b/src/components/claude-chat/permission-tier-selector.tsx
@@ -108,7 +108,7 @@ export const PermissionTierSelector: FC<PermissionTierSelectorProps> = ({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={`group flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 transition-all duration-200 ${meta.bgColor} ${meta.borderColor} ${meta.color} cursor-pointer hover:opacity-80`}
+        className={`group flex items-center gap-1.5 rounded-lg border px-3 py-1.5 transition-all duration-200 ${meta.bgColor} ${meta.borderColor} ${meta.color} cursor-pointer hover:opacity-80`}
         title={meta.desc}
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -122,7 +122,7 @@ export const PermissionTierSelector: FC<PermissionTierSelectorProps> = ({
       {open && (
         <div
           role="listbox"
-          className="absolute bottom-full left-0 z-50 mb-2 w-68 rounded-lg border border-border bg-popover p-1.5 shadow-lg"
+          className="absolute bottom-full left-0 z-50 mb-2 w-64 rounded-lg border border-border bg-popover p-1.5 shadow-lg"
         >
           {PERMISSION_TIERS.map((tier) => {
             const m = TIER_META[tier];
@@ -135,7 +135,7 @@ export const PermissionTierSelector: FC<PermissionTierSelectorProps> = ({
                 role="option"
                 aria-selected={isCurrent}
                 onClick={() => handlePick(tier)}
-                className="flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left cursor-pointer hover:bg-accent transition"
+                className={`flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left cursor-pointer transition hover:bg-accent ${isCurrent ? 'bg-accent' : ''}`}
               >
                 <TierIcon className={`mt-0.5 h-4 w-4 shrink-0 ${m.color}`} />
                 <span className="min-w-0 flex-1">


### PR DESCRIPTION
UI-only polish of the 3-tier permission selector per `docs/project/tasks/permission-tier-selector-ui.md`.

**Scope:** only `permission-tier-selector.tsx` (3-line diff). `permission-tier.js` + backend untouched.
- Trigger padding `px-2.5` → `px-3` to match the adjacent `PermissionBadge`.
- Dropdown `w-68` → `w-64` (spec; unify with other popovers).
- Selected tier row gets a persistent `bg-accent` highlight (beyond the ✓).
- (Already conformed: success/muted/primary tokens, `bg-popover border-border rounded-lg shadow-lg`,
  `hover:bg-accent`, imports `PERMISSION_TIERS`, default `act`, hidden while running.)

**Verified:** `pnpm build` ✓; real app — dropdown shows 3 tiers to spec (🔍 Explore muted / ⚡ Auto green /
🚀 Act primary, default Act with ✓ + highlight), switched to Explore + sent a message →
ws-server log `Permission tier: explore → mode=plan` (full UI→backend chain works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)