### PR TITLE
refine(p3): remove redundant PermissionBadge from composer

### DIFF
--- a/src/components/claude-chat/chat-composer.tsx
+++ b/src/components/claude-chat/chat-composer.tsx
@@ -43,7 +43,7 @@ import { SkillChip } from './skill-chip';
 import { KnowledgeBasePanel } from './knowledge-base-panel';
 import { SessionFilesPanel } from './session-files-panel';
 import { SessionInfoPanel, type SessionMetadata } from './session-info-panel';
-import { PermissionBadge, type PermissionInfo } from './permission-badge';
+import { type PermissionInfo } from './permission-badge';
 import { PermissionTierSelector } from './permission-tier-selector';
 import { ToolbarStatus, type AgentStatusType } from './claude-status';
 import { McpStatusIndicator } from './mcp-status-indicator';
@@ -573,9 +573,6 @@ export function ChatComposer({
                 selectedTier={selectedTier}
                 onSelect={setSelectedTier}
               />
-            )}
-            {!isRunning && (
-              <PermissionBadge permissionInfo={permissionInfo} />
             )}
 
             {/* ToolbarStatus - show when running */}


### PR DESCRIPTION
The "Standard" PermissionBadge next to the tier selector is now redundant + misleading.

**Why:** since PR-B, ws-server overrides `permissionMode` with the tier mapping
(`resolveEffectivePermission`: explore→plan, auto·act→acceptEdits). The badge still showed the old
`permissionInfo.permissionMode` ("Standard") + a 🔒 bash flag — which contradicts the tier (e.g. shows
"Standard 🔒 bash-off" while the user is in **Act** = sandbox bash). Its remaining detail
(disallowedTools/role/whitelist) is debug-ish (DESIGN-SYSTEM §5). The tier selector now owns the
user-facing permission control.

**Change:** frontend-only — remove `<PermissionBadge>` render + its import from `chat-composer.tsx`
(kept `type PermissionInfo` for the still-typed prop). **Backend untouched** — `getPermissionInfo`/
`fetchPermissionInfo` stay (allowBash/org/role still feed disallowedTools + audit; settings page still
uses `permissionInfo.role`).

**Verified:** build ✓; composer now shows only the tier selector (no Standard badge); sent a message →
ws-server log `Permission tier: act → mode=acceptEdits` (chain intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)