### PR TITLE
feat(capabilities): 统一能力中心（Skills + MCP 分 tab）

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -20,8 +20,7 @@ import FileTextIcon from 'virtual:icons/ri/file-text-line';
 import FlowChartIcon from 'virtual:icons/ri/flow-chart';
 import HomeSmileIcon from 'virtual:icons/ri/home-smile-line';
 import SparklingIcon from 'virtual:icons/ri/sparkling-line';
-import SettingsIcon from 'virtual:icons/ri/settings-4-line';
-import PlugIcon from 'virtual:icons/ri/plug-line';
+import AppsIcon from 'virtual:icons/ri/apps-2-line';
 import ShieldIcon from 'virtual:icons/ri/shield-line';
 import { FEATURE_CONFIG } from '~/config/features';
 import { isAdminUser } from '~/server/function/skills.server';
@@ -57,16 +56,10 @@ export function AppSidebar({ user, ...props }: React.ComponentProps<typeof Sideb
           enabled: FEATURE_CONFIG.claudeChat,
         },
         {
-          title: content.nav.skillsStore,
-          url: '/agents/skills',
-          icon: SettingsIcon,
-          enabled: FEATURE_CONFIG.skills,
-        },
-        {
-          title: content.nav.mcpStore,
-          url: '/agents/mcp',
-          icon: PlugIcon,
-          enabled: FEATURE_CONFIG.mcpStore,
+          title: content.nav.capabilityCenter,
+          url: '/agents/capabilities',
+          icon: AppsIcon,
+          enabled: FEATURE_CONFIG.skills || FEATURE_CONFIG.mcpStore,
         },
       ],
       hasDivider: true,

--- a/src/contents/app.content.ts
+++ b/src/contents/app.content.ts
@@ -16,6 +16,14 @@ const appContent = {
         ko: 'Claude Chat',
         'zh-Hant': 'Claude Chat',
       }),
+      capabilityCenter: t({
+        en: 'Capability Center',
+        'zh-Hans': '能力中心',
+        fr: 'Centre de capacités',
+        ja: '機能センター',
+        ko: '기능 센터',
+        'zh-Hant': '能力中心',
+      }),
       skillsStore: t({
         en: 'Skills Store',
         'zh-Hans': '技能商店',

--- a/src/routes/agents/capabilities/route.tsx
+++ b/src/routes/agents/capabilities/route.tsx
@@ -1,0 +1,119 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useIntlayer } from 'react-intlayer';
+import { useState } from 'react';
+import { listAllSkillsFn, isAdminUser } from '~/server/function/skills.server';
+import { listAllMcpsFn } from '~/server/function/mcp.server';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { SkillsPageComponent } from '~/components/skills/skills-page';
+import { SkillUploadDialog } from '~/components/skills/skill-upload-dialog';
+import { GitHubSkillInstaller } from '~/components/skills/github-skill-installer';
+import { McpPageComponent } from '~/components/mcp/mcp-page';
+import type { ExtendedSkillInfo } from '~/claude/skills';
+import type { ExtendedMcpInfo } from '~/claude/mcp';
+
+/**
+ * Capability Center — unified discovery/management surface for Skills + MCP.
+ *
+ * Folds the former standalone `/agents/skills` and `/agents/mcp` pages into a
+ * single tabbed center (Skills / MCP), per the product decision to unify the
+ * *discovery/UI layer* while keeping each capability's runtime model distinct
+ * (Skills = filesystem-scanned; MCP = SDK-managed connections).
+ * See docs/project/prd/2026-06-mcp-capability-center-prd.md (§5).
+ *
+ * The old routes redirect here with the matching tab preselected.
+ */
+type CapabilityTab = 'skills' | 'mcp';
+
+export const Route = createFileRoute('/agents/capabilities')({
+  validateSearch: (search: Record<string, unknown>): { tab: CapabilityTab } => ({
+    tab: search.tab === 'mcp' ? 'mcp' : 'skills',
+  }),
+  loader: async () => {
+    const [skillsResult, mcpResult, adminCheck] = await Promise.all([
+      listAllSkillsFn(),
+      listAllMcpsFn(),
+      isAdminUser(),
+    ]);
+
+    const allSkills: ExtendedSkillInfo[] = [
+      ...skillsResult.official,
+      ...skillsResult.user,
+    ];
+
+    const officialMcps = mcpResult.official || [];
+    const systemMcps = mcpResult.system || [];
+    const userMcps = mcpResult.user || [];
+    const allMcps: ExtendedMcpInfo[] = [...officialMcps, ...systemMcps, ...userMcps];
+
+    return {
+      allSkills,
+      isAdmin: adminCheck.isAdmin ?? false,
+      officialMcps,
+      systemMcps,
+      userMcps,
+      allMcps,
+    };
+  },
+  component: CapabilityCenter,
+});
+
+function CapabilityCenter() {
+  const { allSkills, isAdmin, officialMcps, systemMcps, userMcps, allMcps } =
+    Route.useLoaderData();
+  const { tab } = Route.useSearch();
+  const content = useIntlayer('app');
+
+  const [activeTab, setActiveTab] = useState<string>(tab);
+  const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
+  const [isGitHubInstallOpen, setIsGitHubInstallOpen] = useState(false);
+
+  const enabledSkills = allSkills.filter((s) => s.enabled).map((s) => s.slug);
+  const enabledMcps = allMcps.filter((m) => m.enabled).map((m) => m.slug);
+
+  const handleSkillUploadSuccess = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className="container mx-auto max-w-6xl px-6 py-8">
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="skills">{content.nav.skillsStore}</TabsTrigger>
+          <TabsTrigger value="mcp">{content.nav.mcpStore}</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="skills" className="mt-6">
+          <SkillsPageComponent
+            skills={allSkills}
+            enabledSkills={enabledSkills}
+            isAdmin={isAdmin}
+            onNewSkill={() => setIsUploadDialogOpen(true)}
+          />
+        </TabsContent>
+
+        <TabsContent value="mcp" className="mt-6">
+          <McpPageComponent
+            mcps={officialMcps}
+            systemMcps={systemMcps}
+            userMcps={userMcps}
+            enabledMcps={enabledMcps}
+          />
+        </TabsContent>
+      </Tabs>
+
+      {/* Skill dialogs (preserved from the former /agents/skills route) */}
+      <SkillUploadDialog
+        open={isUploadDialogOpen}
+        onOpenChange={setIsUploadDialogOpen}
+        onSuccess={handleSkillUploadSuccess}
+      />
+      {isAdmin && (
+        <GitHubSkillInstaller
+          open={isGitHubInstallOpen}
+          onOpenChange={setIsGitHubInstallOpen}
+          onSuccess={handleSkillUploadSuccess}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/routes/agents/mcp/route.tsx
+++ b/src/routes/agents/mcp/route.tsx
@@ -1,46 +1,11 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { listAllMcpsFn } from '~/server/function/mcp.server';
-import { McpPageComponent } from '~/components/mcp/mcp-page';
-import type { ExtendedMcpInfo } from '~/claude/mcp';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 /**
- * MCP Management Route - New List-Based Design
- *
- * Displays all MCPs in two groups: Installed and Recommended
- * - Installed: MCPs that the user has enabled
- * - Recommended: All other available MCPs
- *
- * Custom MCPs (system or personal) can be deleted.
- * Official MCPs cannot be deleted.
+ * Legacy route — MCP moved into the unified Capability Center.
+ * Redirect to /agents/capabilities with the MCP tab preselected.
  */
 export const Route = createFileRoute('/agents/mcp')({
-  loader: async () => {
-    const result = await listAllMcpsFn();
-    const official = result.official || [];
-    const system = result.system || [];
-    const user = result.user || [];
-    const allMcps: ExtendedMcpInfo[] = [...official, ...system, ...user];
-
-    return {
-      officialMcps: official,
-      systemMcps: system,
-      userMcps: user,
-      allMcps,
-    };
-  },
-  component: () => {
-    const { officialMcps, systemMcps, userMcps, allMcps } = Route.useLoaderData();
-    const enabledMcps = allMcps.filter((mcp) => mcp.enabled).map((mcp) => mcp.slug);
-
-    return (
-      <div className="container mx-auto px-6 py-8 max-w-6xl">
-        <McpPageComponent
-          mcps={officialMcps}
-          systemMcps={systemMcps}
-          userMcps={userMcps}
-          enabledMcps={enabledMcps}
-        />
-      </div>
-    );
+  beforeLoad: () => {
+    throw redirect({ to: '/agents/capabilities', search: { tab: 'mcp' } });
   },
 });

--- a/src/routes/agents/skills/route.tsx
+++ b/src/routes/agents/skills/route.tsx
@@ -1,81 +1,11 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { useIntlayer } from 'react-intlayer';
-import { listAllSkillsFn, isAdminUser } from '~/server/function/skills.server';
-import { SkillsPageComponent } from '~/components/skills/skills-page';
-import { SkillUploadDialog } from '~/components/skills/skill-upload-dialog';
-import { GitHubSkillInstaller } from '~/components/skills/github-skill-installer';
-import type { ExtendedSkillInfo } from '~/claude/skills';
-import { useState } from 'react';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 /**
- * Skills Management Route - New List-Based Design
- *
- * Displays all skills in two groups: Installed and Recommended
- * - Installed: Skills that the user has enabled
- * - Recommended: All other available skills
- *
- * Only user-uploaded skills can be deleted.
- * GitHub-installed and official skills cannot be deleted by regular users.
+ * Legacy route — Skills moved into the unified Capability Center.
+ * Redirect to /agents/capabilities with the Skills tab preselected.
  */
 export const Route = createFileRoute('/agents/skills')({
-  loader: async () => {
-    const [result, adminCheck] = await Promise.all([
-      listAllSkillsFn(),
-      isAdminUser(),
-    ]);
-
-    // Merge official and user skills into a single list
-    const allSkills: ExtendedSkillInfo[] = [
-      ...result.official,
-      ...result.user,
-    ];
-
-    return {
-      allSkills,
-      isAdmin: adminCheck.isAdmin ?? false,
-    };
-  },
-  component: () => {
-    const { allSkills, isAdmin } = Route.useLoaderData();
-    const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
-    const [isGitHubInstallOpen, setIsGitHubInstallOpen] = useState(false);
-
-    // Get enabled skills
-    const enabledSkills = allSkills.filter((s) => s.enabled).map((s) => s.slug);
-
-    const handleUploadSuccess = () => {
-      window.location.reload();
-    };
-
-    const handleNewSkill = () => {
-      setIsUploadDialogOpen(true);
-    };
-
-    return (
-      <div className="container mx-auto px-6 py-8 max-w-6xl">
-        <SkillsPageComponent
-          skills={allSkills}
-          enabledSkills={enabledSkills}
-          isAdmin={isAdmin}
-          onNewSkill={handleNewSkill}
-        />
-
-        {/* Upload Dialog */}
-        <SkillUploadDialog
-          open={isUploadDialogOpen}
-          onOpenChange={setIsUploadDialogOpen}
-          onSuccess={handleUploadSuccess}
-        />
-
-        {/* GitHub Install Dialog - Admin Only */}
-        {isAdmin && (
-          <GitHubSkillInstaller
-            open={isGitHubInstallOpen}
-            onOpenChange={setIsGitHubInstallOpen}
-            onSuccess={handleUploadSuccess}
-          />
-        )}
-      </div>
-    );
+  beforeLoad: () => {
+    throw redirect({ to: '/agents/capabilities', search: { tab: 'skills' } });
   },
 });


### PR DESCRIPTION
## 目标（MCP PRD P0 · 收口）
把独立的 `/agents/skills` 与 `/agents/mcp` 收口进**一个统一能力中心** `/agents/capabilities`（Skills / MCP 分 tab）——对齐「统一发现/UI 层、运行时模型各自独立」的决策。这也把"能力中心"的壳立起来，Skills 后续工作也在此承载。

## 改动
- **新路由 `/agents/capabilities`**：分 tab 外壳（技能/MCP），内嵌现有 `SkillsPageComponent` + `McpPageComponent`（两者本就 props-only、无页面外壳）。合并 loader（`listAllSkillsFn` + `listAllMcpsFn` + `isAdminUser`），保留技能上传 / GitHub 安装弹窗。
- **`tab` 搜索参数**（`validateSearch`）选择初始 tab。
- **导航收口**：侧栏两个入口（Skills Store + MCP Store）合并为单个「能力中心」（AppsIcon），任一 feature 开启即显示。
- **旧路由改重定向**：`/agents/skills → ?tab=skills`、`/agents/mcp → ?tab=mcp`（保住书签/外链）。
- **i18n**：新增 `nav.capabilityCenter`（6 语言）。

## 验证（已登录真机）
- 能力中心渲染两个 tab，均带真实数据（技能 7 个、MCP python/glm-image/zhipu… 等）；
- 两个旧路由经登录流程后都落到正确的 tab；
- tab 切换正常（Radix automatic 激活；探针里"点击不切换"是无头环境不聚焦的假象，真实点击聚焦即切换）；
- `pnpm build` ✓、`pnpm lint` 0 error。

## 范围
纯前端结构收口；未改后端 / MCP 运行时 / composer。后续 P0 轻护栏（关键 env 保护、stdio 警示、URL scheme 校验）与 P1（SDK 运行时状态）另行提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)