### PR TITLE
feat(skills): S2 core — install catalog skills into My Skills + default-2 lock

### DIFF
--- a/src/claude/skills/catalog-content.ts
+++ b/src/claude/skills/catalog-content.ts
@@ -1,0 +1,106 @@
+/**
+ * Catalog skill content resolver (server-only).
+ *
+ * Cache-first SKILL.md resolution for a catalog row: returns the cached content
+ * from skill_content_cache, else fetches from skills-api and upserts the cache.
+ * Shared by the detail server function (display) and the materializer (S2 install).
+ *
+ * See docs/project/prd/2026-06-skills-integration-prd.md (S1b/S2).
+ */
+
+import { fetchSkillContent, parseSkillMarkdown } from './skills-api-client';
+import { hashSkillMd } from './schema-generator';
+import type { SkillUpstreamRef } from '~/db/schema/skill-catalog.schema';
+
+export type CatalogContentStatus = 'cached' | 'fetched' | 'no_upstream' | 'unavailable';
+
+export interface ResolvedSkillContent {
+  skillMd: string | null;
+  instructions: string | null;
+  metadata: Record<string, string> | null;
+  contentHash: string | null;
+  status: CatalogContentStatus;
+  error: string | null;
+}
+
+function render(
+  raw: string | null,
+  contentHash: string | null,
+  status: CatalogContentStatus,
+  error: string | null,
+): ResolvedSkillContent {
+  const { metadata, body } = parseSkillMarkdown(raw);
+  return {
+    skillMd: raw,
+    instructions: raw ? body : null,
+    metadata: raw ? metadata : null,
+    contentHash,
+    status,
+    error,
+  };
+}
+
+/**
+ * Resolve a catalog skill's SKILL.md, cache-first.
+ *
+ * @param catalog  the catalog row id + upstream ref
+ * @param opts.force  bypass the cache and refetch
+ */
+export async function getCatalogSkillContent(
+  catalog: { id: string; upstream: SkillUpstreamRef | null },
+  opts?: { force?: boolean },
+): Promise<ResolvedSkillContent> {
+  const { db } = await import('~/db/db-config');
+  const { skillContentCache } = await import('~/db/schema');
+  const { eq } = await import('drizzle-orm');
+
+  const readCache = async () => {
+    const [row] = await db
+      .select()
+      .from(skillContentCache)
+      .where(eq(skillContentCache.catalogId, catalog.id))
+      .limit(1);
+    return row ?? null;
+  };
+
+  if (!opts?.force) {
+    const cached = await readCache();
+    if (cached?.skillMd) {
+      return render(cached.skillMd, cached.contentHash, 'cached', null);
+    }
+  }
+
+  if (!catalog.upstream) {
+    return render(null, null, 'no_upstream', null);
+  }
+
+  try {
+    const content = await fetchSkillContent(catalog.upstream);
+    const raw = content.raw ?? null;
+    if (!raw) {
+      return render(null, null, 'unavailable', 'skills-api returned empty content');
+    }
+    const contentHash = hashSkillMd(raw);
+    const now = new Date();
+    await db
+      .insert(skillContentCache)
+      .values({ catalogId: catalog.id, skillMd: raw, contentHash, fetchedAt: now })
+      .onConflictDoUpdate({
+        target: skillContentCache.catalogId,
+        set: { skillMd: raw, contentHash, fetchedAt: now },
+      });
+    return render(raw, contentHash, 'fetched', null);
+  } catch (error) {
+    // Fall back to any stale cache even on force
+    const cached = await readCache();
+    if (cached?.skillMd) {
+      return render(cached.skillMd, cached.contentHash, 'cached', null);
+    }
+    return render(
+      null,
+      null,
+      'unavailable',
+      error instanceof Error ? error.message : 'content fetch failed',
+    );
+  }
+}

--- a/src/claude/skills/catalog-materializer.ts
+++ b/src/claude/skills/catalog-materializer.ts
@@ -1,0 +1,104 @@
+/**
+ * Catalog → filesystem materializer (server-only).
+ *
+ * Projects an installed catalog skill onto disk at the per-user skills dir
+ * `{claudeHome}/.claude/skills/<slug>/` so the Claude Agent SDK loads it on the
+ * NEXT conversation (this SDK version does not hot-reload a running/resumed
+ * session — see PRD D7 / the "需重新发起对话" contract).
+ *
+ * Content source:
+ *  - source='builtin' → copy the directory from the FS skills-store (8 baoyu)
+ *  - source='curated'|'upstream' → write SKILL.md from skill_content_cache
+ *    (fetched from skills-api on demand, cache-first)
+ *
+ * ws-server.mjs's filesystem sync preserves whatever is materialized here
+ * (it only removes user-*disabled* skills), so this is the single write path;
+ * no ws-server changes are needed.
+ *
+ * See docs/project/prd/2026-06-skills-integration-prd.md (S2).
+ */
+
+import * as fsp from 'node:fs/promises';
+import path from 'node:path';
+import { getUserClaudeHome, getSkillsStoreDir, normalizeSkillName } from './manager';
+import { fileExists } from './metadata';
+import { getCatalogSkillContent } from './catalog-content';
+
+/** Admin-default skills: always installed, locked (cannot be uninstalled). */
+export const DEFAULT_SKILL_SLUGS = ['find-skills', 'skill-creator'] as const;
+
+export function isDefaultSkill(slug: string): boolean {
+  return (DEFAULT_SKILL_SLUGS as readonly string[]).includes(slug);
+}
+
+function userSkillDir(userId: string, slug: string): string {
+  return path.join(getUserClaudeHome(userId), '.claude', 'skills', normalizeSkillName(slug));
+}
+
+export interface MaterializeResult {
+  slug: string;
+  ok: boolean;
+  status: 'builtin_copied' | 'content_written' | 'skipped_no_content' | 'error';
+  error?: string;
+}
+
+/**
+ * Materialize one installed catalog skill onto disk for a user.
+ * Idempotent: overwrites any existing directory (auto-update).
+ */
+export async function materializeCatalogSkill(
+  userId: string,
+  catalog: {
+    id: string;
+    slug: string;
+    source: string;
+    upstream: { owner: string; repo: string; skillId: string } | null;
+  },
+): Promise<MaterializeResult> {
+  const slug = normalizeSkillName(catalog.slug);
+  const targetDir = userSkillDir(userId, slug);
+
+  try {
+    if (catalog.source === 'builtin') {
+      // Copy the whole skill directory from the FS skills-store.
+      const sourceDir = path.join(getSkillsStoreDir(), slug);
+      if (!(await fileExists(sourceDir))) {
+        return { slug, ok: false, status: 'error', error: `builtin source not found: ${slug}` };
+      }
+      await fsp.rm(targetDir, { recursive: true, force: true });
+      await fsp.mkdir(path.dirname(targetDir), { recursive: true });
+      await fsp.cp(sourceDir, targetDir, { recursive: true });
+      return { slug, ok: true, status: 'builtin_copied' };
+    }
+
+    // curated / upstream → write SKILL.md from the content cache (cache-first).
+    const content = await getCatalogSkillContent({ id: catalog.id, upstream: catalog.upstream });
+    if (!content.skillMd) {
+      return {
+        slug,
+        ok: false,
+        status: 'skipped_no_content',
+        error: content.error ?? content.status,
+      };
+    }
+    await fsp.mkdir(targetDir, { recursive: true });
+    await fsp.writeFile(path.join(targetDir, 'SKILL.md'), content.skillMd, 'utf-8');
+    return { slug, ok: true, status: 'content_written' };
+  } catch (error) {
+    return {
+      slug,
+      ok: false,
+      status: 'error',
+      error: error instanceof Error ? error.message : 'materialize failed',
+    };
+  }
+}
+
+/**
+ * Remove a materialized skill directory for a user (uninstall projection).
+ * Does NOT touch the global/disabled lists — catalog skills are not global, so
+ * ws-server's sync won't re-add them.
+ */
+export async function dematerializeSkill(userId: string, slug: string): Promise<void> {
+  await fsp.rm(userSkillDir(userId, normalizeSkillName(slug)), { recursive: true, force: true });
+}

--- a/src/components/skills/curated-skills-section.tsx
+++ b/src/components/skills/curated-skills-section.tsx
@@ -1,21 +1,29 @@
 import { FC, useMemo, useState } from 'react';
-import { Search, ExternalLink, Sparkles } from 'lucide-react';
+import { Search, ExternalLink, Sparkles, Check, Plus, Loader2, Lock } from 'lucide-react';
+import { toast } from 'sonner';
 import { useIntlayer } from 'react-intlayer';
+import { useServerFn } from '@tanstack/react-start';
 import { toLocalizedString } from '~/lib/utils';
 import { Input } from '~/components/ui/input';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
-import type { CuratedSkillItem } from '~/server/function/skills.server';
+import {
+  installCuratedSkillFn,
+  uninstallCuratedSkillFn,
+  type CuratedSkillItem,
+} from '~/server/function/skills.server';
 import { CuratedSkillDetailDialog } from './curated-skill-detail-dialog';
 
 /**
- * Curated Skills Section — read-only browse of the DB-backed curated catalog
- * (seeded from the platform's curated-100). Skills S1a: display only —
- * search + category filter + cards. Runtime enable/materialization (S2) and
- * SKILL.md detail from skills-api (S1b) are later phases, so there is
- * intentionally no enable toggle here yet.
+ * Curated Skills Section — the Skill Library (DB-backed curated catalog).
  *
- * See docs/project/prd/2026-06-skills-integration-prd.md (§9 S1).
+ * S1: browse/search/category + detail (SKILL.md from skills-api).
+ * S2: install/uninstall into "My Skills" (per-user, materialized to disk).
+ *   - Install takes effect on the NEXT new conversation (this SDK version does
+ *     not hot-reload a running session — see PRD D7).
+ *   - Default skills (find-skills, skill-creator) are always installed + locked.
+ *
+ * See docs/project/prd/2026-06-skills-integration-prd.md.
  */
 
 const CATEGORY_ORDER = [
@@ -28,11 +36,23 @@ const CATEGORY_ORDER = [
   'security',
 ] as const;
 
-export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skills }) => {
+// Mirror of catalog-materializer DEFAULT_SKILL_SLUGS (server enforces the lock).
+const DEFAULT_SKILL_SLUGS = ['find-skills', 'skill-creator'];
+
+export const CuratedSkillsSection: FC<{
+  skills: CuratedSkillItem[];
+  installedSlugs?: string[];
+}> = ({ skills, installedSlugs = [] }) => {
   const content = useIntlayer('skills');
+  const installFn = useServerFn(installCuratedSkillFn);
+  const uninstallFn = useServerFn(uninstallCuratedSkillFn);
+
   const [searchQuery, setSearchQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [detailSlug, setDetailSlug] = useState<string | null>(null);
+  const [onlyInstalled, setOnlyInstalled] = useState(false);
+  const [installed, setInstalled] = useState<Set<string>>(() => new Set(installedSlugs));
+  const [pending, setPending] = useState<string | null>(null);
 
   const categoryLabel = (key: string | null): string => {
     if (!key) return key ?? '';
@@ -40,7 +60,6 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
     return key in map ? toLocalizedString(map[key]) : key;
   };
 
-  // Categories actually present in the data, in canonical order
   const presentCategories = useMemo(() => {
     const set = new Set(skills.map((s) => s.category).filter(Boolean) as string[]);
     return CATEGORY_ORDER.filter((c) => set.has(c));
@@ -48,6 +67,9 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
 
   const filtered = useMemo(() => {
     let list = skills;
+    if (onlyInstalled) {
+      list = list.filter((s) => installed.has(s.slug) || DEFAULT_SKILL_SLUGS.includes(s.slug));
+    }
     if (activeCategory) {
       list = list.filter((s) => s.category === activeCategory);
     }
@@ -62,7 +84,75 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
       );
     }
     return list;
-  }, [skills, activeCategory, searchQuery]);
+  }, [skills, activeCategory, searchQuery, onlyInstalled, installed]);
+
+  const handleToggleInstall = async (e: React.MouseEvent, slug: string) => {
+    e.stopPropagation();
+    if (DEFAULT_SKILL_SLUGS.includes(slug)) {
+      toast.info(toLocalizedString(content.curated.defaultLockedToast));
+      return;
+    }
+    const isInstalled = installed.has(slug);
+    setPending(slug);
+    try {
+      if (isInstalled) {
+        await uninstallFn({ data: { slug } });
+        setInstalled((prev) => {
+          const next = new Set(prev);
+          next.delete(slug);
+          return next;
+        });
+        toast.success(toLocalizedString(content.curated.uninstalledToast));
+      } else {
+        await installFn({ data: { slug } });
+        setInstalled((prev) => new Set(prev).add(slug));
+        toast.success(toLocalizedString(content.curated.installedToast));
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '';
+      toast.error(`${toLocalizedString(content.curated.installFailed)}${message ? `: ${message}` : ''}`);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const renderInstallControl = (slug: string) => {
+    const isDefault = DEFAULT_SKILL_SLUGS.includes(slug);
+    const isInstalled = isDefault || installed.has(slug);
+    const isPending = pending === slug;
+
+    if (isDefault) {
+      return (
+        <Badge variant="secondary" className="gap-1 text-[10px]">
+          <Lock className="h-3 w-3" />
+          {content.curated.defaultLocked}
+        </Badge>
+      );
+    }
+
+    return (
+      <Button
+        size="sm"
+        variant={isInstalled ? 'outline' : 'default'}
+        className="h-7 gap-1 px-2 text-xs"
+        disabled={isPending}
+        onClick={(e) => handleToggleInstall(e, slug)}
+      >
+        {isPending ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : isInstalled ? (
+          <Check className="h-3 w-3" />
+        ) : (
+          <Plus className="h-3 w-3" />
+        )}
+        {isPending
+          ? content.curated.installing
+          : isInstalled
+            ? content.curated.installed
+            : content.curated.install}
+      </Button>
+    );
+  };
 
   return (
     <section className="mb-10">
@@ -70,14 +160,13 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
       <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
         <Sparkles className="h-5 w-5 text-primary" />
         <h2 className="text-lg font-semibold">{content.curated.title}</h2>
-        <Badge variant="secondary">{content.curated.previewBadge}</Badge>
         <span className="text-sm text-muted-foreground">
           {toLocalizedString(content.curated.count).replace('{count}', String(skills.length))}
         </span>
       </div>
       <p className="mb-4 text-sm text-muted-foreground">{content.curated.subtitle}</p>
 
-      {/* Toolbar: search + category filter */}
+      {/* Toolbar: search + category filter + My-Skills toggle */}
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -107,6 +196,15 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
             </Button>
           ))}
         </div>
+        <Button
+          variant={onlyInstalled ? 'default' : 'outline'}
+          size="sm"
+          className="ml-auto gap-1"
+          onClick={() => setOnlyInstalled((v) => !v)}
+        >
+          <Check className="h-3.5 w-3.5" />
+          {content.curated.onlyInstalled}
+        </Button>
       </div>
 
       {/* Grid */}
@@ -153,7 +251,7 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
                 <p className="mb-3 line-clamp-2 text-xs text-muted-foreground">{skill.summaryZh}</p>
               )}
 
-              <div className="mt-auto flex flex-wrap items-center gap-1.5">
+              <div className="mb-3 flex flex-wrap items-center gap-1.5">
                 {skill.category && (
                   <Badge variant="secondary" className="text-[10px]">
                     {categoryLabel(skill.category)}
@@ -164,6 +262,11 @@ export const CuratedSkillsSection: FC<{ skills: CuratedSkillItem[] }> = ({ skill
                     {tag}
                   </Badge>
                 ))}
+              </div>
+
+              {/* Action row: install control + GitHub link */}
+              <div className="mt-auto flex items-center gap-2">
+                {renderInstallControl(skill.slug)}
                 {skill.githubUrl && (
                   <a
                     href={skill.githubUrl}

--- a/src/contents/skills.content.ts
+++ b/src/contents/skills.content.ts
@@ -71,6 +71,31 @@ const skillsContent = {
       allCategories: t({ en: 'All', 'zh-Hans': '全部', fr: 'Tous', ja: 'すべて', ko: '전체', 'zh-Hant': '全部' }),
       viewOnGithub: t({ en: 'View on GitHub', 'zh-Hans': '在 GitHub 查看', fr: 'Voir sur GitHub', ja: 'GitHub で見る', ko: 'GitHub에서 보기', 'zh-Hant': '在 GitHub 檢視' }),
       viewDetails: t({ en: 'Details', 'zh-Hans': '详情', fr: 'Détails', ja: '詳細', ko: '상세', 'zh-Hant': '詳情' }),
+      // Install / My Skills (S2)
+      install: t({ en: 'Install', 'zh-Hans': '安装', fr: 'Installer', ja: 'インストール', ko: '설치', 'zh-Hant': '安裝' }),
+      installed: t({ en: 'Installed', 'zh-Hans': '已安装', fr: 'Installé', ja: 'インストール済み', ko: '설치됨', 'zh-Hant': '已安裝' }),
+      uninstall: t({ en: 'Uninstall', 'zh-Hans': '卸载', fr: 'Désinstaller', ja: 'アンインストール', ko: '제거', 'zh-Hant': '解除安裝' }),
+      installing: t({ en: 'Installing…', 'zh-Hans': '安装中…', fr: 'Installation…', ja: 'インストール中…', ko: '설치 중…', 'zh-Hant': '安裝中…' }),
+      defaultLocked: t({ en: 'Default', 'zh-Hans': '默认', fr: 'Par défaut', ja: 'デフォルト', ko: '기본', 'zh-Hant': '預設' }),
+      installedToast: t({
+        en: 'Added to My Skills — takes effect in your next new conversation.',
+        'zh-Hans': '已加入「我的技能」——下个新对话生效。',
+        fr: 'Ajouté à Mes Skills — effectif dans votre prochaine conversation.',
+        ja: '「マイスキル」に追加しました — 次の新しい会話から有効です。',
+        ko: '「내 스킬」에 추가됨 — 다음 새 대화부터 적용됩니다.',
+        'zh-Hant': '已加入「我的技能」——下個新對話生效。',
+      }),
+      uninstalledToast: t({
+        en: 'Removed from My Skills — applies to your next new conversation.',
+        'zh-Hans': '已从「我的技能」移除——下个新对话生效。',
+        fr: 'Retiré de Mes Skills — effectif dans votre prochaine conversation.',
+        ja: '「マイスキル」から削除しました — 次の新しい会話から反映されます。',
+        ko: '「내 스킬」에서 제거됨 — 다음 새 대화부터 적용됩니다.',
+        'zh-Hant': '已從「我的技能」移除——下個新對話生效。',
+      }),
+      installFailed: t({ en: 'Install failed', 'zh-Hans': '安装失败', fr: 'Échec de l\'installation', ja: 'インストール失敗', ko: '설치 실패', 'zh-Hant': '安裝失敗' }),
+      defaultLockedToast: t({ en: 'Default skills cannot be uninstalled.', 'zh-Hans': '默认技能不可卸载。', fr: 'Les skills par défaut ne peuvent pas être désinstallés.', ja: 'デフォルトスキルはアンインストールできません。', ko: '기본 스킬은 제거할 수 없습니다.', 'zh-Hant': '預設技能不可解除安裝。' }),
+      onlyInstalled: t({ en: 'My Skills only', 'zh-Hans': '只看已安装', fr: 'Mes Skills seulement', ja: 'マイスキルのみ', ko: '내 스킬만', 'zh-Hant': '只看已安裝' }),
       empty: t({ en: 'No curated skills match your filters', 'zh-Hans': '没有符合条件的精选技能', fr: 'Aucun skill ne correspond', ja: '条件に合う厳選スキルがありません', ko: '조건에 맞는 엄선 스킬이 없습니다', 'zh-Hant': '沒有符合條件的精選技能' }),
       // Detail dialog (S1b)
       detail: {

--- a/src/routes/agents/capabilities/route.tsx
+++ b/src/routes/agents/capabilities/route.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useIntlayer } from 'react-intlayer';
 import { useState } from 'react';
-import { listAllSkillsFn, listCuratedSkillsFn, isAdminUser } from '~/server/function/skills.server';
+import { listAllSkillsFn, listCuratedSkillsFn, listMySkillsFn, isAdminUser } from '~/server/function/skills.server';
 import { listAllMcpsFn } from '~/server/function/mcp.server';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { SkillsPageComponent } from '~/components/skills/skills-page';
@@ -30,12 +30,15 @@ export const Route = createFileRoute('/agents/capabilities')({
     tab: search.tab === 'mcp' ? 'mcp' : 'skills',
   }),
   loader: async () => {
-    const [skillsResult, curatedSkills, mcpResult, adminCheck] = await Promise.all([
+    const [skillsResult, curatedSkills, mySkills, mcpResult, adminCheck] = await Promise.all([
       listAllSkillsFn(),
       listCuratedSkillsFn(),
+      listMySkillsFn(),
       listAllMcpsFn(),
       isAdminUser(),
     ]);
+
+    const installedCuratedSlugs = mySkills.map((s) => s.slug);
 
     const allSkills: ExtendedSkillInfo[] = [
       ...skillsResult.official,
@@ -50,6 +53,7 @@ export const Route = createFileRoute('/agents/capabilities')({
     return {
       allSkills,
       curatedSkills,
+      installedCuratedSlugs,
       isAdmin: adminCheck.isAdmin ?? false,
       officialMcps,
       systemMcps,
@@ -61,7 +65,7 @@ export const Route = createFileRoute('/agents/capabilities')({
 });
 
 function CapabilityCenter() {
-  const { allSkills, curatedSkills, isAdmin, officialMcps, systemMcps, userMcps, allMcps } =
+  const { allSkills, curatedSkills, installedCuratedSlugs, isAdmin, officialMcps, systemMcps, userMcps, allMcps } =
     Route.useLoaderData();
   const { tab } = Route.useSearch();
   const content = useIntlayer('app');
@@ -86,7 +90,9 @@ function CapabilityCenter() {
         </TabsList>
 
         <TabsContent value="skills" className="mt-6">
-          {curatedSkills.length > 0 && <CuratedSkillsSection skills={curatedSkills} />}
+          {curatedSkills.length > 0 && (
+            <CuratedSkillsSection skills={curatedSkills} installedSlugs={installedCuratedSlugs} />
+          )}
           <SkillsPageComponent
             skills={allSkills}
             enabledSkills={enabledSkills}

--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -78,7 +78,7 @@ import {
   type TextContentPart,
   type ContentPart,
 } from '~/lib/chat-session-store';
-import { disableUserSkillsFn } from '~/server/function/skills.server';
+import { disableUserSkillsFn, ensureDefaultSkillsFn } from '~/server/function/skills.server';
 import {
   trackClaudeAgentSessionCreated,
   trackClaudeAgentSessionSwitched,
@@ -161,8 +161,15 @@ const useFileHandlers = () => useContext(FileHandlersContext);
 export const Route = createFileRoute('/agents/claude-chat')({
   component: RouteComponent,
   loader: async () => {
-    // Fetch permission info on server side
-    const permissionInfo = await getPermissionInfo();
+    // Fetch permission info + ensure default skills are installed (idempotent,
+    // best-effort: a materialization hiccup must not block the chat page).
+    const [permissionInfo] = await Promise.all([
+      getPermissionInfo(),
+      ensureDefaultSkillsFn().catch((error) => {
+        console.warn('[Skills] ensureDefaultSkills failed (non-fatal):', error);
+        return null;
+      }),
+    ]);
     return { permissionInfo };
   },
 });

--- a/src/server/function/skills.server.ts
+++ b/src/server/function/skills.server.ts
@@ -403,6 +403,189 @@ export const getCuratedSkillDetailFn = createServerFn({ method: 'POST' })
     }
   });
 
+// ============================================================================
+// Catalog "install" (My Skills) — S2 execution layer
+//
+// Install = materialize the skill onto disk (per-user) + record in
+// skill_enablement. Takes effect on the NEXT new conversation (this SDK version
+// does not hot-reload a running session). Default skills (find-skills,
+// skill-creator) are always installed and locked. See PRD D6/D7/S2.
+// ============================================================================
+
+export interface MySkillItem {
+  slug: string;
+  name: string;
+  titleZh: string | null;
+  iconEmoji: string | null;
+  category: string | null;
+  source: string;
+  isDefault: boolean;
+}
+
+const curatedSlugSchema = z.object({ slug: z.string().min(1) });
+
+function parseSlugInput(input: unknown): { slug: string } {
+  const payload = typeof input === 'string' ? JSON.parse(input) : input;
+  const data = payload && typeof payload === 'object' && 'data' in payload
+    ? (payload as { data?: unknown }).data
+    : payload;
+  return curatedSlugSchema.parse(data);
+}
+
+/** Load an official catalog row by slug (id + source + upstream). */
+async function loadOfficialCatalogRow(slug: string) {
+  const { db } = await import('~/db/db-config');
+  const { skillCatalog } = await import('~/db/schema');
+  const { and, eq } = await import('drizzle-orm');
+  const [row] = await db
+    .select({
+      id: skillCatalog.id,
+      slug: skillCatalog.slug,
+      source: skillCatalog.source,
+      upstream: skillCatalog.upstream,
+    })
+    .from(skillCatalog)
+    .where(and(eq(skillCatalog.slug, slug), eq(skillCatalog.scope, 'official')))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * List the current user's installed skills (My Skills).
+ */
+export const listMySkillsFn = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<MySkillItem[]> => {
+    const user = await requireUser();
+    const { db } = await import('~/db/db-config');
+    const { skillCatalog, skillEnablement } = await import('~/db/schema');
+    const { and, eq } = await import('drizzle-orm');
+    const { isDefaultSkill } = await import('~/claude/skills/catalog-materializer');
+
+    const rows = await db
+      .select({
+        slug: skillCatalog.slug,
+        name: skillCatalog.name,
+        titleZh: skillCatalog.titleZh,
+        iconEmoji: skillCatalog.iconEmoji,
+        category: skillCatalog.category,
+        source: skillCatalog.source,
+      })
+      .from(skillEnablement)
+      .innerJoin(skillCatalog, eq(skillEnablement.catalogId, skillCatalog.id))
+      .where(and(eq(skillEnablement.userId, user.id), eq(skillEnablement.enabled, true)));
+
+    return rows.map((r) => ({ ...r, isDefault: isDefaultSkill(r.slug) }));
+  },
+);
+
+/**
+ * Install (enable) a catalog skill for the current user:
+ * materialize onto disk + record in skill_enablement. Effective next conversation.
+ */
+export const installCuratedSkillFn = createServerFn({ method: 'POST' })
+  .inputValidator(parseSlugInput)
+  .handler(async ({ data }) => {
+    const user = await requireUser();
+    const { db } = await import('~/db/db-config');
+    const { skillEnablement } = await import('~/db/schema');
+    const { materializeCatalogSkill } = await import('~/claude/skills/catalog-materializer');
+
+    const row = await loadOfficialCatalogRow(data.slug);
+    if (!row) throw new Error(`Curated skill not found: ${data.slug}`);
+
+    const result = await materializeCatalogSkill(user.id, row);
+    if (!result.ok) {
+      throw new Error(`Failed to install ${data.slug}: ${result.error ?? result.status}`);
+    }
+
+    const now = new Date();
+    await db
+      .insert(skillEnablement)
+      .values({ userId: user.id, catalogId: row.id, enabled: true, updatedAt: now })
+      .onConflictDoUpdate({
+        target: [skillEnablement.userId, skillEnablement.catalogId],
+        set: { enabled: true, updatedAt: now },
+      });
+
+    return { slug: data.slug, installed: true, effectiveNextConversation: true };
+  });
+
+/**
+ * Uninstall (disable) a catalog skill for the current user:
+ * remove the materialized dir + clear skill_enablement. Default skills are locked.
+ */
+export const uninstallCuratedSkillFn = createServerFn({ method: 'POST' })
+  .inputValidator(parseSlugInput)
+  .handler(async ({ data }) => {
+    const user = await requireUser();
+    const { isDefaultSkill, dematerializeSkill } = await import('~/claude/skills/catalog-materializer');
+
+    if (isDefaultSkill(data.slug)) {
+      throw new Error('SKILL_DEFAULT_LOCKED');
+    }
+
+    const { db } = await import('~/db/db-config');
+    const { skillEnablement } = await import('~/db/schema');
+    const { and, eq } = await import('drizzle-orm');
+
+    const row = await loadOfficialCatalogRow(data.slug);
+    if (!row) throw new Error(`Curated skill not found: ${data.slug}`);
+
+    await dematerializeSkill(user.id, data.slug);
+    await db
+      .delete(skillEnablement)
+      .where(and(eq(skillEnablement.userId, user.id), eq(skillEnablement.catalogId, row.id)));
+
+    return { slug: data.slug, installed: false };
+  });
+
+/**
+ * Ensure the default skills (find-skills + skill-creator) are installed for the
+ * current user. Idempotent — call on app/chat load. Materializes any missing
+ * default and records enablement.
+ */
+export const ensureDefaultSkillsFn = createServerFn({ method: 'POST' }).handler(async () => {
+  const user = await requireUser();
+  const { db } = await import('~/db/db-config');
+  const { skillCatalog, skillEnablement } = await import('~/db/schema');
+  const { and, eq } = await import('drizzle-orm');
+  const { DEFAULT_SKILL_SLUGS, materializeCatalogSkill } = await import('~/claude/skills/catalog-materializer');
+
+  const ensured: string[] = [];
+  for (const slug of DEFAULT_SKILL_SLUGS) {
+    const row = await loadOfficialCatalogRow(slug);
+    if (!row) {
+      console.warn(`[Skills] default skill not in catalog, skipping: ${slug}`);
+      continue;
+    }
+
+    const [existing] = await db
+      .select({ enabled: skillEnablement.enabled })
+      .from(skillEnablement)
+      .where(and(eq(skillEnablement.userId, user.id), eq(skillEnablement.catalogId, row.id)))
+      .limit(1);
+    if (existing?.enabled) continue;
+
+    const result = await materializeCatalogSkill(user.id, row);
+    if (!result.ok) {
+      console.error(`[Skills] failed to materialize default skill ${slug}:`, result.error);
+      continue;
+    }
+
+    const now = new Date();
+    await db
+      .insert(skillEnablement)
+      .values({ userId: user.id, catalogId: row.id, enabled: true, updatedAt: now })
+      .onConflictDoUpdate({
+        target: [skillEnablement.userId, skillEnablement.catalogId],
+        set: { enabled: true, updatedAt: now },
+      });
+    ensured.push(slug);
+  }
+
+  return { ensured };
+});
+
 /**
  * Get global skills (admin only)
  */


### PR DESCRIPTION
## Skills 集成 S2（核心）— 安装到「我的技能」+ 默认 2 个锁定

落实 owner 拍板的执行层模型（PRD D6/D7/S2）。**契约**：安装 = 物化到磁盘（用户级）+ 记 `skill_enablement`；**下个新对话生效**（本版 SDK 不支持运行中/resume 会话热加载）。**零 ws-server 改动** —— 其 FS sync 只删「用户禁用」的技能，会保留已物化的目录。

### 新增服务端模块
- `catalog-content.ts`：`getCatalogSkillContent()` —— cache-first 的 SKILL.md 解析器（从 S1b 详情逻辑抽出共享：缓存→skills-api→upsert）。
- `catalog-materializer.ts`：
  - `DEFAULT_SKILL_SLUGS = [find-skills, skill-creator]`、`isDefaultSkill()`
  - `materializeCatalogSkill()` 写入 `{claudeHome}/.claude/skills/<slug>/`（builtin→从 skills-store 拷贝；curated/upstream→从内容缓存写 SKILL.md）
  - `dematerializeSkill()` 移除目录

### 服务端函数（skills.server.ts）
- `installCuratedSkillFn` / `uninstallCuratedSkillFn`（默认技能锁定：`SKILL_DEFAULT_LOCKED`）
- `listMySkillsFn`（我的技能）
- `ensureDefaultSkillsFn`（幂等，确保默认 2 个已安装）

### 接线
- **claude-chat 路由 loader** 调 `ensureDefaultSkillsFn`（best-effort、并行）—— 进对话前确保默认 2 个已装。
- **capabilities loader** 传 `installedSlugs`；`CuratedSkillsSection` 增加：安装/卸载按钮、「只看已安装」筛选、默认锁定徽章、「下个新对话生效」toast。新增 i18n（`curated.install/installed/…`）。

### 验证
- 实跑 builtin 物化/反物化（拷贝+删除 OK）；curated 内容解析已在 S1b 端到端验证；`pnpm build` ✓、`oxlint` 0 errors。
- typecheck：新增文件无报错（仓库既有 `claude-chat/route.tsx`、`getSkillDetail` 等历史错误非本 PR 引入）。

### 不在本期（下一步）
- 把 8 个 baoyu 灌入 catalog（`source=builtin`）+ 编辑元数据。
- schema 后台/懒生成 + composer 可填充表单（S2.2）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)