### PR TITLE
chore(deps): claude-agent-sdk 0.1.77 → 0.2.112（ARK 兼容的最高版本）

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@ai-sdk/openai": "2.0.32",
     "@ai-sdk/react": "^3.0.11",
-    "@anthropic-ai/claude-agent-sdk": "^0.1.77",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "@anthropic-ai/sandbox-runtime": "^0.0.52",
     "@assistant-ui/react": "^0.11.15",
     "@assistant-ui/react-ai-sdk": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.0.11
         version: 3.0.11(react@19.1.1)(zod@4.1.11)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.1.77
-        version: 0.1.77(zod@4.1.11)
+        specifier: ^0.2.112
+        version: 0.2.112(zod@4.1.11)
       '@anthropic-ai/sandbox-runtime':
         specifier: ^0.0.52
         version: 0.0.52
@@ -91,7 +91,7 @@ importers:
         version: 1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11)
       '@mastra/mcp':
         specifier: 1.0.0-beta.10
-        version: 1.0.0-beta.10(@mastra/core@1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(hono@4.11.3)(zod@4.1.11)
+        version: 1.0.0-beta.10(@mastra/core@1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(hono@4.12.23)(zod@4.1.11)
       '@mastra/memory':
         specifier: 1.0.0-beta.14
         version: 1.0.0-beta.14(@mastra/core@1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11))(zod@4.1.11)
@@ -100,16 +100,16 @@ importers:
         version: 1.0.0-beta.13(@mastra/core@1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11))
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.25.2(hono@4.11.3)(zod@4.1.11)
+        version: 1.25.2(hono@4.12.23)(zod@4.1.11)
       '@polar-sh/better-auth':
         specifier: ^1.1.4
-        version: 1.1.4(@polar-sh/sdk@0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11)))(better-auth@1.3.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(solid-js@1.9.9))
+        version: 1.1.4(@polar-sh/sdk@0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11)))(better-auth@1.3.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(solid-js@1.9.9))
       '@polar-sh/sdk':
         specifier: ^0.35.2
-        version: 0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))
+        version: 0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))
       '@polar-sh/tanstack-start':
         specifier: ^0.1.8
-        version: 0.1.8(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))(crossws@0.4.1(srvx@0.9.8))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))
+        version: 0.1.8(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))(crossws@0.4.1(srvx@0.9.8))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))
       '@posthog/react':
         specifier: ^1.7.1
         version: 1.7.1(@types/react@19.1.13)(posthog-js@1.345.5)(react@19.1.1)
@@ -458,7 +458,7 @@ importers:
         version: 3.6.2
       shadcn:
         specifier: ^3.3.1
-        version: 3.3.1(@types/node@24.5.2)(hono@4.11.3)(typescript@5.9.2)
+        version: 3.3.1(@types/node@24.5.2)(hono@4.12.23)(typescript@5.9.2)
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
@@ -591,16 +591,25 @@ packages:
   '@antfu/utils@9.2.1':
     resolution: {integrity: sha512-TMilPqXyii1AsiEii6l6ubRzbo76p6oshUSYPaKsmXDavyMLqjzVDkcp3pHp5ELMUNJHATcEOGxKTTsX9yYhGg==}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.77':
-    resolution: {integrity: sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==}
+  '@anthropic-ai/claude-agent-sdk@0.2.112':
+    resolution: {integrity: sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: ^4.0.0
 
   '@anthropic-ai/sandbox-runtime@0.0.52':
     resolution: {integrity: sha512-vYaM7OslFmOAzNgfy5gxvt3NoWFeCbr7C0AKyuduQq7Gdxbg2NnYmE7deBf8Nxj3ZNECTcC5RhAfz0lZwvbtBA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@apidevtools/json-schema-ref-parser@14.2.1':
     resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
@@ -1815,85 +1824,91 @@ packages:
   '@iconify/utils@3.0.2':
     resolution: {integrity: sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -2275,6 +2290,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.25.2':
     resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -7046,6 +7071,12 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -7448,6 +7479,10 @@ packages:
     resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -7584,6 +7619,10 @@ packages:
   ioredis@5.8.0:
     resolution: {integrity: sha512-AUXbKn9gvo9hHKvk6LbZJQSKn/qIfkWXrnsyL9Yrf+oeXmla9Nmf6XEumOddyhM8neynpK5oAV6r9r99KBuwzA==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -7794,6 +7833,10 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-to-zod@2.7.0:
     resolution: {integrity: sha512-eW59l3NQ6sa3HcB+Ahf7pP6iGU7MY4we5JsPqXQ2ZcIPF8QxSg/lkY8lN0Js/AG0NjMbk+nZGUfHlceiHF+bwQ==}
@@ -9801,6 +9844,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -10715,18 +10761,24 @@ snapshots:
 
   '@antfu/utils@9.2.1': {}
 
-  '@anthropic-ai/claude-agent-sdk@0.1.77(zod@4.1.11)':
+  '@anthropic-ai/claude-agent-sdk@0.2.112(zod@4.1.11)':
     dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@4.1.11)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.1.11)
       zod: 4.1.11
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
 
   '@anthropic-ai/sandbox-runtime@0.0.52':
     dependencies:
@@ -10735,6 +10787,12 @@ snapshots:
       node-forge: 1.4.0
       shell-quote: 1.8.4
       zod: 3.25.76
+
+  '@anthropic-ai/sdk@0.81.0(zod@4.1.11)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.1.11
 
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
@@ -12301,6 +12359,10 @@ snapshots:
     dependencies:
       hono: 4.11.3
 
+  '@hono/node-server@1.19.9(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.63.0(react@19.1.1))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -12336,63 +12398,66 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@img/sharp-darwin-arm64@0.33.5':
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.33.5':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.33.5':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.33.5':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
+  '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     optional: true
 
-  '@img/sharp-win32-x64@0.33.5':
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@inquirer/ansi@1.0.0': {}
@@ -12825,11 +12890,11 @@ snapshots:
       - openapi-types
       - supports-color
 
-  '@mastra/mcp@1.0.0-beta.10(@mastra/core@1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(hono@4.11.3)(zod@4.1.11)':
+  '@mastra/mcp@1.0.0-beta.10(@mastra/core@1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(hono@4.12.23)(zod@4.1.11)':
     dependencies:
       '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
       '@mastra/core': 1.0.0-beta.24(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.1.11))(zod@4.1.11))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.1.11))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.1.11)
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.1.11)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.23)(zod@4.1.11)
       exit-hook: 5.0.1
       fast-deep-equal: 3.1.3
       uuid: 13.0.0
@@ -12909,28 +12974,6 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.3)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.5
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.0
-      raw-body: 3.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - hono
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.3)
@@ -12951,6 +12994,72 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.1.11)
     transitivePeerDependencies:
       - hono
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.23)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - hono
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.23)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 4.1.11
+      zod-to-json-schema: 3.25.1(zod@4.1.11)
+    transitivePeerDependencies:
+      - hono
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.1.11)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.23)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.23
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 4.1.11
+      zod-to-json-schema: 3.25.1(zod@4.1.11)
+    transitivePeerDependencies:
       - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
@@ -13902,36 +14011,36 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@polar-sh/adapter-utils@0.2.6(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))':
+  '@polar-sh/adapter-utils@0.2.6(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))':
     dependencies:
-      '@polar-sh/sdk': 0.34.17(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))
+      '@polar-sh/sdk': 0.34.17(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
 
-  '@polar-sh/better-auth@1.1.4(@polar-sh/sdk@0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11)))(better-auth@1.3.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(solid-js@1.9.9))':
+  '@polar-sh/better-auth@1.1.4(@polar-sh/sdk@0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11)))(better-auth@1.3.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(solid-js@1.9.9))':
     dependencies:
-      '@polar-sh/sdk': 0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))
+      '@polar-sh/sdk': 0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))
       better-auth: 1.3.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(solid-js@1.9.9)
       zod: 3.25.76
 
-  '@polar-sh/sdk@0.34.17(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))':
+  '@polar-sh/sdk@0.34.17(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))':
     dependencies:
       standardwebhooks: 1.0.0
       zod: 3.25.76
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.1.11)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.23)(zod@4.1.11)
 
-  '@polar-sh/sdk@0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))':
+  '@polar-sh/sdk@0.35.2(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))':
     dependencies:
       standardwebhooks: 1.0.0
       zod: 3.25.76
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.1.11)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.23)(zod@4.1.11)
 
-  '@polar-sh/tanstack-start@0.1.8(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))(crossws@0.4.1(srvx@0.9.8))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))':
+  '@polar-sh/tanstack-start@0.1.8(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))(crossws@0.4.1(srvx@0.9.8))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
-      '@polar-sh/adapter-utils': 0.2.6(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))
-      '@polar-sh/sdk': 0.34.17(@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.11))
+      '@polar-sh/adapter-utils': 0.2.6(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))
+      '@polar-sh/sdk': 0.34.17(@modelcontextprotocol/sdk@1.25.2(hono@4.12.23)(zod@4.1.11))
       '@tanstack/react-start': 1.132.6(crossws@0.4.1(srvx@0.9.8))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -18078,6 +18187,11 @@ snapshots:
     dependencies:
       express: 5.2.1
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -18604,6 +18718,8 @@ snapshots:
 
   hono@4.11.3: {}
 
+  hono@4.12.23: {}
+
   hookable@5.5.3: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
@@ -18755,6 +18871,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -18925,6 +19043,11 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      ts-algebra: 2.0.0
 
   json-schema-to-zod@2.7.0: {}
 
@@ -20962,7 +21085,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.3.1(@types/node@24.5.2)(hono@4.11.3)(typescript@5.9.2):
+  shadcn@3.3.1(@types/node@24.5.2)(hono@4.12.23)(typescript@5.9.2):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.28.4
@@ -20970,7 +21093,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
       '@dotenvx/dotenvx': 1.50.1
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.23)(zod@3.25.76)
       browserslist: 4.26.2
       commander: 14.0.1
       cosmiconfig: 9.0.0(typescript@5.9.2)
@@ -21403,6 +21526,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:

--- a/src/claude/permissions.ts
+++ b/src/claude/permissions.ts
@@ -5,7 +5,6 @@ const PERMISSION_MODES: PermissionMode[] = [
   'plan',
   'dontAsk',
   'acceptEdits',
-  'delegate',
   'bypassPermissions',
 ];
 

--- a/src/claude/skills/schema-generator.ts
+++ b/src/claude/skills/schema-generator.ts
@@ -1121,7 +1121,7 @@ async function generateSchemaFromContentOnce(
         debugLog('Assistant event:', JSON.stringify(event).slice(0, 2000));
         traceLog('Assistant event raw', event);
 
-        const content = (event as { message?: { content?: Array<Record<string, unknown>> } }).message?.content;
+        const content = (event as unknown as { message?: { content?: Array<Record<string, unknown>> } }).message?.content;
         if (Array.isArray(content)) {
           for (const block of content) {
             // Check for StructuredOutput tool_use

--- a/src/claude/skills/template-generator.ts
+++ b/src/claude/skills/template-generator.ts
@@ -285,7 +285,7 @@ export async function generateTemplateFromSchema(
       }
 
       if (event.type === 'assistant') {
-        const content = (event as { message?: { content?: Array<Record<string, unknown>> } }).message?.content;
+        const content = (event as unknown as { message?: { content?: Array<Record<string, unknown>> } }).message?.content;
         if (Array.isArray(content)) {
           for (const block of content) {
             if (block?.type === 'text' && typeof block.text === 'string') {

--- a/src/components/claude-chat/permission-badge.tsx
+++ b/src/components/claude-chat/permission-badge.tsx
@@ -19,7 +19,6 @@ export type PermissionMode =
   | 'plan'
   | 'dontAsk'
   | 'acceptEdits'
-  | 'delegate'
   | 'bypassPermissions';
 
 // Permission info interface
@@ -73,15 +72,6 @@ const getModeDisplay = (mode: PermissionMode, bashEnabled: boolean) => {
         icon: ShieldCheckIcon,
         label: 'Accept Edits',
         description: '编辑模式：自动接受文件编辑',
-        color: 'text-muted-foreground',
-        bgColor: 'bg-muted',
-        borderColor: 'border-border',
-      };
-    case 'delegate':
-      return {
-        icon: ShieldCheckIcon,
-        label: 'Delegate',
-        description: '委托模式：允许委派任务',
         color: 'text-muted-foreground',
         bgColor: 'bg-muted',
         borderColor: 'border-border',
@@ -318,15 +308,6 @@ export const PermissionBadge: FC<PermissionBadgeProps> = ({ permissionInfo }) =>
                 <>
                   <p className="mb-2">🟣 <strong>Accept Edits 模式</strong></p>
                   <p className="mb-1">• 自动接受文件编辑</p>
-                  <p className="mb-1">• Bash 工具默认禁用</p>
-                  <p>• 路径级安全边界已启用</p>
-                </>
-              )}
-
-              {info.mode === 'delegate' && (
-                <>
-                  <p className="mb-2">🟪 <strong>Delegate 模式</strong></p>
-                  <p className="mb-1">• 允许委派任务执行</p>
                   <p className="mb-1">• Bash 工具默认禁用</p>
                   <p>• 路径级安全边界已启用</p>
                 </>

--- a/src/components/settings/sections/PermissionSettings.tsx
+++ b/src/components/settings/sections/PermissionSettings.tsx
@@ -42,7 +42,6 @@ const ALL_PERMISSION_MODES: PermissionMode[] = [
   'plan',
   'dontAsk',
   'acceptEdits',
-  'delegate',
   'bypassPermissions',
 ];
 
@@ -150,15 +149,6 @@ export function PermissionSettingsSection({
           color: 'text-indigo-600 dark:text-indigo-400',
           bgColor: 'bg-indigo-50 dark:bg-indigo-950',
           borderColor: 'border-indigo-200 dark:border-indigo-800',
-        };
-      case 'delegate':
-        return {
-          icon: ShieldCheckIcon,
-          label: toLocalizedString(content.permissionModes.delegate),
-          description: toLocalizedString(content.permissionModes.descDelegate),
-          color: 'text-purple-600 dark:text-purple-400',
-          bgColor: 'bg-purple-50 dark:bg-purple-950',
-          borderColor: 'border-purple-200 dark:border-purple-800',
         };
       case 'bypassPermissions':
         return {
@@ -270,17 +260,6 @@ export function PermissionSettingsSection({
                       <div className="font-medium">Accept Edits</div>
                       <div className="text-xs text-muted-foreground">
                         编辑模式，自动接受文件编辑
-                      </div>
-                    </div>
-                  </div>
-                </SelectItem>
-                <SelectItem value="delegate">
-                  <div className="flex items-center gap-2">
-                    <ShieldCheckIcon className="h-4 w-4 text-purple-600" />
-                    <div>
-                      <div className="font-medium">Delegate</div>
-                      <div className="text-xs text-muted-foreground">
-                        委托模式，允许委派任务
                       </div>
                     </div>
                   </div>

--- a/src/routes/api/auth/permission-info/route.tsx
+++ b/src/routes/api/auth/permission-info/route.tsx
@@ -11,7 +11,6 @@ const ALL_PERMISSION_MODES: PermissionMode[] = [
   'plan',
   'dontAsk',
   'acceptEdits',
-  'delegate',
   'bypassPermissions',
 ];
 

--- a/src/server/permissions.server.ts
+++ b/src/server/permissions.server.ts
@@ -23,7 +23,6 @@ const ALL_PERMISSION_MODES: PermissionMode[] = [
   'plan',
   'dontAsk',
   'acceptEdits',
-  'delegate',
   'bypassPermissions',
 ];
 
@@ -112,7 +111,7 @@ export const getPermissionInfo = createServerFn({ method: 'GET' })
       // Bypass mode requires admin role
       actualMode = isWhitelisted ? 'bypassPermissions' : 'default';
     } else {
-      // All other modes are used as-is (plan, dontAsk, acceptEdits, delegate, default)
+      // All other modes are used as-is (plan, dontAsk, acceptEdits, default)
       actualMode = permissionMode;
     }
 


### PR DESCRIPTION
## 目标
在**保证 ARK(火山)网关可用**的前提下,把 SDK 升到尽可能新的版本。

## 为什么是 0.2.112
- **0.2.113+ 改为 spawn 原生二进制**(不再用内置 `cli.js`),与 ARK 的 `/api/coding` 端点不兼容——实测会陷入 `api_retry` 无限重试(二进制能启动、认证识别正常,但每个模型请求被退回)。即便指向真实 `claude 2.1.160` 二进制、换 `ANTHROPIC_AUTH_TOKEN` 也一样。
- **0.2.112 是最后一个内置-JS 版本**,与我们现有 `cli.js` 嵌入方式 drop-in 兼容。

## 实测验证(0.2.112 + ARK)
- chat-like `query()`:**4/4 成功**;
- effortLevel 崩溃:**已消失**;
- 真实 skill 的 schema 生成:成功(5 个 inputs、`needsReview=false`);
- 本地:lint 0 error、unit **77/77**、production build ✓。

## 升级带来的必要改动
1. **移除 `delegate` 权限模式**(owner 拍板):新 SDK 的 `PermissionMode` 已不含它,且 tier 系统在 query 时已架空它。从权限设置 UI / badge / 后端模式列表移除;已存的 `delegate` 配置归一化为 `default`。涉及 `permissions.ts`、`permissions.server.ts`、`PermissionSettings.tsx`、`permission-badge.tsx`、`api/auth/permission-info`。
2. 修复两处 `SDKAssistantMessage.content` 的**纯类型** cast(经 `unknown` 转换,无运行时变化)——`schema-generator.ts`、`template-generator.ts`。

## 解锁(留待后续使用)
`startup()` 预热(首个 query ~20x)、Sessions API、MCP toggle/reconnect、`getContextUsage`、`taskBudget`、Opus 4.7 支持。

## 不包含
`skills` 选项(0.2.120)与 0.3.x 特性——它们在原生二进制区,需要"切原生二进制 + 离开 ARK"的独立迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)