### PR TITLE
feat(mcp): P1 — 能力中心 MCP 连接状态徽章

### DIFF
--- a/src/components/mcp/mcp-list-item.tsx
+++ b/src/components/mcp/mcp-list-item.tsx
@@ -8,6 +8,8 @@ import type { ExtendedMcpInfo } from '~/claude/mcp';
 import { toLocalizedString } from '~/lib/utils';
 import { cn } from '~/lib/utils';
 
+export type McpVerifyResult = { ok: boolean; message?: string };
+
 interface McpListItemProps {
   mcp: ExtendedMcpInfo;
   isEnabled: boolean;
@@ -17,6 +19,8 @@ interface McpListItemProps {
   onDelete?: () => void;
   verifying?: boolean;
   deleting?: boolean;
+  /** Last on-demand connection test result (P1: status badge in the capability center). */
+  verifyResult?: McpVerifyResult;
 }
 
 export const McpListItem: FC<McpListItemProps> = ({
@@ -28,6 +32,7 @@ export const McpListItem: FC<McpListItemProps> = ({
   onDelete,
   verifying,
   deleting,
+  verifyResult,
 }) => {
   const content = useIntlayer('mcp');
 
@@ -51,6 +56,19 @@ export const McpListItem: FC<McpListItemProps> = ({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <h3 className="font-medium text-sm truncate">{mcp.name}</h3>
+          {verifyResult && (
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 shrink-0 text-xs',
+                verifyResult.ok ? 'text-green-600 dark:text-green-500' : 'text-destructive'
+              )}
+              title={verifyResult.message
+                || toLocalizedString(verifyResult.ok ? content.verify.success : content.verify.failed)}
+            >
+              <span className={cn('h-2 w-2 rounded-full', verifyResult.ok ? 'bg-green-500' : 'bg-destructive')} />
+              {toLocalizedString(verifyResult.ok ? content.verify.connectedShort : content.verify.failedShort)}
+            </span>
+          )}
           {isSystem && (
             <Badge variant="secondary" className="text-xs bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
               <Globe className="mr-1 h-3 w-3" />

--- a/src/components/mcp/mcp-page.tsx
+++ b/src/components/mcp/mcp-page.tsx
@@ -50,6 +50,7 @@ export const McpPageComponent: FC<{
   const [userMcps, setUserMcps] = useState<ExtendedMcpInfo[]>(() => initialUserMcps || []);
   const [enabledMcps, setEnabledMcps] = useState<string[]>(() => initialEnabled || []);
   const [verifyingSlug, setVerifyingSlug] = useState<string | null>(null);
+  const [verifyResults, setVerifyResults] = useState<Record<string, { ok: boolean; message?: string }>>({});
   const [deletingSlug, setDeletingSlug] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -116,18 +117,19 @@ export const McpPageComponent: FC<{
     try {
       setVerifyingSlug(slug);
       const result = await verifyMcp({ data: { slug } });
-      if (result.ok) {
-        alert(toLocalizedString(content.verify.success));
-      } else {
-        const detail = result.message
-          || (result.details ? JSON.stringify(result.details, null, 2) : '')
-          || result.stderr
-          || '';
-        alert(`${toLocalizedString(content.verify.failed)} ${detail}`.trim());
-      }
+      const message = result.ok
+        ? (result.message || undefined)
+        : (result.message
+            || (result.details ? JSON.stringify(result.details, null, 2) : '')
+            || result.stderr
+            || undefined);
+      setVerifyResults((prev) => ({ ...prev, [slug]: { ok: !!result.ok, message } }));
     } catch (error) {
       console.error('Failed to verify MCP:', error);
-      alert(toLocalizedString(content.verify.genericFailed));
+      setVerifyResults((prev) => ({
+        ...prev,
+        [slug]: { ok: false, message: toLocalizedString(content.verify.genericFailed) },
+      }));
     } finally {
       setVerifyingSlug(null);
     }
@@ -241,6 +243,7 @@ export const McpPageComponent: FC<{
                   onDelete={mcp.store !== 'official' ? () => handleDeleteCustomMcp(mcp.slug) : undefined}
                   verifying={verifyingSlug === mcp.slug}
                   deleting={deletingSlug === mcp.slug}
+                  verifyResult={verifyResults[mcp.slug]}
                 />
               ))}
             </div>
@@ -265,6 +268,7 @@ export const McpPageComponent: FC<{
                   onDelete={mcp.store !== 'official' ? () => handleDeleteCustomMcp(mcp.slug) : undefined}
                   verifying={verifyingSlug === mcp.slug}
                   deleting={deletingSlug === mcp.slug}
+                  verifyResult={verifyResults[mcp.slug]}
                 />
               ))}
             </div>

--- a/src/contents/mcp.content.ts
+++ b/src/contents/mcp.content.ts
@@ -73,6 +73,8 @@ const mcpContent = {
       success: t({ en: 'MCP verified successfully.', 'zh-Hans': 'MCP 验证成功。', fr: 'MCP vérifié avec succès.', ja: 'MCP の検証に成功しました。', ko: 'MCP 검증 성공.', 'zh-Hant': 'MCP 驗證成功。' }),
       failed: t({ en: 'MCP verification failed.', 'zh-Hans': 'MCP 验证失败。', fr: 'Échec de la vérification MCP.', ja: 'MCP の検証に失敗しました。', ko: 'MCP 검증 실패.', 'zh-Hant': 'MCP 驗證失敗。' }),
       genericFailed: t({ en: 'MCP verification failed.', 'zh-Hans': 'MCP 验证失败。', fr: 'Échec de la vérification MCP.', ja: 'MCP の検証に失敗しました。', ko: 'MCP 검증 실패.', 'zh-Hant': 'MCP 驗證失敗。' }),
+      connectedShort: t({ en: 'Connected', 'zh-Hans': '已连接', fr: 'Connecté', ja: '接続済み', ko: '연결됨', 'zh-Hant': '已連接' }),
+      failedShort: t({ en: 'Failed', 'zh-Hans': '连接失败', fr: 'Échec', ja: '失敗', ko: '실패', 'zh-Hant': '連接失敗' }),
     },
 
     // Delete messages


### PR DESCRIPTION
## 目标(MCP P1 · 架构适配版,owner 拍板)
在**能力中心**给每个 MCP 显示**连接状态徽章**,用**请求-响应**方式(按需 verify),而非 SDK 的 query-绑定运行时方法——后者只在"一轮对话进行中"存在,与 per-message worker 模型不兼容。

## 改动
- `mcp-page`:每张卡的 **Verify** 现在把结果**持久化**(按 slug 存),替代原来的 `alert()`。
- `mcp-list-item`:名字旁渲染**连接状态 pill**——绿 ● Connected / 红 ● Failed,verify 的 message 作 tooltip。**Verify = 按需"测试/重连"**。
- i18n:`connectedShort` / `failedShort` 短标签。

## 不包含(架构限制,已延后)
- mid-turn 真实 reconnect/toggle(经 Query 对象)——需要每会话持久 worker(大改造)。
- 注:**热启停已生效**(下一条消息读启用集);**会话进行中的实时状态**已由 chat 面板(`McpStatusPopover`/`SessionInfoPanel`,来自 `system.init`)展示。

## 验证
真机:在 MCP Store 对 glm-image 点 Verify → 显示 **● Connected**(截图确认)。`pnpm build` ✓、`pnpm lint` 0 error。

## 范围
`mcp-list-item.tsx` + `mcp-page.tsx` + `mcp.content.ts`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)