### PR TITLE
chore(deps): claude-agent-sdk 0.1.76 → 0.1.77（修复 effortLevel 崩溃）

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@ai-sdk/openai": "2.0.32",
     "@ai-sdk/react": "^3.0.11",
-    "@anthropic-ai/claude-agent-sdk": "^0.1.76",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.77",
     "@anthropic-ai/sandbox-runtime": "^0.0.52",
     "@assistant-ui/react": "^0.11.15",
     "@assistant-ui/react-ai-sdk": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.0.11
         version: 3.0.11(react@19.1.1)(zod@4.1.11)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.76
-        version: 0.1.76(zod@4.1.11)
+        specifier: ^0.1.77
+        version: 0.1.77(zod@4.1.11)
       '@anthropic-ai/sandbox-runtime':
         specifier: ^0.0.52
         version: 0.0.52
@@ -591,11 +591,11 @@ packages:
   '@antfu/utils@9.2.1':
     resolution: {integrity: sha512-TMilPqXyii1AsiEii6l6ubRzbo76p6oshUSYPaKsmXDavyMLqjzVDkcp3pHp5ELMUNJHATcEOGxKTTsX9yYhGg==}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.76':
-    resolution: {integrity: sha512-s7RvpXoFaLXLG7A1cJBAPD8ilwOhhc/12fb5mJXRuD561o4FmPtQ+WRfuy9akMmrFRfLsKv8Ornw3ClGAPL2fw==}
+  '@anthropic-ai/claude-agent-sdk@0.1.77':
+    resolution: {integrity: sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.24.1 || ^4.0.0
+      zod: ^3.25.0 || ^4.0.0
 
   '@anthropic-ai/sandbox-runtime@0.0.52':
     resolution: {integrity: sha512-vYaM7OslFmOAzNgfy5gxvt3NoWFeCbr7C0AKyuduQq7Gdxbg2NnYmE7deBf8Nxj3ZNECTcC5RhAfz0lZwvbtBA==}
@@ -10715,7 +10715,7 @@ snapshots:
 
   '@antfu/utils@9.2.1': {}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@4.1.11)':
+  '@anthropic-ai/claude-agent-sdk@0.1.77(zod@4.1.11)':
     dependencies:
       zod: 4.1.11
     optionalDependencies:


### PR DESCRIPTION
## 目标
升级 claude-agent-sdk 以从根上修复 schema 生成的 flaky 崩溃（`Cannot read properties of null (reading 'effortLevel')`，见 #76）。

## 为什么不是「最新版」0.3.160
**最新版在本部署不可用**：0.3.x 的新版内置 Claude Code CLI 与 **ark-code-latest 网关**（Volcano `…/api/coding`）不兼容。实测通过该网关的 chat-like `query()`：
- **每次都 hang 到超时**（45s × 3 全部 abort），偶发 `401 "API key format is incorrect"`；
- 0.3.x 还移除了 `'delegate'` PermissionMode（`src/claude/permissions.ts` 会型别报错）。

升级到 0.3.x 会**直接弄坏本环境的 chat**。要用 0.3.x 需先把网关从 ark 切到原生 Anthropic —— 属于基础设施/成本决策，单独评估。

## 为什么是 0.1.77
最小 drop-in 补丁，同时满足：
- **修复 effortLevel 崩溃**：在 0.1.76 上约 75% 崩溃的 `tools:[] + outputFormat` 配置，0.1.77 上探针 **6/6 成功**；
- **保持 ark 网关兼容**（`query()` 正常返回，无 hang/401）；
- **API 不变**（无 `delegate` 移除、无型别破坏）。

## 验证
- lint 0 error（1182 warning 均既有）；`pnpm test:unit` **77/77 通过**；
- 真实 skill 的 schema 生成成功；
- lockfile 仅 SDK 0.1.76→0.1.77 的传递依赖变化（6/6 行）。
- 注：CI `typecheck` 为 `continue-on-error`（既有 200+ 型别告警），required 门为 lint / unit / build。

## 关于 #76 的 workaround
保留（防御性）：preset 配置 + 重试现在很少触发，但作为对瞬时失败的兜底继续存在。

## 范围
仅 `package.json` + `pnpm-lock.yaml`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)