### PR TITLE
fix(p3): new-chat button disappearing + wrong session-toggle icon

### DIFF
--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -28,7 +28,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { useIntlayer } from 'react-intlayer';
 import { useServerFn } from '@tanstack/react-start';
 import { useQuery } from '@tanstack/react-query';
-import { ThumbsDown, ThumbsUp, Layers, Paperclip, FolderOpen, Plus, MessageSquare, Loader2 } from 'lucide-react';
+import { ThumbsDown, ThumbsUp, Layers, Paperclip, PanelLeftClose, PanelLeftOpen, Plus, MessageSquare, Loader2 } from 'lucide-react';
 import { createContext, useContext, useEffect, useState, useCallback, useRef, useMemo, type FC, type MutableRefObject, type PointerEvent as ReactPointerEvent } from 'react';
 import { MarkdownText } from '~/components/assistant-ui/markdown-text';
 import { StreamingMarkdown } from '~/components/claude-chat/streaming-markdown';
@@ -460,17 +460,15 @@ function RouteComponent() {
         {/* Floating action buttons - only show when no artifact */}
         {!activeArtifactId && (
           <div className="absolute top-4 left-4 z-10 flex gap-2">
-            {hasAnySessions && (
-              <button
-                type="button"
-                onClick={() => setSessionListExpanded(!sessionListExpanded)}
-                className="flex h-9 w-9 items-center justify-center rounded-lg bg-card border shadow-sm transition-colors hover:bg-accent"
-                aria-label={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
-                title={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
-              >
-                <FolderOpen className="h-4 w-4" />
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => setSessionListExpanded(!sessionListExpanded)}
+              className="flex h-9 w-9 items-center justify-center rounded-lg bg-card border shadow-sm transition-colors hover:bg-accent"
+              aria-label={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
+              title={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
+            >
+              {sessionListExpanded ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}
+            </button>
             {!sessionListExpanded && (
               <button
                 type="button"
@@ -500,7 +498,7 @@ function RouteComponent() {
       <div className="h-full">
         <div className={cn('flex h-full', activeArtifactId && 'group')} ref={artifactSplitRef}>
           {/* Session List - only show when no artifact AND user has sessions */}
-          {!activeArtifactId && hasAnySessions && (
+          {!activeArtifactId && (
             <SessionList
               currentSessionId={currentSessionId}
               onSelectSession={handleSelectSession}
@@ -734,17 +732,15 @@ const MainContent: FC<{
       {/* Floating action buttons - only show when no artifact */}
       {!activeArtifactId && (
         <div className="absolute top-4 left-4 z-10 flex gap-2">
-          {hasAnySessions && (
-            <button
-              type="button"
-              onClick={() => setSessionListExpanded(!sessionListExpanded)}
-              className="flex h-9 w-9 items-center justify-center rounded-lg bg-card border shadow-sm transition-colors hover:bg-accent"
-              aria-label={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
-              title={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
-            >
-              <FolderOpen className="h-4 w-4" />
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => setSessionListExpanded(!sessionListExpanded)}
+            className="flex h-9 w-9 items-center justify-center rounded-lg bg-card border shadow-sm transition-colors hover:bg-accent"
+            aria-label={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
+            title={toLocalizedString(sessionListExpanded ? content.sidebar.collapse : content.sidebar.expand)}
+          >
+            {sessionListExpanded ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}
+          </button>
           {!sessionListExpanded && (
             <button
               type="button"
@@ -774,7 +770,7 @@ const MainContent: FC<{
     <>
       <div className={cn('flex h-full', activeArtifactId && 'group')} ref={artifactSplitRef}>
         {/* Session List - only show when no artifact AND user has sessions */}
-        {!activeArtifactId && hasAnySessions && (
+        {!activeArtifactId && (
           <SessionList
             currentSessionId={currentSessionId}
             onSelectSession={handleSelectSession}


### PR DESCRIPTION
**Bug:** during normal use the New Chat button could vanish and the session list became un-toggleable.

**Root cause:** the new-chat button, the session-list toggle, AND the `SessionList` render were all
gated on `hasAnySessions`. Dead state = `sessionListExpanded` persisted `true` + `hasAnySessions=false`
+ a `currentSessionId` (e.g. right after creating the first session, before the session-count query
refetches): the big empty-state is skipped (has a session id), the floating "+" is hidden (expanded),
and the toggle + SessionList are both gated off → no new-chat button anywhere, no toggle. Stuck.

**Fix (route.tsx, both dev + MainContent blocks):**
- Render `<SessionList>` whenever expanded (drop the `hasAnySessions` gate). It already renders its own
  "+ New Chat" + an empty state, so new-chat is always reachable when expanded.
- Session-list toggle always shown (drop the `hasAnySessions` gate) — can always collapse/expand.
- Icon: `FolderOpen` → `PanelLeftClose`/`PanelLeftOpen` (sidebar-toggle icon; folder was semantically
  wrong for "collapse conversations"). craft / lobe-chat-aligned.

**Verified:** build ✓; real app — collapsed shows panel-toggle + "+"; expanding shows the SessionList
with "+ New Chat" + the conversation list ("7 conversation").

🤖 Generated with [Claude Code](https://claude.com/claude-code)