### PR TITLE
feat(skills): S1b — fetch SKILL.md from skills-api into content cache + detail dialog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,10 @@ MCP_STORE_DIR="src/mcp-store"
 # SKILLS_STORE_SEED_MODE="skip"
 # A2Composer store (optional). Defaults to SKILLS_STORE_DIR/.a2composer
 # A2COMPOSER_STORE_DIR="/data/skills-store/.a2composer"
+# Upstream skills-api (curated catalog content source; public reads need no key)
+# Default: https://skills-api.deeptoai.com — override to point at your own deployment
+# SKILLS_API_URL="https://skills-api.deeptoai.com"
+# SKILLS_API_KEY=""  # optional x-api-key; only gates /api/admin/*, not content reads
 
 # Python runner limits for MCP execution (optional).
 PYTHON_RUNNER_TIMEOUT_MS="10000"

--- a/src/claude/skills/skills-api-client.ts
+++ b/src/claude/skills/skills-api-client.ts
@@ -1,0 +1,97 @@
+/**
+ * skills-api client (server-only)
+ *
+ * Thin client for the upstream skills-api registry (Hono service, ~9,600
+ * scraped GitHub skills). Used to fetch SKILL.md content on demand for catalog
+ * entries that reference an upstream skill. Public reads need no key; the
+ * optional SKILLS_API_KEY only gates /api/admin/*.
+ *
+ * Config:
+ *   SKILLS_API_URL  — base URL (default: https://skills-api.deeptoai.com)
+ *   SKILLS_API_KEY  — optional x-api-key (not needed for content reads)
+ *
+ * See docs/project/prd/2026-06-skills-integration-prd.md (§1, §8, S1b).
+ */
+
+import type { SkillUpstreamRef } from '~/db/schema/skill-catalog.schema';
+
+const DEFAULT_SKILLS_API_URL = 'https://skills-api.deeptoai.com';
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Resolve the skills-api base URL (trailing slashes trimmed). */
+export function getSkillsApiBaseUrl(): string {
+  const raw = process.env.SKILLS_API_URL?.trim() || DEFAULT_SKILLS_API_URL;
+  return raw.replace(/\/+$/, '');
+}
+
+/** Response shape of GET /api/skills/:owner/:repo/:skillId/content */
+export interface SkillsApiContent {
+  source: string;
+  skillId: string;
+  path: string;
+  // Frontmatter parsed from SKILL.md (name/description/…)
+  metadata: Record<string, unknown> | null;
+  // SKILL.md body (frontmatter stripped)
+  instructions: string | null;
+  // Full raw SKILL.md (frontmatter + body)
+  raw: string | null;
+}
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { accept: 'application/json' };
+  const key = process.env.SKILLS_API_KEY?.trim();
+  if (key) headers['x-api-key'] = key;
+  return headers;
+}
+
+/**
+ * Fetch the full SKILL.md content for an upstream skill reference.
+ * Throws on network error / non-2xx so callers can surface a clear status.
+ */
+export async function fetchSkillContent(
+  ref: SkillUpstreamRef,
+  opts?: { branch?: string },
+): Promise<SkillsApiContent> {
+  const base = getSkillsApiBaseUrl();
+  const { owner, repo, skillId } = ref;
+  const path = `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(skillId)}`;
+  const query = opts?.branch ? `?branch=${encodeURIComponent(opts.branch)}` : '';
+  const url = `${base}/api/skills/${path}/content${query}`;
+
+  const res = await fetch(url, {
+    headers: buildHeaders(),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`skills-api content fetch failed (${res.status}): ${body.slice(0, 200)}`);
+  }
+
+  return (await res.json()) as SkillsApiContent;
+}
+
+/**
+ * Split a raw SKILL.md into frontmatter (simple key: value) + body.
+ * Used so cache-hits (which only store the raw text) render the same way as
+ * fresh fetches. Not a full YAML parser — SKILL.md frontmatter is flat.
+ */
+export function parseSkillMarkdown(raw: string | null | undefined): {
+  metadata: Record<string, string>;
+  body: string;
+} {
+  if (!raw) return { metadata: {}, body: '' };
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { metadata: {}, body: raw };
+  const metadata: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx > 0) {
+      metadata[line.slice(0, idx).trim()] = line
+        .slice(idx + 1)
+        .trim()
+        .replace(/^["']|["']$/g, '');
+    }
+  }
+  return { metadata, body: match[2] };
+}

--- a/src/components/skills/curated-skill-detail-dialog.tsx
+++ b/src/components/skills/curated-skill-detail-dialog.tsx
@@ -1,0 +1,142 @@
+import { FC, ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+import ReactMarkdown from 'react-markdown';
+import { markdownComponents, markdownRemarkPlugins } from '~/components/claude-chat/markdown-components';
+import { Loader2, ExternalLink, AlertCircle } from 'lucide-react';
+import { useIntlayer } from 'react-intlayer';
+import { toLocalizedString } from '~/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { Badge } from '~/components/ui/badge';
+import { ScrollArea } from '~/components/ui/scroll-area';
+import { getCuratedSkillDetailFn } from '~/server/function/skills.server';
+
+/**
+ * Curated Skill Detail Dialog (Skills S1b) — read-only.
+ *
+ * Lazily fetches a curated skill's editorial fields + SKILL.md content
+ * (cache-first from skill_content_cache, else fetched from skills-api and
+ * cached server-side). No enable/run yet (S2).
+ */
+export const CuratedSkillDetailDialog: FC<{
+  slug: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}> = ({ slug, isOpen, onClose }) => {
+  const content = useIntlayer('skills');
+  const getDetail = useServerFn(getCuratedSkillDetailFn);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['curated-skill-detail', slug],
+    queryFn: async () => {
+      if (!slug) return null;
+      return await getDetail({ data: { slug } });
+    },
+    enabled: !!slug && isOpen,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const c = content.curated;
+  const d = c.detail;
+
+  const editorialBlocks: Array<{ label: ReactNode; value: string | null }> = data
+    ? [
+        { label: d.suitableFor, value: data.suitableForZh },
+        { label: d.problem, value: data.problemZh },
+        { label: d.firstTask, value: data.firstTaskZh },
+        { label: d.riskNotes, value: data.riskNotesZh },
+      ]
+    : [];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="text-2xl leading-none" aria-hidden>
+              {data?.iconEmoji || '🧩'}
+            </span>
+            <span>{data?.titleZh || data?.name || slug}</span>
+            {data?.level && (
+              <Badge variant="outline" className="text-[10px]">
+                {data.level}
+              </Badge>
+            )}
+          </DialogTitle>
+          {data?.summaryZh && <DialogDescription>{data.summaryZh}</DialogDescription>}
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[65vh] pr-4">
+          {/* Meta row */}
+          {data && (
+            <div className="mb-4 flex flex-wrap items-center gap-1.5">
+              {data.category && (
+                <Badge variant="secondary" className="text-[10px]">
+                  {data.category}
+                </Badge>
+              )}
+              {data.tags.map((tag) => (
+                <Badge key={tag} variant="outline" className="text-[10px]">
+                  {tag}
+                </Badge>
+              ))}
+              {data.githubUrl && (
+                <a
+                  href={data.githubUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {data.sourceLabel || toLocalizedString(c.viewOnGithub)}
+                </a>
+              )}
+            </div>
+          )}
+
+          {/* Editorial blocks */}
+          {editorialBlocks.some((b) => b.value) && (
+            <div className="mb-5 grid gap-3 rounded-lg border bg-muted/30 p-4 sm:grid-cols-2">
+              {editorialBlocks
+                .filter((b) => b.value)
+                .map((b, i) => (
+                  <div key={i}>
+                    <p className="mb-0.5 text-xs font-medium text-muted-foreground">{b.label}</p>
+                    <p className="text-sm">{b.value}</p>
+                  </div>
+                ))}
+            </div>
+          )}
+
+          {/* SKILL.md content */}
+          <div>
+            <p className="mb-2 text-xs font-medium text-muted-foreground">{d.instructions}</p>
+            {isLoading ? (
+              <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {d.loading}
+              </div>
+            ) : data?.instructions ? (
+              <div className="space-y-2 text-sm leading-relaxed">
+                <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+                  {data.instructions}
+                </ReactMarkdown>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                <AlertCircle className="h-4 w-4" />
+                {data?.contentStatus === 'no_upstream' ? d.noUpstream : d.contentUnavailable}
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/skills/curated-skills-section.tsx
+++ b/src/components/skills/curated-skills-section.tsx
@@ -6,6 +6,7 @@ import { Input } from '~/components/ui/input';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import type { CuratedSkillItem } from '~/server/function/skills.server';
+import { CuratedSkillDetailDialog } from './curated-skill-detail-dialog';
 
 /**
  * Curated Skills Section — read-only browse of the DB-backed curated catalog
@@ -31,6 +32,7 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
   const content = useIntlayer('skills');
   const [searchQuery, setSearchQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [detailSlug, setDetailSlug] = useState<string | null>(null);
 
   const categoryLabel = (key: string | null): string => {
     if (!key) return key ?? '';
@@ -117,7 +119,16 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
           {filtered.map((skill) => (
             <div
               key={skill.slug}
-              className="flex flex-col rounded-lg border bg-card p-4 transition-colors hover:border-primary/50"
+              role="button"
+              tabIndex={0}
+              onClick={() => setDetailSlug(skill.slug)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setDetailSlug(skill.slug);
+                }
+              }}
+              className="flex cursor-pointer flex-col rounded-lg border bg-card p-4 text-left transition-colors hover:border-primary/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
             >
               <div className="mb-2 flex items-start gap-2">
                 <span className="text-2xl leading-none" aria-hidden>
@@ -158,6 +169,7 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
                     href={skill.githubUrl}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
                     className="ml-auto inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
                     title={toLocalizedString(content.curated.viewOnGithub)}
                   >
@@ -170,6 +182,12 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
           ))}
         </div>
       )}
+
+      <CuratedSkillDetailDialog
+        slug={detailSlug}
+        isOpen={detailSlug !== null}
+        onClose={() => setDetailSlug(null)}
+      />
     </section>
   );
 };

--- a/src/contents/skills.content.ts
+++ b/src/contents/skills.content.ts
@@ -70,7 +70,20 @@ const skillsContent = {
       searchPlaceholder: t({ en: 'Search curated skills...', 'zh-Hans': '搜索精选技能...', fr: 'Rechercher...', ja: '厳選スキルを検索...', ko: '엄선 스킬 검색...', 'zh-Hant': '搜尋精選技能...' }),
       allCategories: t({ en: 'All', 'zh-Hans': '全部', fr: 'Tous', ja: 'すべて', ko: '전체', 'zh-Hant': '全部' }),
       viewOnGithub: t({ en: 'View on GitHub', 'zh-Hans': '在 GitHub 查看', fr: 'Voir sur GitHub', ja: 'GitHub で見る', ko: 'GitHub에서 보기', 'zh-Hant': '在 GitHub 檢視' }),
+      viewDetails: t({ en: 'Details', 'zh-Hans': '详情', fr: 'Détails', ja: '詳細', ko: '상세', 'zh-Hant': '詳情' }),
       empty: t({ en: 'No curated skills match your filters', 'zh-Hans': '没有符合条件的精选技能', fr: 'Aucun skill ne correspond', ja: '条件に合う厳選スキルがありません', ko: '조건에 맞는 엄선 스킬이 없습니다', 'zh-Hant': '沒有符合條件的精選技能' }),
+      // Detail dialog (S1b)
+      detail: {
+        loading: t({ en: 'Loading content…', 'zh-Hans': '正在加载内容…', fr: 'Chargement…', ja: '読み込み中…', ko: '불러오는 중…', 'zh-Hant': '正在載入內容…' }),
+        suitableFor: t({ en: 'Who it\'s for', 'zh-Hans': '适合谁', fr: 'Pour qui', ja: '対象者', ko: '대상', 'zh-Hant': '適合誰' }),
+        problem: t({ en: 'What it solves', 'zh-Hans': '解决什么问题', fr: 'Ce que ça résout', ja: '解決する課題', ko: '해결하는 문제', 'zh-Hant': '解決什麼問題' }),
+        firstTask: t({ en: 'First task', 'zh-Hans': '第一个任务', fr: 'Première tâche', ja: '最初のタスク', ko: '첫 작업', 'zh-Hant': '第一個任務' }),
+        riskNotes: t({ en: 'Risk notes', 'zh-Hans': '风险提示', fr: 'Risques', ja: 'リスク', ko: '리스크', 'zh-Hant': '風險提示' }),
+        instructions: t({ en: 'SKILL.md', 'zh-Hans': 'SKILL.md 内容', fr: 'SKILL.md', ja: 'SKILL.md 内容', ko: 'SKILL.md 내용', 'zh-Hant': 'SKILL.md 內容' }),
+        contentUnavailable: t({ en: 'Content unavailable from skills-api right now.', 'zh-Hans': '暂时无法从 skills-api 获取内容。', fr: 'Contenu indisponible pour le moment.', ja: 'skills-api からコンテンツを取得できません。', ko: '지금은 skills-api에서 콘텐츠를 가져올 수 없습니다.', 'zh-Hant': '暫時無法從 skills-api 取得內容。' }),
+        noUpstream: t({ en: 'This entry has no upstream source.', 'zh-Hans': '该条目没有上游内容源。', fr: 'Aucune source amont.', ja: 'このエントリーには上流ソースがありません。', ko: '이 항목에는 업스트림 소스가 없습니다.', 'zh-Hant': '該條目沒有上游內容源。' }),
+        close: t({ en: 'Close', 'zh-Hans': '关闭', fr: 'Fermer', ja: '閉じる', ko: '닫기', 'zh-Hant': '關閉' }),
+      },
       categories: {
         ai_engineering: t({ en: 'AI Engineering', 'zh-Hans': 'AI 工程', fr: 'Ingénierie IA', ja: 'AI エンジニアリング', ko: 'AI 엔지니어링', 'zh-Hant': 'AI 工程' }),
         research: t({ en: 'Research', 'zh-Hans': '研究', fr: 'Recherche', ja: 'リサーチ', ko: '리서치', 'zh-Hant': '研究' }),

--- a/src/server/function/skills.server.ts
+++ b/src/server/function/skills.server.ts
@@ -234,6 +234,176 @@ export const listCuratedSkillsFn = createServerFn({ method: 'GET' }).handler(
 );
 
 /**
+ * Status of a curated skill's SKILL.md content.
+ * - cached: served from skill_content_cache
+ * - fetched: just fetched from skills-api and cached
+ * - no_upstream: catalog row has no upstream ref (cannot fetch)
+ * - unavailable: fetch failed (network / 404) and nothing cached
+ */
+export type CuratedContentStatus = 'cached' | 'fetched' | 'no_upstream' | 'unavailable';
+
+export interface CuratedSkillDetail {
+  slug: string;
+  name: string;
+  titleZh: string | null;
+  summaryZh: string | null;
+  category: string | null;
+  level: string | null;
+  tags: string[];
+  reusabilityStatus: string | null;
+  suitableForZh: string | null;
+  problemZh: string | null;
+  firstTaskZh: string | null;
+  riskNotesZh: string | null;
+  iconEmoji: string | null;
+  source: string;
+  githubUrl: string | null;
+  skillsShUrl: string | null;
+  sourceLabel: string | null;
+  // Content (from skills-api, cached in skill_content_cache)
+  skillMd: string | null;
+  instructions: string | null;
+  metadata: Record<string, string> | null;
+  contentHash: string | null;
+  contentStatus: CuratedContentStatus;
+  contentError: string | null;
+}
+
+/**
+ * Get a curated skill's full detail: editorial fields (from skill_catalog) +
+ * SKILL.md content (cache-first from skill_content_cache, else fetched from
+ * skills-api and cached). Authenticated — content fetch hits an external API
+ * and writes the cache. See PRD S1b.
+ */
+export const getCuratedSkillDetailFn = createServerFn({ method: 'POST' })
+  .inputValidator((input) => {
+    const payload = typeof input === 'string' ? JSON.parse(input) : input;
+    const data = payload && typeof payload === 'object' && 'data' in payload
+      ? (payload as { data?: unknown }).data
+      : payload;
+    return z.object({
+      slug: z.string().min(1),
+      force: z.boolean().optional().default(false),
+    }).parse(data);
+  })
+  .handler(async ({ data }): Promise<CuratedSkillDetail> => {
+    await requireUser();
+
+    const { db } = await import('~/db/db-config');
+    const { skillCatalog, skillContentCache } = await import('~/db/schema');
+    const { and, eq } = await import('drizzle-orm');
+    const { fetchSkillContent, parseSkillMarkdown } = await import('~/claude/skills/skills-api-client');
+
+    const [row] = await db
+      .select()
+      .from(skillCatalog)
+      .where(and(eq(skillCatalog.slug, data.slug), eq(skillCatalog.scope, 'official')))
+      .limit(1);
+
+    if (!row) {
+      throw new Error(`Curated skill not found: ${data.slug}`);
+    }
+
+    const editorial = {
+      slug: row.slug,
+      name: row.name,
+      titleZh: row.titleZh,
+      summaryZh: row.summaryZh,
+      category: row.category,
+      level: row.level,
+      tags: Array.isArray(row.tags) ? row.tags : [],
+      reusabilityStatus: row.reusabilityStatus,
+      suitableForZh: row.suitableForZh,
+      problemZh: row.problemZh,
+      firstTaskZh: row.firstTaskZh,
+      riskNotesZh: row.riskNotesZh,
+      iconEmoji: row.iconEmoji,
+      source: row.source,
+      githubUrl: row.githubUrl,
+      skillsShUrl: row.skillsShUrl,
+      sourceLabel: row.sourceLabel,
+    };
+
+    const renderContent = (
+      raw: string | null,
+      contentHash: string | null,
+      status: CuratedContentStatus,
+      contentError: string | null,
+    ): CuratedSkillDetail => {
+      const { metadata, body } = parseSkillMarkdown(raw);
+      return {
+        ...editorial,
+        skillMd: raw,
+        instructions: raw ? body : null,
+        metadata: raw ? metadata : null,
+        contentHash,
+        contentStatus: status,
+        contentError,
+      };
+    };
+
+    // Cache-first
+    if (!data.force) {
+      const [cached] = await db
+        .select()
+        .from(skillContentCache)
+        .where(eq(skillContentCache.catalogId, row.id))
+        .limit(1);
+      if (cached?.skillMd) {
+        return renderContent(cached.skillMd, cached.contentHash, 'cached', null);
+      }
+    }
+
+    if (!row.upstream) {
+      return renderContent(null, null, 'no_upstream', null);
+    }
+
+    // Fetch from skills-api + cache
+    try {
+      const content = await fetchSkillContent(row.upstream);
+      const raw = content.raw ?? null;
+      if (!raw) {
+        return renderContent(null, null, 'unavailable', 'skills-api returned empty content');
+      }
+      const contentHash = hashSkillMd(raw);
+      const now = new Date();
+      await db
+        .insert(skillContentCache)
+        .values({
+          catalogId: row.id,
+          skillMd: raw,
+          contentHash,
+          fetchedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: skillContentCache.catalogId,
+          set: { skillMd: raw, contentHash, fetchedAt: now },
+        });
+      return renderContent(raw, contentHash, 'fetched', null);
+    } catch (error) {
+      console.error('[Skills] getCuratedSkillDetail content fetch failed', {
+        slug: data.slug,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Last-resort: return any stale cache even on force
+      const [cached] = await db
+        .select()
+        .from(skillContentCache)
+        .where(eq(skillContentCache.catalogId, row.id))
+        .limit(1);
+      if (cached?.skillMd) {
+        return renderContent(cached.skillMd, cached.contentHash, 'cached', null);
+      }
+      return renderContent(
+        null,
+        null,
+        'unavailable',
+        error instanceof Error ? error.message : 'content fetch failed',
+      );
+    }
+  });
+
+/**
  * Get global skills (admin only)
  */
 export const getGlobalSkillsFn = createServerFn({ method: 'GET' }).handler(async () => {


### PR DESCRIPTION
## Skills 集成 S1b — 内容拉取 + 缓存 + 详情页

延续 #90/#91。对应 PRD §9 S1b：从 skills-api 取 SKILL.md → `skill_content_cache` 落库 + 详情渲染。

### 变更
- **skills-api 客户端**（server-only）`src/claude/skills/skills-api-client.ts`
  - `getSkillsApiBaseUrl()`（`SKILLS_API_URL`，默认 `https://skills-api.deeptoai.com`）
  - `fetchSkillContent({owner,repo,skillId})` → `{metadata,instructions,raw}`（可选 `SKILLS_API_KEY`；内容读取无需 key）
  - `parseSkillMarkdown(raw)` → `{metadata, body}`，让缓存命中与新拉取走同一渲染路径
- **`getCuratedSkillDetailFn`**（POST，需登录）：catalog 编辑字段 + SKILL.md 内容
  - **cache-first**：先查 `skill_content_cache`；未命中则拉 skills-api → sha256 哈希 → upsert 落库
  - 拉取失败时回退到 stale 缓存；返回 `contentStatus`（cached/fetched/no_upstream/unavailable）
- **`CuratedSkillDetailDialog`**：react-query 懒加载，渲染编辑块（适合谁/解决什么问题/第一个任务/风险提示）+ SKILL.md（复用共享 `markdownComponents`）；含加载/不可用/无上游态
- 精选卡片可点击（键盘可达）打开详情；GitHub 链接阻断冒泡。新增 i18n（`curated.detail.*`）
- `.env.example` 增加 `SKILLS_API_URL` + `SKILLS_API_KEY` 说明

### 验证
- 对**线上 skills-api** 端到端验证：客户端 fetch+parse OK（find-skills，raw 5430 字符，frontmatter name/description）
- DB：`skill_content_cache` 的 PK `onConflictDoUpdate` **幂等**（read-back 确认 md 长度/hash/fetchedAt；二次 upsert 无 PK 冲突）
- `pnpm build` ✓；`oxlint` 0 errors；改动文件 `tsc` 无新增报错

### 非目标（后续）
- 不跑、不生成 schema（S2）。`files`/`tree` 暂不取（仅 SKILL.md）。
- 内容刷新/stale 检测（scrapedAt/ETag）留给 S4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)