### PR TITLE
feat(claude-chat): 侧栏自持折叠 + 两列协调 (Stage 2 + Stage 4)

### DIFF
--- a/src/components/claude-chat/session-list.tsx
+++ b/src/components/claude-chat/session-list.tsx
@@ -9,7 +9,7 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus, Loader2, MessageSquare } from 'lucide-react';
+import { Plus, Loader2, MessageSquare, PanelLeftClose } from 'lucide-react';
 import { useIntlayer } from 'react-intlayer';
 import { SessionItem, type SessionItemData } from './session-item';
 import { cn, toLocalizedString } from '~/lib/utils';
@@ -105,19 +105,19 @@ export function SessionList({
   return (
     <div
       className={cn(
-        'flex h-full flex-col transition-all duration-300 ease-in-out border-r bg-background/50',
+        'flex h-full flex-col transition-all duration-300 ease-in-out border-r border-sidebar-border bg-sidebar',
         isExpanded ? 'w-64' : 'w-0 overflow-hidden'
       )}
     >
       {isExpanded ? (
         <>
-          {/* Header with New Chat button */}
-          <div className="shrink-0 border-b p-3">
+          {/* Header: New Chat (primary) + collapse toggle (sidebar owns its own collapse) */}
+          <div className="flex shrink-0 items-center gap-2 border-b p-3">
             <button
               type="button"
               onClick={onNewSession}
               className={cn(
-                'flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5',
+                'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5',
                 'bg-primary text-primary-foreground text-sm font-medium',
                 'transition-colors hover:bg-primary/90',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
@@ -125,6 +125,15 @@ export function SessionList({
             >
               <Plus className="h-4 w-4" />
               <span>{content.sessionList.newChat}</span>
+            </button>
+            <button
+              type="button"
+              onClick={onToggleExpanded}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-sidebar-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              aria-label={toLocalizedString(content.sidebar.collapse)}
+              title={toLocalizedString(content.sidebar.collapse)}
+            >
+              <PanelLeftClose className="h-4 w-4" />
             </button>
           </div>
 

--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -458,7 +458,7 @@ function RouteComponent() {
     const chatPanel = (
       <>
         {/* Floating action buttons - only show when no artifact */}
-        {!activeArtifactId && (
+        {!activeArtifactId && !sessionListExpanded && (
           <div className="absolute top-4 left-4 z-10 flex gap-2">
             <button
               type="button"
@@ -730,7 +730,7 @@ const MainContent: FC<{
   const chatPanel = (
     <>
       {/* Floating action buttons - only show when no artifact */}
-      {!activeArtifactId && (
+      {!activeArtifactId && !sessionListExpanded && (
         <div className="absolute top-4 left-4 z-10 flex gap-2">
           <button
             type="button"


### PR DESCRIPTION
## 目标 / Why
延续侧边栏优化方案，落地 **Stage 2 + Stage 4**：让「会话侧栏」自己拥有展开/折叠控制，并与左侧「图标导航栏」在两列布局中视觉协调。对应 PRD Phase 3 UI/UX 改造 + 修复此前「新建对话按钮消失 / 折叠图标错误」的后续结构整理。

## 改动 / What
**Stage 2 — 侧栏自持折叠**
- 折叠按钮移入 `SessionList` 自己的 header，与「New Chat」并排（New Chat `flex-1` + 折叠 toggle）。
- 中部浮动的「展开 + 新建对话」按钮仅在侧栏**折叠时**渲染（展开时不再出现，避免重复）。

**Stage 4 — 两列协调**
- `SessionList` 采用 sidebar 语义 token（`bg-sidebar` / `border-sidebar-border`），与最左侧 `AppSidebar` 图标导航栏在两列布局（图标栏 + 会话栏）下视觉统一。

## 验证 / Verify
- 本地 `pnpm build` 通过（✓ built）。
- 真机（localhost:3000）验证：
  - 展开态：header 显示 New Chat + 折叠 toggle，中部**无**浮动按钮；
  - 折叠态：会话栏收起为 0 宽，左上出现「展开」+「新建对话 +」浮动按钮，与图标栏并存；
  - 折叠状态持久化（localStorage `sessionListExpanded`）正常。

## 范围 / Scope
仅前端 UI 结构/样式：`session-list.tsx`、`route.tsx`。未触碰后端 / 权限逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)