### PR TITLE
feat(skills): S2.2 — fillable-variable schema generation + detail-dialog form

### DIFF
--- a/src/claude/skills/catalog-schema.ts
+++ b/src/claude/skills/catalog-schema.ts
@@ -1,0 +1,171 @@
+/**
+ * Catalog skill fillable-variable schema (server-only).
+ *
+ * Generates the composer form schema from a catalog skill's SKILL.md and caches
+ * it in skill_schema_cache, keyed by (catalogId, contentHash). Lazy/on-demand:
+ * generation runs only when explicitly requested (it costs an SDK/LLM call), and
+ * the cache is GLOBAL per (catalogId, contentHash) — generate once, every user
+ * benefits. Stale detection compares the cached hash against the current content.
+ *
+ * Reuses the (fixed) generateSchemaFromContent core — an independent SDK call
+ * chain, decoupled from the filesystem. See PRD D5 / S2.2.
+ */
+
+import {
+  generateSchemaFromContent,
+  SCHEMA_GENERATOR_VERSION,
+  type SkillSchema,
+} from './schema-generator';
+import { getCatalogSkillContent } from './catalog-content';
+import type { SkillUpstreamRef } from '~/db/schema/skill-catalog.schema';
+
+export type CatalogSchemaStatus = 'missing' | 'valid' | 'stale' | 'failed' | 'needs_review';
+
+export interface CatalogSchemaResult {
+  status: CatalogSchemaStatus;
+  schema: SkillSchema | null;
+  contentHash: string | null;
+  generatedAt: string | null;
+  lastError: string | null;
+}
+
+function toIso(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+/**
+ * Read the cached schema for a catalog skill (no generation).
+ * Marks the row 'stale' if the current content hash differs from the one the
+ * schema was generated from.
+ */
+export async function readCatalogSchema(catalogId: string): Promise<CatalogSchemaResult> {
+  const { db } = await import('~/db/db-config');
+  const { skillSchemaCache, skillContentCache } = await import('~/db/schema');
+  const { eq, desc } = await import('drizzle-orm');
+
+  const [schemaRow] = await db
+    .select()
+    .from(skillSchemaCache)
+    .where(eq(skillSchemaCache.catalogId, catalogId))
+    .orderBy(desc(skillSchemaCache.generatedAt))
+    .limit(1);
+
+  if (!schemaRow) {
+    return { status: 'missing', schema: null, contentHash: null, generatedAt: null, lastError: null };
+  }
+
+  const [contentRow] = await db
+    .select({ hash: skillContentCache.contentHash })
+    .from(skillContentCache)
+    .where(eq(skillContentCache.catalogId, catalogId))
+    .limit(1);
+
+  let status = schemaRow.status as CatalogSchemaStatus;
+  if (
+    (status === 'valid' || status === 'needs_review') &&
+    contentRow?.hash &&
+    schemaRow.contentHash &&
+    contentRow.hash !== schemaRow.contentHash
+  ) {
+    status = 'stale';
+  }
+
+  return {
+    status,
+    schema: (schemaRow.schema as SkillSchema | null) ?? null,
+    contentHash: schemaRow.contentHash,
+    generatedAt: toIso(schemaRow.generatedAt),
+    lastError: schemaRow.lastError ?? null,
+  };
+}
+
+/**
+ * Generate (or return cached) the fillable-variable schema for a catalog skill.
+ * Resolves SKILL.md (cache-first), runs the generator, and upserts the result
+ * keyed by content hash. Failures are recorded as status='failed' (non-throwing).
+ */
+export async function generateCatalogSchema(
+  catalog: { id: string; upstream: SkillUpstreamRef | null },
+  opts?: { force?: boolean },
+): Promise<CatalogSchemaResult> {
+  const { db } = await import('~/db/db-config');
+  const { skillSchemaCache } = await import('~/db/schema');
+  const { and, eq } = await import('drizzle-orm');
+
+  const content = await getCatalogSkillContent(catalog);
+  if (!content.skillMd || !content.contentHash) {
+    return {
+      status: 'missing',
+      schema: null,
+      contentHash: null,
+      generatedAt: null,
+      lastError: content.error ?? 'no SKILL.md content',
+    };
+  }
+  const hash = content.contentHash;
+
+  if (!opts?.force) {
+    const [existing] = await db
+      .select()
+      .from(skillSchemaCache)
+      .where(and(eq(skillSchemaCache.catalogId, catalog.id), eq(skillSchemaCache.contentHash, hash)))
+      .limit(1);
+    if (existing && (existing.status === 'valid' || existing.status === 'needs_review') && existing.schema) {
+      return {
+        status: existing.status as CatalogSchemaStatus,
+        schema: existing.schema as SkillSchema,
+        contentHash: hash,
+        generatedAt: toIso(existing.generatedAt),
+        lastError: null,
+      };
+    }
+  }
+
+  const now = new Date();
+  try {
+    const result = await generateSchemaFromContent(content.skillMd);
+    const status: CatalogSchemaStatus = result.needsReview ? 'needs_review' : 'valid';
+    await db
+      .insert(skillSchemaCache)
+      .values({
+        catalogId: catalog.id,
+        contentHash: hash,
+        schema: result.schema,
+        status,
+        generatorVersion: SCHEMA_GENERATOR_VERSION,
+        generatedAt: now,
+        lastError: result.errorMessage ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [skillSchemaCache.catalogId, skillSchemaCache.contentHash],
+        set: {
+          schema: result.schema,
+          status,
+          generatorVersion: SCHEMA_GENERATOR_VERSION,
+          generatedAt: now,
+          lastError: result.errorMessage ?? null,
+        },
+      });
+    return { status, schema: result.schema, contentHash: hash, generatedAt: now.toISOString(), lastError: result.errorMessage ?? null };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'schema generation failed';
+    await db
+      .insert(skillSchemaCache)
+      .values({
+        catalogId: catalog.id,
+        contentHash: hash,
+        schema: null,
+        status: 'failed',
+        generatorVersion: SCHEMA_GENERATOR_VERSION,
+        generatedAt: now,
+        lastError: msg,
+      })
+      .onConflictDoUpdate({
+        target: [skillSchemaCache.catalogId, skillSchemaCache.contentHash],
+        set: { status: 'failed', generatedAt: now, lastError: msg },
+      });
+    return { status: 'failed', schema: null, contentHash: hash, generatedAt: now.toISOString(), lastError: msg };
+  }
+}

--- a/src/components/skills/curated-skill-detail-dialog.tsx
+++ b/src/components/skills/curated-skill-detail-dialog.tsx
@@ -1,9 +1,10 @@
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
 import ReactMarkdown from 'react-markdown';
 import { markdownComponents, markdownRemarkPlugins } from '~/components/claude-chat/markdown-components';
-import { Loader2, ExternalLink, AlertCircle } from 'lucide-react';
+import { Loader2, ExternalLink, AlertCircle, Sparkles, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
 import { useIntlayer } from 'react-intlayer';
 import { toLocalizedString } from '~/lib/utils';
 import {
@@ -14,8 +15,13 @@ import {
   DialogTitle,
 } from '~/components/ui/dialog';
 import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
 import { ScrollArea } from '~/components/ui/scroll-area';
-import { getCuratedSkillDetailFn } from '~/server/function/skills.server';
+import {
+  getCuratedSkillDetailFn,
+  getCuratedSkillSchemaFn,
+  generateCuratedSkillSchemaFn,
+} from '~/server/function/skills.server';
 
 /**
  * Curated Skill Detail Dialog (Skills S1b) — read-only.
@@ -31,6 +37,9 @@ export const CuratedSkillDetailDialog: FC<{
 }> = ({ slug, isOpen, onClose }) => {
   const content = useIntlayer('skills');
   const getDetail = useServerFn(getCuratedSkillDetailFn);
+  const getSchema = useServerFn(getCuratedSkillSchemaFn);
+  const genSchema = useServerFn(generateCuratedSkillSchemaFn);
+  const [generating, setGenerating] = useState(false);
 
   const { data, isLoading } = useQuery({
     queryKey: ['curated-skill-detail', slug],
@@ -42,8 +51,41 @@ export const CuratedSkillDetailDialog: FC<{
     staleTime: 5 * 60 * 1000,
   });
 
+  const { data: schema, refetch: refetchSchema } = useQuery({
+    queryKey: ['curated-skill-schema', slug],
+    queryFn: async () => {
+      if (!slug) return null;
+      return await getSchema({ data: { slug } });
+    },
+    enabled: !!slug && isOpen,
+    staleTime: 5 * 60 * 1000,
+  });
+
   const c = content.curated;
   const d = c.detail;
+  const sc = c.schema;
+
+  const handleGenerateSchema = async (force = false) => {
+    if (!slug) return;
+    setGenerating(true);
+    try {
+      await genSchema({ data: { slug, force } });
+      await refetchSchema();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : toLocalizedString(sc.failed));
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const schemaInputs = (schema?.schema?.inputs ?? []) as Array<{
+    name: string;
+    label?: string;
+    type: string;
+    required?: boolean;
+    description?: string;
+  }>;
+  const hasSchema = schema?.status === 'valid' || schema?.status === 'needs_review' || schema?.status === 'stale';
 
   const editorialBlocks: Array<{ label: ReactNode; value: string | null }> = data
     ? [
@@ -132,6 +174,71 @@ export const CuratedSkillDetailDialog: FC<{
               <div className="flex items-center gap-2 rounded-md border border-dashed p-4 text-sm text-muted-foreground">
                 <AlertCircle className="h-4 w-4" />
                 {data?.contentStatus === 'no_upstream' ? d.noUpstream : d.contentUnavailable}
+              </div>
+            )}
+          </div>
+
+          {/* Fillable-variable schema (S2.2) */}
+          <div className="mt-6 border-t pt-4">
+            <div className="mb-2 flex items-center gap-2">
+              <Sparkles className="h-3.5 w-3.5 text-primary" />
+              <p className="text-xs font-medium text-muted-foreground">{sc.heading}</p>
+              {schema?.status === 'stale' && (
+                <Badge variant="outline" className="text-[10px]">{sc.stale}</Badge>
+              )}
+              {schema?.status === 'needs_review' && (
+                <Badge variant="outline" className="text-[10px]">{sc.needsReview}</Badge>
+              )}
+            </div>
+
+            {hasSchema ? (
+              <>
+                {schemaInputs.length > 0 ? (
+                  <div className="space-y-2">
+                    {schemaInputs.map((field) => (
+                      <div key={field.name} className="rounded-md border bg-muted/30 p-2.5">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium">{field.label || field.name}</span>
+                          <Badge variant="secondary" className="text-[10px]">{field.type}</Badge>
+                          {field.required && (
+                            <span className="text-[10px] text-destructive">{sc.required}</span>
+                          )}
+                        </div>
+                        {field.description && (
+                          <p className="mt-0.5 text-xs text-muted-foreground">{field.description}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">{sc.noInputs}</p>
+                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2 h-7 gap-1 px-2 text-xs"
+                  disabled={generating}
+                  onClick={() => handleGenerateSchema(true)}
+                >
+                  {generating ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                  {generating ? sc.generating : sc.regenerate}
+                </Button>
+              </>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  {schema?.status === 'failed' ? sc.failed : sc.none}
+                </p>
+                <p className="text-[11px] text-muted-foreground/70">{sc.costNote}</p>
+                <Button
+                  size="sm"
+                  className="h-7 gap-1 px-2 text-xs"
+                  disabled={generating || data?.contentStatus === 'no_upstream'}
+                  onClick={() => handleGenerateSchema(false)}
+                >
+                  {generating ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
+                  {generating ? sc.generating : sc.generate}
+                </Button>
               </div>
             )}
           </div>

--- a/src/contents/skills.content.ts
+++ b/src/contents/skills.content.ts
@@ -109,6 +109,27 @@ const skillsContent = {
         noUpstream: t({ en: 'This entry has no upstream source.', 'zh-Hans': '该条目没有上游内容源。', fr: 'Aucune source amont.', ja: 'このエントリーには上流ソースがありません。', ko: '이 항목에는 업스트림 소스가 없습니다.', 'zh-Hant': '該條目沒有上游內容源。' }),
         close: t({ en: 'Close', 'zh-Hans': '关闭', fr: 'Fermer', ja: '閉じる', ko: '닫기', 'zh-Hant': '關閉' }),
       },
+      // Fillable-variable schema (S2.2)
+      schema: {
+        heading: t({ en: 'Fillable variables', 'zh-Hans': '可填充变量', fr: 'Variables', ja: '入力変数', ko: '입력 변수', 'zh-Hant': '可填充變量' }),
+        none: t({ en: 'No fillable-variable form yet.', 'zh-Hans': '尚未生成可填充表单。', fr: 'Pas encore de formulaire.', ja: 'フォーム未生成。', ko: '아직 폼이 없습니다.', 'zh-Hant': '尚未產生可填充表單。' }),
+        noInputs: t({ en: 'This skill needs no input fields.', 'zh-Hans': '该技能无需输入字段。', fr: 'Aucun champ requis.', ja: '入力フィールドは不要です。', ko: '입력 필드가 필요 없습니다.', 'zh-Hant': '該技能無需輸入欄位。' }),
+        generate: t({ en: 'Generate form', 'zh-Hans': '生成可填充表单', fr: 'Générer le formulaire', ja: 'フォームを生成', ko: '폼 생성', 'zh-Hant': '產生可填充表單' }),
+        regenerate: t({ en: 'Regenerate', 'zh-Hans': '重新生成', fr: 'Régénérer', ja: '再生成', ko: '다시 생성', 'zh-Hant': '重新產生' }),
+        generating: t({ en: 'Generating…', 'zh-Hans': '生成中…', fr: 'Génération…', ja: '生成中…', ko: '생성 중…', 'zh-Hant': '產生中…' }),
+        required: t({ en: 'required', 'zh-Hans': '必填', fr: 'requis', ja: '必須', ko: '필수', 'zh-Hant': '必填' }),
+        costNote: t({
+          en: 'Generation runs one AI call; the result is cached per content and shared across the team.',
+          'zh-Hans': '生成会调用一次 AI；结果按内容缓存、团队共享。',
+          fr: 'La génération lance un appel IA ; le résultat est mis en cache et partagé.',
+          ja: '生成は AI を1回呼び出します。結果は内容ごとにキャッシュされ共有されます。',
+          ko: '생성은 AI를 1회 호출하며, 결과는 콘텐츠별로 캐시되어 공유됩니다.',
+          'zh-Hant': '產生會呼叫一次 AI；結果按內容快取、團隊共享。',
+        }),
+        stale: t({ en: 'Content changed — form may be outdated.', 'zh-Hans': '内容已更新——表单可能过期。', fr: 'Contenu modifié — formulaire peut-être obsolète.', ja: '内容が更新されました — フォームが古い可能性。', ko: '콘텐츠 변경 — 폼이 오래됐을 수 있음.', 'zh-Hant': '內容已更新——表單可能過期。' }),
+        needsReview: t({ en: 'Auto-generated in fallback mode — review before relying on it.', 'zh-Hans': '容错模式生成——使用前请人工核对。', fr: 'Généré en mode secours — à vérifier.', ja: 'フォールバック生成 — 確認してください。', ko: '폴백 모드 생성 — 확인 필요.', 'zh-Hant': '容錯模式產生——使用前請人工核對。' }),
+        failed: t({ en: 'Generation failed.', 'zh-Hans': '生成失败。', fr: 'Échec de la génération.', ja: '生成に失敗しました。', ko: '생성 실패.', 'zh-Hant': '產生失敗。' }),
+      },
       categories: {
         ai_engineering: t({ en: 'AI Engineering', 'zh-Hans': 'AI 工程', fr: 'Ingénierie IA', ja: 'AI エンジニアリング', ko: 'AI 엔지니어링', 'zh-Hant': 'AI 工程' }),
         research: t({ en: 'Research', 'zh-Hans': '研究', fr: 'Recherche', ja: 'リサーチ', ko: '리서치', 'zh-Hant': '研究' }),

--- a/src/server/function/skills.server.ts
+++ b/src/server/function/skills.server.ts
@@ -51,6 +51,7 @@ import {
   type SchemaStatus,
 } from '~/claude/skills';
 import { validateGitHubUrl } from '~/claude/skills/command-parser';
+import type { CatalogSchemaResult } from '~/claude/skills/catalog-schema';
 
 /**
  * Require authenticated user
@@ -585,6 +586,45 @@ export const ensureDefaultSkillsFn = createServerFn({ method: 'POST' }).handler(
 
   return { ensured };
 });
+
+// ============================================================================
+// Catalog fillable-variable schema (S2.2) — generated from SKILL.md, cached in
+// skill_schema_cache by content hash. Lazy/on-demand (each generation is an SDK
+// call); the cache is global per (catalogId, contentHash). See PRD D5/S2.2.
+// ============================================================================
+
+/**
+ * Read the cached fillable-variable schema for a curated skill (no generation).
+ */
+export const getCuratedSkillSchemaFn = createServerFn({ method: 'POST' })
+  .inputValidator(parseSlugInput)
+  .handler(async ({ data }): Promise<CatalogSchemaResult> => {
+    await requireUser();
+    const { readCatalogSchema } = await import('~/claude/skills/catalog-schema');
+    const row = await loadOfficialCatalogRow(data.slug);
+    if (!row) throw new Error(`Curated skill not found: ${data.slug}`);
+    return await readCatalogSchema(row.id);
+  });
+
+/**
+ * Generate (or refresh) the fillable-variable schema for a curated skill.
+ * Costs an SDK/LLM call; result is cached globally by content hash.
+ */
+export const generateCuratedSkillSchemaFn = createServerFn({ method: 'POST' })
+  .inputValidator((input) => {
+    const payload = typeof input === 'string' ? JSON.parse(input) : input;
+    const data = payload && typeof payload === 'object' && 'data' in payload
+      ? (payload as { data?: unknown }).data
+      : payload;
+    return z.object({ slug: z.string().min(1), force: z.boolean().optional().default(false) }).parse(data);
+  })
+  .handler(async ({ data }): Promise<CatalogSchemaResult> => {
+    await requireUser();
+    const { generateCatalogSchema } = await import('~/claude/skills/catalog-schema');
+    const row = await loadOfficialCatalogRow(data.slug);
+    if (!row) throw new Error(`Curated skill not found: ${data.slug}`);
+    return await generateCatalogSchema({ id: row.id, upstream: row.upstream }, { force: data.force });
+  });
 
 /**
  * Get global skills (admin only)


### PR DESCRIPTION
## Skills S2.2 — 可填充变量 schema 生成 + 详情页表单

从 catalog skill 的 SKILL.md 生成 composer 表单 schema，按 `(catalogId, contentHash)` 缓存进 `skill_schema_cache`。**懒生成**（每次生成 = 一次 SDK/LLM 调用）；缓存**全局共享**（生成一次，全员受益）。复用已修好的 `generateSchemaFromContent` 核心（独立 SDK 链、与 FS 解耦）。

### 变更
- `catalog-schema.ts`：
  - `readCatalogSchema(catalogId)`：cache-first 读；当内容 hash 与 schema 的 hash 不一致时标 `stale`。
  - `generateCatalogSchema(catalog,{force})`：取 SKILL.md（cache-first）→ 生成 → upsert；失败记 `status='failed'`（不抛）。状态枚举：missing/valid/stale/failed/needs_review。
- Server fns：`getCuratedSkillSchemaFn`（读）、`generateCuratedSkillSchemaFn`（生成/刷新）—— 均需登录；生成耗费用但全局缓存。
- **详情弹窗**新增「可填充变量」区：列出生成的字段（只读预览）、生成/重新生成按钮（带费用提示）、stale/needs_review/failed 态。（交互式 composer 表单随 D9 的 composer 重做一起做。）

### 验证
对**线上 ARK + DB** 端到端实测：SKILL.md → schema（2 字段，name「查找技能」，needsReview=false）→ `skill_schema_cache`（status=valid, v1.1.0）→ 读回一致；`pnpm build` ✓、`oxlint` 0 errors；新增文件 typecheck 无报错。

### 不在本期（S4）
- 后台预热（走 BullMQ worker）；composer 交互表单接线（随 D9 composer 重做）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)