### PR TITLE
fix(chat): 切走再回来历史空白 —— 恢复对话历史

### DIFF
--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -247,14 +247,27 @@ function RouteComponent() {
     return unsubscribe;
   }, [loadHistoricalMessages]);
 
-  // Sync with adapter's session ID on mount
+  // Sync with adapter's session ID on mount, and re-hydrate history.
+  // The adapter keeps the session id across SPA navigation (module-level), but the
+  // assistant-ui thread is ephemeral and resets when this route remounts (e.g. after
+  // navigating to the Capability Center and back). So on mount, if a session was
+  // already active, resume it to reload the conversation — otherwise the user returns
+  // to an empty page even though the session is still "selected".
   useEffect(() => {
     const sessionId = getSessionId();
     if (sessionId) {
       setCurrentSessionId(sessionId);
       setSessionId(sessionId);
+      if (!checkIsQueryRunning()) {
+        clearMessages();
+        resumeSession(sessionId).catch((error) => {
+          console.error('[Route] Failed to resume restored session on mount:', error);
+        });
+      }
     }
-  }, [setSessionId]);
+    // Run once on mount; setSessionId/clearMessages are stable store actions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setSessionId, clearMessages]);
 
   // Listen for session init events to keep route state in sync with adapter
   useEffect(() => {

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -78,7 +78,12 @@ console.log(
 function resolveSessionsRoot() {
   const envRoot = process.env.CLAUDE_SESSIONS_ROOT;
   if (envRoot && envRoot.trim()) {
-    return envRoot;
+    // IMPORTANT: resolve to an ABSOLUTE path. A relative value (e.g. "./user-data")
+    // would resolve differently for the ws-server (cwd = repo root) vs the worker
+    // (cwd = per-session workspace), so the SDK would write the transcript under the
+    // workspace while resume looks for it under the repo root → "Session file not
+    // found" → conversation history fails to reload. Absolute = both agree.
+    return path.resolve(envRoot.trim());
   }
   // Check for Docker production path
   const dockerPath = '/data/users';
@@ -90,6 +95,10 @@ function resolveSessionsRoot() {
 }
 
 const SESSIONS_ROOT = resolveSessionsRoot();
+// Normalize the env var to the resolved ABSOLUTE path so spawned workers (which
+// inherit process.env) and the skills/mcp managers (which read CLAUDE_SESSIONS_ROOT)
+// all resolve to the same location regardless of their cwd.
+process.env.CLAUDE_SESSIONS_ROOT = SESSIONS_ROOT;
 console.log('[WS Server] Sessions root:', SESSIONS_ROOT);
 
 const config = {
@@ -427,7 +436,8 @@ async function loadSessionFromDb(cookie, workspaceSessionId) {
  * JSONL files are stored at: CLAUDE_HOME/.claude/projects/{project}/{sessionId}.jsonl
  */
 async function locateSessionFile(claudeHome, sessionId) {
-  const projectsRoot = path.join(claudeHome, '.claude', 'projects');
+  // Resolve to absolute in case a legacy session stored a relative claude_home_path.
+  const projectsRoot = path.join(path.resolve(claudeHome), '.claude', 'projects');
 
   try {
     await access(projectsRoot);


### PR DESCRIPTION
## 修复的 bug
在某对话聊完 → 切到别的页面(如能力中心)→ 返回聊天 → **历史空白页**(会话仍显示"已选中")。

## 两个耦合根因 + 修法
1. **resume 找不到 SDK transcript**(`ws-server.mjs`):`CLAUDE_SESSIONS_ROOT="./user-data"` 是**相对路径**,worker(cwd=会话 workspace)和 ws-server(cwd=仓库根)解析到不同绝对位置 → SDK 把 transcript 写在 workspace 内层,而 resume 在仓库根下找 → "Session file not found"。**修法**:`resolveSessionsRoot()` 用 `path.resolve()` 绝对化 + 归一化 `process.env.CLAUDE_SESSIONS_ROOT`(让 worker 与 skills/mcp managers 一致);`locateSessionFile()` 也对 legacy 相对 claudeHome 做 resolve。**(本地 dev 专属;生产用绝对 `/data/users`,不受影响。)**
2. **remount 不重拉历史**(`route.tsx`):assistant-ui thread 随路由 remount 清空,但挂载时没有重新触发 resume。**修法**:挂载时恢复 session id 的 effect 现在**顺带 resume**(无运行中查询时),历史自动重载。

## 验证(真机)
- 新会话 transcript 现在写到**正确的绝对位置**(`user-data/<user>/.claude/projects/…`,不再嵌套);
- 能力中心 ↔ 聊天来回切 → 对话**自动恢复**(无需手点),截图确认 `请只回复两个字：测试 / 测试` 完整显示。
- `pnpm build` ✓、`pnpm lint` 0 error。本地 unit 因 **node 版本环境问题**(本机 node 20,项目要求 22.12,某 ESM-only 依赖 require 失败)无法跑,**与本改动无关**(stash 掉改动后 main 同样报错);CI 跑 22.12。

## 范围
`ws-server.mjs`(会话路径绝对化)+ `src/routes/agents/claude-chat/route.tsx`(挂载时自动 resume)。即"治标"路线;治本(自有 DB 消息存储)与 Workspace 概念已记入 backlog。

🤖 Generated with [Claude Code](https://claude.com/claude-code)