### PR TITLE
fix(skills): S4a — composer reads DB schema + lean skill-context (token fix)

### DIFF
--- a/src/components/claude-chat/a2composer-panel.tsx
+++ b/src/components/claude-chat/a2composer-panel.tsx
@@ -17,7 +17,7 @@ import { ChevronDown, Minimize2 } from 'lucide-react';
 import type { A2Category, A2Template, A2ComposerStore } from '~/lib/a2composer/types';
 import { resolveSkillMatch } from '~/lib/a2composer/skill-match';
 import { applyTemplate, extractVariables } from '~/lib/a2composer/template-utils';
-import { listAllSkillsFn, getSkillSchemaFn, ensureUserSkillEnabledFn } from '~/server/function/skills.server';
+import { listAllSkillsFn, getCuratedSkillSchemaFn, ensureUserSkillEnabledFn } from '~/server/function/skills.server';
 import { getA2ComposerStoreFn } from '~/server/function/a2composer.server';
 import type { ExtendedSkillInfo, SkillInputField } from '~/claude/skills';
 import { useChatSessionStore } from '~/lib/chat-session-store';
@@ -41,7 +41,7 @@ export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOp
   const [variableValues, setVariableValues] = useState<Record<string, string>>({});
 
   const listAllSkills = useServerFn(listAllSkillsFn);
-  const getSkillSchema = useServerFn(getSkillSchemaFn);
+  const getSkillSchema = useServerFn(getCuratedSkillSchemaFn);
   const ensureSkillEnabled = useServerFn(ensureUserSkillEnabledFn);
   const getStore = useServerFn(getA2ComposerStoreFn);
   const addTemporarySkill = useChatSessionStore((state) => state.addTemporarySkill);
@@ -82,8 +82,8 @@ export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOp
 
   const { data: schemaData } = useQuery({
     queryKey: ['a2composer-schema', selectedTemplate?.skillId],
-    // P1 fix: Use { data: { skillSlug } } pattern for POST server functions
-    queryFn: () => getSkillSchema({ data: { skillSlug: selectedTemplate?.skillId ?? '' } }),
+    // S4: read the fillable-variable schema from the DB cache (skill_schema_cache)
+    queryFn: () => getSkillSchema({ data: { slug: selectedTemplate?.skillId ?? '' } }),
     enabled: Boolean(selectedTemplate?.skillId),
   });
 

--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -529,9 +529,14 @@ Example bad operations:
 - Read("/etc/passwd")                ← DON'T access system files
 - Write(".claude/skills/my-skill/SKILL.md", "...")  ← DON'T write to skills`;
 
+    // The skill is already materialized in .claude/skills and surfaced to the
+    // model via the SDK's progressive disclosure (name + description). When the
+    // user explicitly selects one, we only nudge the model to prefer it — we do
+    // NOT inject the full SKILL.md (that's redundant with disclosure and wastes
+    // tokens on every turn; the SDK loads the body on demand via the Skill tool).
     const skillContext = await loadSkillContext(skillSlug, config.cwd);
     const skillAppend = skillContext
-      ? `\n\n[Explicit Skill Selected: ${skillContext.slug}]\n${skillContext.content}\n[End Skill]\n`
+      ? `\n\n[The user explicitly selected the "${skillContext.slug}" skill for this message. Prefer using it; load its full instructions via the Skill tool as needed.]\n`
       : '';
 
     const stream = query({


### PR DESCRIPTION
## S4a — composer 正确性修复（来自 S4 缺陷分析）

两个解耦、零风险的修复（更大的 composer UX 重做 + 旧 UI 清理另行处理，需先定上传迁移/选择器 UX）：

- **`loadSkillContext`（worker）**：不再每轮把所选技能的**整篇 SKILL.md** 灌进 system prompt。已安装技能本就由 SDK **渐进式披露**（name+desc）+ Skill 工具按需加载，全文注入是冗余 + 每轮浪费 token。改为只注入一行「优先使用该技能」提示。
- **A2ComposerPanel 可填充表单**：schema 改读 **DB**（`getCuratedSkillSchemaFn` → `skill_schema_cache`，S2.2），不再读已失效的 FS `getSkillSchemaFn`（`.schema.json` 在退役 skills-store 后已不存在）。返回 `{schema.inputs}` 形状一致，表单渲染不变。

`pnpm build` + `oxlint` 0 errors 通过。（a2composer-panel 既有的 options 索引签名告警与本改动无关、早已存在。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)