### PR TITLE
docs: real-preview architecture decision + workbench/ordering fix plan

### DIFF
--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -200,6 +200,18 @@ file → done). The earlier GLM-plan blocker is resolved.
 
 ## Decision log
 
+- **2026-06-04** — **「真预览」架构拍板（架构师评审）**：让用户看到 agent 生成的多文件 App 真正运行。
+  方向 = **per-session 持久沙盒 + 按需预览进程 + idle 回收**（不每会话常驻 dev server）。
+  新增 `PreviewRuntime`/`SessionSandboxManager`（不硬改 one-shot `DockerBackend`）+ `preview-controller`
+  sidecar 独占 docker socket；**双档**（默认 build→内置静态服务器 serve=硬验收，HMR dev=best-effort）；
+  **Traefik + Docker provider + forward-auth**（本地 `*.127-0-0-1.sslip.io`、生产 `*.preview.<domain>`+
+  wildcard cert，子路径仅兜底，v1 不做 on-demand TLS）；鉴权用**一次性 bootstrap JWT → opaque
+  httpOnly host-only preview cookie**；app manifest = `.oxygenie/app.json`（v1 启发式生成，命令仅限
+  package.json scripts）；**Provider 抽象先留、只实现 Docker**；**v1 硬验收 = 纯前端 SPA
+  install→build→static→iframe**，Next/Express/带 API = best-effort。诊断+对比+计划见
+  `research/2026-06-real-preview-architect-brief.md` + `…-v1-implementation-plan.md` +
+  `…-workbench-artifact-ordering-fix-plan.md`。**归属**：沙盒新对话执行。也顺带记录三个 UI 缺陷
+  （Workbench 只 Progress/滞后、每文件一张「打开成果物」、消息错乱）的根因与 Phase A/B 修正（UI 轨道）。
 - **2026-06-04** — **Skills integration S1–S4 shipped + owner-tested** (PRs #90–#99). Model:
   **DB catalog = source of truth**, FS = runtime projection (materialize enabled skills to
   `~/.claude/skills/`). Key owner decisions recorded in the Skills PRD:

--- a/docs/project/research/2026-06-real-preview-architect-brief.md
+++ b/docs/project/research/2026-06-real-preview-architect-brief.md
@@ -1,0 +1,130 @@
+# 架构评审简报：Workbench / 成果物「真预览」/ 消息顺序
+
+> 日期：2026-06-04 ｜ 面向：外部/资深架构师评审 ｜ 状态：待评审
+> 配套：`2026-06-workbench-artifact-ordering-fix-plan.md`（详细修正计划 + UI/IA 设计）。
+> 目的：请架构师评估方案合理性，**重点是「真预览」（让用户看到 agent 生成的多文件 App 真正跑起来）的架构选型**。
+
+---
+
+## 0. 产品与约束（评审前提）
+
+- **OxyGenie**：自托管、单组织、多用户（半可信团队）的 Claude-Agent 工作台。**不是公网多租户 SaaS**。
+- **执行模型**：每条消息 spawn 一个子进程 worker 调用 Claude Agent SDK；**per-session 沙盒**（每会话独立 `CLAUDE_HOME` + workspace 目录）。已有 `ExecutionRuntime` 抽象 + `LocalProcessBackend`（srt 沙盒）/`DockerBackend`，但**当前是「每消息即起即灭」**，无长驻进程。
+- **规模目标**：单台 16G/8-core，约 50 并发会话（已有并发上限 + idle-reaper + per-worker 堆限）。
+- **模型网关**：ARK（火山）；Claude Agent SDK **钉死 0.2.112**（0.2.113+ 原生二进制与 ARK 不兼容）。
+- **部署**：Docker Compose（本地 hybrid：`start-production.mjs` 同进程跑 Nitro :3000 + WS :3001）/ Dokploy。
+
+---
+
+## 1. 问题（用户实测反馈）
+
+1. **右侧 Workbench 四个 tab（Progress / Sub-agents / Files / Context）只有 Progress 有内容、且滞后**；其余三个空。
+2. **每个生成文件一张「打开成果物」卡**（交互诡异）；用 React+Vite 生成了一个产品、agent 自称成功，但**用户完全看不到结果**。
+3. **消息前后错乱**。
+
+---
+
+## 2. 调研结果（根因，附 file:line）
+
+**(1) Workbench**
+- Files / Context = **从未实现的占位**（`workbench-panel.tsx:248-259` 硬编码空态）。
+- Progress / Sub-agents = **靠刮消息流里的 tool-call**（`use-session-workbench.ts:57-84` 刮 `TodoWrite`、`:113` 刮 `Task`）；Progress 滞后因只在完整 assistant 消息落库时更新（`ws-adapter.ts:988-1027`），非增量。Sub-agents 空 = 没派生 Task 或 SDK 事件形状漂移未识别。**脆弱点：刮 tool-call 名字，而非读结构化状态。**
+
+**(2) 成果物 / 预览**
+- 过度触发：每个 `Write`/`Edit` 抽一个 artifact（`use-artifact-detection.ts:97-121` / `:243-256`），每 artifact 一张卡（`route.tsx:2176-2183`）。
+- React 预览**仅单文件**：`artifact-react.tsx:29` Sandpack 单入口文件，多文件 import 必崩。
+- **无真 dev server**：浏览器内 Sandpack 打包，从不起真实 Vite。
+- 结构化输出 artifact 元数据（`ws-query-worker.mjs:115-151`）与沙盒 workspace 真文件**两套系统脱节**；已有多文件 `workspace-sandpack-panel.tsx:82-102` 但独立未接入。
+
+**(3) 消息顺序**
+- **无序号**，全靠 JS 到达顺序（`ws-server.mjs:745` 发送不加 seq；`ws-adapter.ts:761` 只 push）。
+- `messages_loaded` 双处理（`ws-adapter.ts:524-531`，queue switch `:834-1367` 无该分支 → 死事件卡队列）。
+- 历史 + live 两段渲染无合并去重（`route.tsx:1459-1471`）。
+
+---
+
+## 3. 我的解决方案（概要；详见配套计划）
+
+**UI/IA 原则**：交付物 **push** 并保留；过程信息 push 到**可折叠**载体、**完成自动收起**；导航/索引/元信息 **pull**（右侧 Workbench 按需）。一轮 = 一张「turn 卡」（最终文本 + 至多一张交付物卡 + 一个折叠「运行过程」）。
+
+**分期**
+- **Phase A（前端/adapter，中等、可控）**：A1 事件加单调 `seq` + 单一有序时间线 + 删 `messages_loaded` 双处理（治错乱）；A2 turn 卡 + 过程折叠（完成收起）；A3 artifact 每轮一张（去重）。
+- **Phase B（前端 + 轻 server fn，小–中）**：B1 Files 读沙盒 workspace FS；B2 Context 接已有用量/模型/skills/mcp；B3 Progress/Sub-agents 稳健化 + 核验 SDK 事件。
+- **Phase C（沙盒为主，大、架构性）**：**真预览** —— 本简报第 5 节专门评审。
+
+---
+
+## 4. 难点评估（诚实）
+
+| 相 | 规模 | 风险 | 说明 |
+|---|---|---|---|
+| A1 顺序 | 中 | 中（核心链路） | 改动概念简单，但落在最大最中心的 `ws-adapter.ts`(1418行)/`chat-session-store.ts`/`route.tsx`(2000+行)，回归影响每次对话，须真机端到端验证。 |
+| A2 turn 卡 + 折叠 | 中 | 低（纯展示） | 收益最直观，建议先做。 |
+| A3 artifact 去重 | 小–中 | 低 | 局部。 |
+| B1/B2 | 小–中 | 低（加法、pull） | Files 读沙盒 FS；Context 接已有数据。 |
+| B3 | 小（先诊断） | 取决于结论 | SDK 事件形状核验，根治并入 C。 |
+| **C 真预览** | **大** | **高 / 架构性** | **非 UI 问题**：长驻 dev server + 端口暴露 + 反代/路由 + 生命周期回收 + iframe 安全。撞上「per-message 即起即灭 → per-session 长驻」的运行时演进（Phase 0.5 推迟项）。 |
+
+**一句话**：80% 的「看起来不对」用可控前端工（A+B）即可消除；剩 20%「真正跑起来给我看」是沙盒硬活（C），需架构决策。
+
+---
+
+## 5. 「真预览」业界怎么解（评审核心）⭐
+
+**问题本质**：agent 生成一个**多文件、有依赖、要跑 dev server** 的 App，如何让用户在产品里**看到它真正运行**。业界两大流派：
+
+### 流派 ①：浏览器内运行时（无后端基建）
+- **bolt.new = WebContainers**（StackBlitz）：用 WASM 在**浏览器标签页内**跑 Node + npm + dev server，预览即时、可装任意 npm 包、零服务器成本。**局限**：仅限浏览器可跑的（无原生二进制、受浏览器约束）、重型项目吃前端内存。
+- **Sandpack**（CodeSandbox）：更轻，浏览器内打包单/少文件组件。**OxyGenie 现在用的就是这个的最弱形态（单文件）** → 这就是多文件看不到的根因。
+
+### 流派 ②：远程/持久沙盒 + dev server + 反代「端口→URL」（主流、能跑真东西）
+- **E2B Fragments**：Firecracker microVM；`Sandbox.create(template)` → 写文件 → 装依赖 → web 模板返回 **`https://${sbx.getHost(port)}`** 预览 URL，iframe 嵌。**一次生成=一个完整可跑 fragment**（非每文件）。
+- **OpenHands**：**每会话一个持久 Docker runtime 容器**；把容器内 web 端口经 **host 端口映射 / 反向代理 / URL 模板**（`SANDBOX_CONTAINER_URL_PATTERN`、`WEB_HOST`、host networking）暴露给用户。云端（Daytona）直接把 localhost 端口换成专用 URL，如 `https://5000-sandbox123.node456.daytona.io`。**痛点也很真实**（GitHub issue：localhost vs 远程 host、原生端口转发支持）——说明「端口→可达 URL 的路由」是这条路线的核心工程。
+- **Lovable** = Fly.io + Firecracker microVM；**v0** = 远程沙盒；**deer-flow 2.0**（ByteDance，owner 提到的）= **隔离 Docker 沙盒 + 持久文件系统 + Bash**，能 run code / **build web apps** / 产出报告/PPT/网页（同属 Docker 沙盒族，预览走容器端口）。
+
+### 对 OxyGenie 的判断
+- **现状（Sandpack 单文件）= 流派①的最弱档**，先天看不了多文件 Vite App。
+- **架构对齐的目标 = 流派②**（OpenHands / E2B / deer-flow 同款）：**OxyGenie 已有 per-session 沙盒 + `DockerBackend`**，缺的就是「**持久化该会话沙盒 + 在里面起 dev/serve + 把端口经反代暴露成预览 URL + iframe 嵌**」。这把 C 从「未知」降为「**复杂但有成熟图纸**」。
+- **务实折中**：把 dev-server 预览做成主路径；**WebContainers/Sandpack 作为轻量兜底**（简单单组件 artifact 仍可即时预览，不必起容器）。
+- **自托管约束**：默认要能在团队自己的 Docker 里跑（不强依赖 E2B/Daytona 付费云）；但**预览运行时建议做成可插拔**（自托管 Docker 默认 + 可选接 E2B/Daytona）。
+
+---
+
+## 6. 给架构师的关键问题（请重点拍板）
+
+1. **运行时形态**：真预览需要**长驻** dev server（HMR 体验好但重）还是 **build 后静态 serve**（轻、安全，但无热更）？考虑「用户只想看到结果」这个核心诉求 + 50 并发/16G 预算，**长驻 Vite dev server 每会话一个是否吃得消**？是否走「按需启动 + idle 回收」？
+2. **per-message 即起即灭 → per-session 持久**：是否就此引入「per-session 暖容器/进程」？如何与现有 `ExecutionRuntime`/`DockerBackend` + idle-reaper + 并发上限协调（这正是 Phase 0.5 推迟的 warm-pool/tier-decoupling）？
+3. **端口→URL 路由**：反代用**子路径**（`/preview/<sid>/...`，需处理资源相对路径/HMR websocket）还是**子域名**（`<sid>.preview.host`，更干净但要泛域名/证书）？鉴权如何做到仅本组织可达？
+4. **可插拔**：自托管 Docker 默认 + 可选云沙盒（E2B/Daytona）——值不值得现在就抽象，还是先把自托管 Docker 一条路打通？
+5. **安全**：预览容器的网络出口（egress）、iframe `sandbox` 属性、密钥隔离——半可信团队威胁模型下的边界在哪？
+6. **「一个 App」边界**：artifact「一个交付物」按「本轮写入 workspace 的文件集合」判定，还是要求结构化输出显式声明一个 app（含 entry/port/deps，像 Fragments 的 `fragmentSchema`）？后者更可控但要改 SDK 提示/结构化输出。
+
+---
+
+## 7. 参考来源
+- E2B Fragments：github.com/e2b-dev/fragments（`fragmentSchema`、`sbx.getHost(port)` 预览 URL）
+- OpenHands Runtime：docs.openhands.dev/openhands/usage/architecture/runtime（端口映射/反代、`SANDBOX_CONTAINER_URL_PATTERN`）；Daytona×OpenHands runtime
+- bolt.new / WebContainers：github.com/stackblitz/bolt.new
+- deer-flow 2.0：github.com/bytedance/deer-flow（Docker 沙盒 + 持久 FS + build web apps）
+- deep-agents-ui：github.com/langchain-ai/deep-agents-ui（面板读结构化 state，非刮 tool-call）
+
+---
+
+## 8. 架构决策（已拍板 2026-06-04）
+
+架构师评审后**拍板**，落地见 `2026-06-real-preview-v1-implementation-plan.md`。一句话：
+
+> **v1：Traefik 子域名反代 + 一次性 token 换 preview cookie + `.oxygenie/app.json`/package 探测声明 app + 纯前端 SPA static preview 为硬验收；Live/dev 与服务端应用为 best-effort。**
+
+要点：
+1. **主线 = per-session 持久沙盒 + 按需预览进程 + idle 回收**；**不**每会话常驻 Vite dev server（50 会话/16G 撑不住）。`MAX_ACTIVE_PREVIEWS=4~6`、`PREVIEW_IDLE_TIMEOUT=5~10min`、`PREVIEW_MEMORY=512m~1g`，install 也占名额。
+2. **新增 `PreviewRuntime`/`SessionSandboxManager`**，**不硬改** one-shot `DockerBackend`；**`preview-controller` sidecar 独占 Docker socket**，app/preview 容器绝不碰 socket。
+3. **双档**：默认 `build → 内置静态服务器 serve`（完成态，硬验收）；HMR 才 `dev`（编辑态，best-effort）。
+4. **Traefik + Docker provider + forward-auth**；本地 `*.127-0-0-1.sslip.io`（主站同族域名）、生产 `*.preview.<domain>`+wildcard cert；子路径仅兜底；v1 不做 on-demand TLS。
+5. **鉴权**：一次性 bootstrap JWT（exp 60~120s, jti 一次性消费）→ `/__oxy/auth` 换 **opaque、httpOnly、host-only preview cookie**（Redis 映射，10~15min 滑动，受 idle reaper 约束）→ 302 去掉 URL token；不用 URL 常驻 token。
+6. **manifest = `.oxygenie/app.json` 唯一 schema**；v1 启发式扫描生成，未来 `declare_app` 工具写同一份；**命令只允许 package.json scripts，不执行自由 shell**。
+7. **Provider 抽象先留、只实现 Docker**（不接 E2B/Daytona）。
+8. **v1 硬验收 = 纯前端 SPA：install→build→static→iframe 可见**；Next/Express/带 API = best-effort/下一版。
+
+**归属**：在「沙盒 + 与沙盒交互」新对话执行；与 `…-fix-plan.md` 的 Phase A/B（消息顺序、过程折叠、Files/Context、artifact 去重）并行不冲突。
+</content>

--- a/docs/project/research/2026-06-real-preview-v1-implementation-plan.md
+++ b/docs/project/research/2026-06-real-preview-v1-implementation-plan.md
@@ -1,0 +1,113 @@
+# 真预览 v1 实施计划（架构师已拍板）
+
+> 日期：2026-06-04 ｜ 状态：**已定（架构师拍板）**，待沙盒新对话执行
+> 关联：`2026-06-real-preview-architect-brief.md`（评审简报 + 业界对比）、`2026-06-workbench-artifact-ordering-fix-plan.md`（UI/IA）。
+> 一句话决策：**Traefik 子域名反代 + 一次性 token 换 preview cookie + `.oxygenie/app.json`/package 探测声明 app + 纯前端 SPA static preview 为硬验收；Live/dev 与服务端应用为 best-effort。**
+
+---
+
+## 1. v1 范围（硬验收口径）
+
+> **Vite / CRA / 普通纯前端 SPA：`install → build → static serve → iframe 可见`。**
+
+- Next（server）、Express、带 API/env 的项目 → **best-effort / 下一版**（走 Live/dev 或后续），不作为 v1 成功标准。
+- Live/dev（HMR，编辑态）= best-effort；**Static（完成态）= 硬验收**。
+
+---
+
+## 2. 架构组件
+
+### 2.1 新增 `PreviewRuntime`（独立于 agent 主链路 / 现有 `DockerBackend`）
+**不改** agent 工具执行（继续 one-shot `DockerBackend`）。新增一层 `PreviewRuntime` / `SessionSandboxManager`：
+
+```ts
+type PreviewProvider = 'docker' | 'e2b' | 'daytona'   // v1 只实现 docker
+
+interface PreviewRuntime {
+  ensureSessionSandbox(sessionId): Promise<SandboxHandle>   // per-session 持久容器
+  installDeps(previewId): Promise<void>                     // 流式日志/超时/可取消/缓存
+  startPreview({ sessionId, manifest, mode }): Promise<{ previewId, internalPort }>
+  stopPreview(previewId): Promise<void>
+  reapIdlePreviews(): Promise<void>
+  getPreviewUrl(previewId): string
+}
+```
+- **per-session 持久容器**：挂载该 session 的 workspace + **持久 `node_modules` 卷**（跨预览缓存）；低权限用户、**无宿主密钥、无 Docker socket**、资源限额。
+- **双档**：`mode='static'`（默认/硬验收）= 跑 `buildCommand` → 用 **preview 镜像内置的小静态服务器** serve `dist/`（不依赖用户项目装 `serve`）；`mode='live'`（best-effort）= 跑 `devCommand`（HMR）。
+
+### 2.2 `preview-controller` sidecar（关键安全护栏）
+- **唯一持有 Docker socket 的组件**；app / PreviewManager 通过它的内部 API 起停容器，**绝不**把 docker socket 塞进 app/preview 容器。
+- v1 若为提速让 app 直接管：至少走 **socket-proxy + 最小权限**；preview 容器本身永远不碰 socket。
+
+### 2.3 路由：Traefik + Docker provider + forward-auth
+- 复用现有 Traefik（Dokploy 生产链路已是 Traefik）。preview 容器起来时打 **Traefik labels** → 动态被发现，免静态配置。
+- 域名：
+  - **本地**：`<previewId>.127-0-0-1.sslip.io`；**主站也用同族**（如 `app.127-0-0-1.sslip.io`）——不要 localhost/sslip 混用（否则 iframe cookie 更麻烦）。
+  - **生产**：`<previewId>.preview.<domain>` + **wildcard DNS + wildcard cert**。
+  - **子路径** = 仅最后兜底，不入主线。
+  - **v1 不做 per-preview on-demand TLS。**
+- **forward-auth** 中间件 → 命中 app 的鉴权端点：校验 preview cookie（或首次的 bootstrap token）+ **该用户对该 session 有权**，再放行。
+
+### 2.4 鉴权流（跨源、一次性 token 换 cookie）
+1. 用户点「预览」→ 主站签发 **bootstrap JWT**：`exp=60~120s`，带 `jti / previewId / sessionId / userId`，服务端记录 jti（Redis）**一次性消费**。
+2. token 放 URL，仅用于首次进入：`https://<previewId>.preview.<domain>/__oxy/auth?t=<jwt>`。
+3. `/__oxy/auth` 校验 jti（一次性消费）→ 种 **preview cookie** → **302 去掉 URL token**。
+4. preview cookie：**opaque session id**（Redis/DB 存映射），TTL 10~15min 滑动续期、**受 preview idle reaper 约束**；`httpOnly` + 生产 `Secure` + **host-only**（不宽泛种到主域）。
+5. 后续静态资源 / HMR ws 全靠该 cookie 经 forward-auth。
+- URL 常驻 token 仅极端 fallback，不入主路径。
+
+### 2.5 App manifest：`.oxygenie/app.json`（唯一 schema）
+```jsonc
+{
+  "rootDir": "string", "title": "string", "framework": "vite|cra|next|...",
+  "installCommand": "pnpm install", "buildCommand": "pnpm build",
+  "devCommand": "pnpm dev", "serveCommand": "string?",
+  "port": 5173, "entryFiles": ["..."]
+}
+```
+- **v1**：启发式扫描（探 `package.json` + framework）生成一份**临时 manifest** 写进 `.oxygenie/app.json`。
+- **未来 (A)**：`declare_app`/`preview_ready` 自定义 SDK 工具只是**写/更新同一份 manifest + 发 ready 事件**——无缝接上（留到 SDK 那轮）。
+- **命令校验**：v1 只允许 **`package.json` scripts**（`pnpm build`/`pnpm dev`/`npm run build`），**少碰自由 shell**，不无条件执行任意字符串。
+
+### 2.6 UI（接 `…-fix-plan.md` 的 IA）
+- **每个 App 一张「成果物/预览」交付物卡**（非每文件）；卡片 → 打开预览（默认 **Static**；可切 **Live**）。
+- 显示 install/build 日志 + 状态机：`installing → building → ready → failed → idle-stopped`。
+
+---
+
+## 3. 配置（16G/8-core 起步）
+```
+MAX_CONCURRENT_WORKERS=8           # 既有
+MAX_ACTIVE_PREVIEWS=4~6            # 新增；install 中的 preview 也占名额
+PREVIEW_IDLE_TIMEOUT_MS=300000~600000   # 5~10min
+PREVIEW_MEMORY=512m~1g
+```
+- 会话可 50 个，**同时在跑的 preview 不该 50 个**；idle-reaper 负责回收，active 上限防瞬时击穿。
+
+## 4. 安全（按拍板执行）
+- iframe `sandbox="allow-scripts allow-forms allow-downloads"`，**不轻易给 `allow-same-origin`**；preview origin 与主站分开。
+- preview 容器：低权限用户、无宿主密钥、无 docker socket、资源限额。
+- **egress 分阶段**：install 阶段放行 npm registry；run 阶段默认 deny / allowlist（可配）。
+- cookie host-only；不把主站 cookie 暴露给 preview app。
+- install：日志 + 超时 + 缓存 + 取消。
+
+---
+
+## 5. 任务拆分（粗序）
+1. `PreviewRuntime` 接口 + `DockerPreviewProvider`（ensureSandbox / install / start(static) / stop / reap / getUrl）+ 配置 + active 上限限流。
+2. `preview-controller` sidecar（持有 docker socket）+ compose 接线。
+3. Traefik labels + forward-auth + `/__oxy/auth` bootstrap→cookie 流 + sslip.io(本地)/wildcard(生产)。
+4. `.oxygenie/app.json` schema + 启发式扫描器 + 命令 allowlist。
+5. UI：交付物卡 + 预览 iframe + 日志 + 状态机（接 turn-卡 IA）。
+6. 端到端验收：Vite SPA（install→build→static→iframe）、idle 回收、active 上限、跨源鉴权隔离。
+
+## 6. 推迟（post-v1）
+- (A) `declare_app` 自定义 SDK 工具（咬 SDK 0.2.112 / ARK / 自定义工具事件）。
+- Live/dev（HMR）加固；Next/Express/带 API/env 的服务端应用。
+- per-preview on-demand TLS；`e2b`/`daytona` provider；子路径 fallback 加固。
+
+## 7. 依赖 / 风险
+- **需要 Docker**（preview provider=docker）；纯无 Docker 环境回退到轻量 Sandpack/WebContainers（仅简单单组件）。
+- 与本地 hybrid 模式（`start-production.mjs` 跑在宿主、非每会话 Docker）协调：preview 容器仍经 `preview-controller`/docker socket 起；确认本地开发者机器有 Docker。
+- 最大坑（架构师点名）：① 别把常驻 dev server 当默认；② 子路径反代复杂度（Vite base/HMR ws/绝对路径/history fallback）——所以子域名主线；③ preview 与主站同源（最危险捷径）；④ npm install 生命周期；⑤ 别硬改 DockerBackend 成长驻；⑥ 缺 active 上限会瞬时击穿。
+</content>

--- a/docs/project/research/2026-06-workbench-artifact-ordering-fix-plan.md
+++ b/docs/project/research/2026-06-workbench-artifact-ordering-fix-plan.md
@@ -1,0 +1,88 @@
+# 修正计划：Workbench 面板 / 成果物预览 / 消息顺序 + UI 优雅化
+
+> 日期：2026-06-04 ｜ 状态：计划待评审（仅诊断+计划，未改代码）
+> 关联：本轮三象限诊断 + 参考研究（Fragments、deep-agents-ui）。
+> 背景：owner 反馈右侧 Workbench 只有 Progress 有内容且滞后；每个生成文件一张「打开成果物」卡且 React+Vite 结果看不到；消息前后错乱。沙盒 + SDK 新功能兼容将由**单独的新对话**集中处理。
+
+---
+
+## 1. 根因（concrete，file:line）
+
+**A. Workbench 只有 Progress、且滞后**
+- Files / Context = **从未实现的占位**：`workbench-panel.tsx:248-259` 硬编码 `EmptyState`，无 store 字段/selector。
+- Progress / Sub-agents = **靠刮消息流里的 tool-call**（`use-session-workbench.ts:57-84` 刮 `TodoWrite`、`:109-140`/`:113` 刮 `Task`）。滞后因 selector 依赖 `messages` 变化、只在完整 assistant 消息落库时更新（`ws-adapter.ts:988-1027`），非增量。
+- Sub-agents 空：要么没派生 Task，要么 SDK/沙盒下 `Task` tool-call 事件形状漂移未被识别。**脆弱点：刮 tool-call 名字而非读结构化状态。**
+
+**B. 每文件一张「打开成果物」+ 多文件 App 看不到**
+- 过度触发：`use-artifact-detection.ts:97-121` 把每个 `Write`/`Edit` 抽成 artifact，`:243-256` 每文件 `createArtifact`；`route.tsx:2077` 每条消息触发、`:2176-2183` 每 artifact 一个按钮。
+- React 预览仅单文件：`artifact-react.tsx:29` Sandpack 单入口文件，无 `package.json`/兄弟文件 → 多文件 import 失败。
+- **无真 dev-server**：走浏览器内 Sandpack 打包，从不起真实 Vite。
+- 两套系统脱节：结构化输出 artifact 元数据（`ws-query-worker.mjs:115-151`）vs 沙盒 workspace 真文件，互不连通。已有 `workspace-sandpack-panel.tsx:82-102`（多文件 Sandpack）但独立、未接入。
+
+**C. 消息前后错乱**
+- 无序号：worker→ws→UI 全靠 JS 到达顺序（`ws-server.mjs:745` 发送不加 seq；`ws-adapter.ts:761` `content` 只 push）。
+- `messages_loaded` 双处理：`ws-adapter.ts:524-531` 既回调进 zustand 又转发进 queue，而 queue switch（`:834-1367`）无该分支 → 死事件卡队列。
+- 历史 + live 两段渲染无合并去重：`route.tsx:1459-1471`。
+- tool_use/tool_result 回填假定顺序：`chat-session-store.ts:401-538`。
+
+---
+
+## 2. 参考结论（references）
+
+- **Fragments (e2b-dev/fragments)** —— 「看到生成 App」的标准答案：**一次生成=一个完整可跑 fragment**（`fragmentSchema`: `template/file_path/code/additional_dependencies/install_dependencies_command/port/title/description`）；`Sandbox.create(template)` → 写文件 → 装依赖 → **web 模板返回 `https://${sbx.getHost(port)}` live 预览 URL**（iframe 嵌），**真 dev server 而非浏览器内打包**。
+- **deep-agents-ui (langchain-ai)** —— 面板读 agent **结构化 state**（files/todos/sub-agents），不刮 tool-call。Files 应直接读沙盒 workspace FS。
+
+---
+
+## 3. UI/IA 设计：什么展示、什么处理完收起（核心）
+
+**原则**：交付物 **push**（推到消息流并保留）；过程信息 push 到**可折叠**载体、**完成即自动收起**；导航/索引/元信息 **pull**（右侧 Workbench，按需打开，不抢主流）。一轮对话 = 一张「assistant turn 卡」。
+
+| 内容 | 性质 | 处理中（live） | 完成后 | 位置 |
+|---|---|---|---|---|
+| 最终回答文本 | **交付物** | 流式 | **保留**展开 | 消息流（turn 卡主体） |
+| 生成的 App / 文档 / 图（artifact） | **交付物** | 末尾浮现「查看预览」卡 | **保留** —— **每轮/每 App 一张卡**（非每文件） | turn 卡顶部 + 右侧 Preview |
+| 推理 / thinking | 过程 | 流式（弱化样式） | **收起** 为「Thought for Xs ▸」 | turn 卡内可折叠 |
+| 工具步骤（Read/Write/Bash/Task…） | 过程 | 实时一行状态「正在编辑 App.tsx…」 | **收起** 为「运行过程 · N 步 · 改 3 文件 ▸」 | turn 卡内可折叠组 |
+| Todos / 计划 | 过程+导航 | 实时勾选 | 折叠「计划 4/4 ✓」 | 右侧 **Progress**（pull） |
+| 子代理 | 过程 | 实时树 | 折叠摘要 | 右侧 **Sub-agents**（pull） |
+| Files（workspace） | 交付物索引 | 实时增长 | **保留** | 右侧 **Files**（pull，读沙盒 FS） |
+| Context（用量/模型/skills/mcp） | 元信息 | — | 按需 | 右侧 **Context**（pull） |
+
+**直接消除的乱象**：① 每文件一张「打开成果物」→ 每轮一张交付物卡；② 散落的「步骤已完成」→ 一个折叠的「运行过程」；③ 过程信息抢占主流 → 完成即收起，主流只留答案 + 交付物。
+
+---
+
+## 4. 修正计划（分期 + 归属）
+
+### Phase A — 消息流正确性 + 过程折叠（前端/adapter；安全；当前 UI 轨道可做）
+- **A1 单一有序时间线**：worker 事件加单调 `seq`；UI 把历史+live 合并成**一个按 seq 排序、按 id 去重**的列表；删除 `messages_loaded` 双处理。→ 解决「错乱」。
+- **A2 turn 卡 + 过程折叠**：每个 assistant turn 聚合为一张卡；reasoning + 工具步骤收进**可折叠「运行过程」组**，turn 完成自动折叠 + 一行摘要（步数/改动文件数）。→ 优雅化 + 消除散落卡。
+- **A3 artifact 去重**：交付物**每轮/每 App 一张**（不再每 Write/Edit 一张）；改 `use-artifact-detection`/`route.tsx` 的渲染聚合逻辑。
+
+### Phase B — Workbench 真数据（前端 + 轻量 server fn；当前轨道可做）
+- **B1 Files**：新增 server fn 读 session workspace 目录树 + 文件内容（沙盒 FS = 真相源），Files tab 接上。
+- **B2 Context**：接已有 `usageData` + `sessionMetadata`（模型/skills/mcp/本月用量）。
+- **B3 Progress/Sub-agents 稳健化**：先在 `ws-adapter` 加日志核实 SDK 0.2.112 是否真发 `TodoWrite`/`Task`/tool 事件；修滞后（增量更新）。**与沙盒/SDK 对话重叠** → 见 Phase C。
+
+### Phase C — 真预览（沙盒为主 → **新对话**）
+- **C1 Fragments 式沙盒预览**：在 per-session 沙盒里起 dev server（或 build+serve）→ 暴露端口 → 返回预览 URL → iframe 嵌。替代多文件场景的单文件 Sandpack。
+- **C2 「成果物」= App 预览卡**：接 C1 的预览 URL；无 dev server 时用 `workspace-sandpack-panel`（多文件）兜底。
+- **C3 SDK 事件核验**：确认 Task/TodoWrite/tool_result 事件形状，根治 Progress 滞后 + Sub-agents 空（B3 的根治版）。
+
+**归属**：A + B 属于本「UI/前端」轨道（不碰沙盒运行时）；**C（+B3 根治）属于 owner 要开的「沙盒 + 与沙盒交互」新对话**。A1/A2 的 turn-卡与折叠是后续一切的承载，建议先做。
+
+---
+
+## 5. 验收
+- 消息严格按真实顺序、resume 后历史与新消息不交错/不重复（A1）。
+- 一轮只有：最终文本 +（可选）一张交付物卡 + 一个折叠「运行过程」；过程完成即收起（A2/A3）。
+- 右侧 Files 显示真实 workspace 文件可点看；Context 显示用量/模型/能力（B1/B2）。
+- 生成多文件 React+Vite App → 一张预览卡 → 点开看到**真正运行**的页面（C1/C2）。
+- Progress 实时不滞后、Sub-agents 有数据（B3/C3）。
+
+## 6. 开放问题
+1. 预览的运行方式：沙盒内 `npm run dev`（长驻端口）vs `build` 后静态 serve？长驻 dev server 的生命周期/回收（对齐 idle-reaper）需设计。
+2. 预览安全：iframe sandbox 属性、端口仅本组织可达（对齐 VISION 半可信威胁模型）。
+3. artifact「一个 App」的边界判定：按一轮里写入 workspace 的文件集合？还是靠结构化输出声明一个 app？
+</content>


### PR DESCRIPTION
落库「真预览」诊断 + 架构师评审 + **已拍板的 v1 决策**，以及 Workbench/成果物/消息顺序的修正计划。

- `research/…-workbench-artifact-ordering-fix-plan.md` —— 3 个 UI 症状的根因(file:line) + 渐进式披露 IA（展示 vs 收起）+ 分期（A/B=UI 轨道，C=沙盒轨道）。
- `research/…-real-preview-architect-brief.md` —— 面向架构师的简报 + 业界对比（E2B Fragments / OpenHands / bolt.new WebContainers / deer-flow / deep-agents-ui）+ **§8 已拍板架构决策**。
- `research/…-real-preview-v1-implementation-plan.md` —— 可执行 v1：`PreviewRuntime` + `preview-controller` sidecar；per-session 持久沙盒 + 按需预览进程 + idle 回收；Traefik 子域名 + forward-auth；一次性 bootstrap JWT → opaque host-only preview cookie；`.oxygenie/app.json`（v1 启发式、命令仅限 package.json scripts）；**v1 硬验收 = 纯前端 SPA install→build→static→iframe**；Live/dev + 服务端 = best-effort；Provider 抽象、v1 只 Docker。
- STATUS 决策日志更新。

纯文档。实现归「沙盒/SDK 新对话」（真预览=Phase C）；UI 的 Phase A/B 可并行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)