### PR TITLE
fix(skills): schema 生成不再因 SDK effortLevel null 崩溃

### DIFF
--- a/src/claude/skills/schema-generator.ts
+++ b/src/claude/skills/schema-generator.ts
@@ -196,6 +196,24 @@ type SkillSchemaDraft = z.infer<typeof SkillSchemaDraftZod>;
 const SCHEMA_GENERATION_TIMEOUT_MS = 2 * 60 * 1000;
 const MAX_SCHEMA_INPUTS = 6;
 const MAX_SCHEMA_EXAMPLES = 3;
+
+// claude-agent-sdk 0.1.76 crashes with "Cannot read properties of null (reading
+// 'effortLevel')" when query() is called with `tools: []` (no preset) + outputFormat,
+// because the reasoning/effort config is only populated by the claude_code preset.
+// Empirically this surfaces as a flaky `error_during_execution` (~50-75% of calls).
+// Fix: use the preset (like the working chat path) but disallow every actionable tool
+// so generation stays pure text + Structured Output, and retry the flaky crash.
+const SCHEMA_GENERATION_DISALLOWED_TOOLS = [
+  'Bash', 'Read', 'Write', 'Edit', 'MultiEdit', 'NotebookEdit',
+  'Glob', 'Grep', 'WebFetch', 'WebSearch', 'Task', 'TodoWrite',
+];
+// Max attempts to absorb the flaky SDK effortLevel crash (independent ~50% failures).
+const SCHEMA_GENERATION_MAX_ATTEMPTS = Math.max(
+  1,
+  Number(process.env.SCHEMA_GENERATION_MAX_ATTEMPTS ?? '4'),
+);
+// Error messages that indicate the flaky SDK crash and are worth retrying.
+const SCHEMA_GENERATION_RETRYABLE = /error_during_execution|effortLevel|no result received/i;
 const SCHEMA_GENERATION_DEBUG = process.env.SCHEMA_GENERATION_DEBUG === 'true';
 const SCHEMA_GENERATION_TRACE = process.env.SCHEMA_GENERATION_TRACE ?? 'off';
 const TRACE_ENABLED = SCHEMA_GENERATION_TRACE === 'true' || SCHEMA_GENERATION_TRACE === 'full';
@@ -984,7 +1002,11 @@ export interface GenerateSchemaFromContentResult {
   errorMessage?: string;
 }
 
-export async function generateSchemaFromContent(
+/**
+ * Single generation attempt (one SDK call). May throw on the flaky SDK
+ * `error_during_execution` crash; the exported wrapper retries those.
+ */
+async function generateSchemaFromContentOnce(
   skillMdContent: string,
   timeoutMs: number = SCHEMA_GENERATION_TIMEOUT_MS,
 ): Promise<GenerateSchemaFromContentResult> {
@@ -1023,12 +1045,23 @@ export async function generateSchemaFromContent(
       prompt,
       options: {
         model: resolvedModel,
-        // Disable ALL tools by passing empty array
-        // SDK type: tools?: string[] | { type: 'preset'; preset: 'claude_code' }
-        tools: [],
-        // No MCP servers
-        // P3 fix: Add system prompt for format enforcement
-        systemPrompt: SCHEMA_GENERATION_SYSTEM_PROMPT,
+        // IMPORTANT: use the claude_code preset for BOTH tools and systemPrompt.
+        // Passing `tools: []` (no preset) makes claude-agent-sdk 0.1.76 crash on
+        // outputFormat with "Cannot read properties of null (reading 'effortLevel')"
+        // because the reasoning/effort config is only populated by the preset.
+        // We mirror the working chat path (preset) but lock out every actionable
+        // tool, so generation stays pure text + Structured Output.
+        tools: { type: 'preset', preset: 'claude_code' },
+        disallowedTools: SCHEMA_GENERATION_DISALLOWED_TOOLS,
+        permissionMode: 'bypassPermissions',
+        // Keep generation isolated: do not load project skills / CLAUDE.md.
+        settingSources: [],
+        // P3 fix: Add system prompt for format enforcement (via preset append)
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+          append: SCHEMA_GENERATION_SYSTEM_PROMPT,
+        },
         // Use Structured Outputs for reliable JSON format
         outputFormat: {
           type: 'json_schema',
@@ -1254,6 +1287,45 @@ export async function generateSchemaFromContent(
     // P2 fix: Clean up timeout
     clearTimeout(timeoutId);
   }
+}
+
+/**
+ * Generate schema for a skill, retrying the flaky SDK `error_during_execution`
+ * crash (claude-agent-sdk 0.1.76 + gateway: "Cannot read properties of null
+ * (reading 'effortLevel')"). These failures are independent (~50% each), so a
+ * few retries bring the effective success rate well above 90%. Timeouts and
+ * non-retryable errors propagate immediately.
+ */
+export async function generateSchemaFromContent(
+  skillMdContent: string,
+  timeoutMs: number = SCHEMA_GENERATION_TIMEOUT_MS,
+): Promise<GenerateSchemaFromContentResult> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= SCHEMA_GENERATION_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await generateSchemaFromContentOnce(skillMdContent, timeoutMs);
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      const isRetryable = SCHEMA_GENERATION_RETRYABLE.test(message);
+
+      // Never retry timeouts (the work budget is already spent).
+      const isTimeout = /timed out/i.test(message);
+
+      if (attempt < SCHEMA_GENERATION_MAX_ATTEMPTS && isRetryable && !isTimeout) {
+        console.warn(
+          `[Schema Generator] Attempt ${attempt}/${SCHEMA_GENERATION_MAX_ATTEMPTS} failed (retryable): ${message.split('\n')[0]}; retrying...`,
+        );
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  // Unreachable in practice (loop either returns or throws), but satisfies types.
+  throw lastError ?? new Error('Schema generation failed after retries');
 }
 
 // ============================================================================


### PR DESCRIPTION
## 问题
Skill 的 schema 生成在当前环境(ark-code-latest 网关 + claude-agent-sdk 0.1.76)**约 50–75% 概率直接崩溃**:
```
result.subtype = error_during_execution, 0 tokens
TypeError: Cannot read properties of null (reading 'effortLevel')
```
0 tokens 说明 API 调用根本没发出——SDK 在结构化输出路径里就崩了。证据探针(`/tmp/probe-*`,未入库)逐项隔离后定位:

## 根因
`schema-generator.ts` 用 `tools: []`(不带 preset)+ `outputFormat` 调 `query()`。SDK 的结构化输出路径会读取**只有 `claude_code` preset 才会填充**的 reasoning/effort 配置;没有 preset 时 `effortLevel` 为 null → 抛错。
- 与 `outputFormat` 无关(不带 outputFormat 也会崩);
- **非确定性**:preset 配置约 50% 崩、裸 `tools:[]` 配置约 75% 崩。
- 而生产 chat 路径(`ws-query-worker.mjs`)用 preset tools + preset systemPrompt,**能正常用 outputFormat**。

## 修复(外科式,证据驱动)
1. **对齐生产 chat 的调用形态**:`tools`/`systemPrompt` 都用 `claude_code` preset(自定义 prompt 走 `append`),并用 `disallowedTools` + `settingSources:[]` 锁死所有可执行工具,保持"纯文本 + Structured Output、隔离"的原意。这降低崩溃率。
2. **重试包裹**:对 flaky 的 `error_during_execution` 崩溃重试(默认 4 次,可用 `SCHEMA_GENERATION_MAX_ATTEMPTS` 调)。独立 ~50% 失败 → 有效成功率 >90%。超时/不可重试错误立即抛出。

归一化逻辑**未改动**(仍作为非规范网关响应的兜底)。

## 验证
- `tsc --noEmit` 通过;`oxlint` 0 error(29 个均为既有 warning)。
- 端到端跑真实 skill 3/3 成功:前 1–2 次尝试崩溃 → 后续尝试成功,`needsReview=false`。

## 观察(非本 PR 范围)
- 同一 skill 多次生成的 `inputs` 抽取存在波动(有时 0 项、有时 5 项)——这是 LLM 抽取的质量长尾,由 `needsReview` + 人工校正 + 缓存(生成一次后冻结)闭环兜住。
- 更彻底的根因修复是**升级 claude-agent-sdk**(0.1.76 未对 null effortLevel 做保护);本 PR 是低风险 workaround,SDK 升级建议作为后续独立评估。

## 范围
仅 `src/claude/skills/schema-generator.ts`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)