### PR TITLE
feat(workbench): Phase B — wire Files + Context tabs to real session data

### DIFF
--- a/src/components/claude-chat/workbench-panel.tsx
+++ b/src/components/claude-chat/workbench-panel.tsx
@@ -20,13 +20,17 @@
  */
 
 import { useState, type FC, type ReactNode } from 'react';
-import { ListChecks, GitBranch, FolderOpen, Gauge, Check, Loader2 } from 'lucide-react';
+import { ListChecks, GitBranch, FolderOpen, Gauge, Check, Loader2, FileCode } from 'lucide-react';
 import { cn } from '~/lib/utils';
 import {
   useSessionTodos,
   useSessionSubAgents,
+  useSessionFiles,
+  useSessionContext,
   type TodoItem,
   type SubAgentItem,
+  type SessionFile,
+  type SessionContextInfo,
 } from '~/lib/hooks/use-session-workbench';
 
 type WorkbenchTab = 'progress' | 'subagents' | 'files' | 'context';
@@ -181,6 +185,62 @@ const SubAgentList: FC<{ subAgents: SubAgentItem[] }> = ({ subAgents }) => (
   </div>
 );
 
+/** ③ Files — workspace files the agent wrote/edited this session. */
+const FilesList: FC<{ files: SessionFile[] }> = ({ files }) => (
+  <div className="flex h-full flex-col">
+    <p className="px-4 pt-4 pb-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      Files · {files.length}
+    </p>
+    <ul className="flex flex-col gap-1 px-3 pb-4">
+      {files.map((f) => (
+        <li
+          key={f.path}
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/60"
+          title={f.path}
+        >
+          <FileCode className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-xs font-medium text-foreground">{f.fileName}</p>
+            <p className="truncate text-[10px] text-muted-foreground">{f.path}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+/** ④ Context — model · capabilities · token usage for this session. */
+const ContextView: FC<{ ctx: SessionContextInfo }> = ({ ctx }) => {
+  const rows: Array<{ label: string; value: string }> = [];
+  if (ctx.model) rows.push({ label: 'Model', value: ctx.model });
+  rows.push({ label: 'Skills', value: String(ctx.skills) });
+  rows.push({ label: 'MCP servers', value: String(ctx.mcpServers) });
+  rows.push({ label: 'Tools', value: String(ctx.tools) });
+  if (ctx.numTurns != null) rows.push({ label: 'Turns', value: String(ctx.numTurns) });
+  if (ctx.inputTokens != null || ctx.outputTokens != null) {
+    rows.push({
+      label: 'Tokens',
+      value: `${(ctx.inputTokens ?? 0).toLocaleString()} in · ${(ctx.outputTokens ?? 0).toLocaleString()} out`,
+    });
+  }
+  if (ctx.totalCostUsd != null) rows.push({ label: 'Cost', value: `$${ctx.totalCostUsd.toFixed(4)}` });
+  return (
+    <div className="flex h-full flex-col">
+      <p className="px-4 pt-4 pb-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Context & usage
+      </p>
+      <dl className="flex flex-col gap-2 px-4 pb-4">
+        {rows.map((r) => (
+          <div key={r.label} className="flex items-center justify-between gap-3 text-xs">
+            <dt className="text-muted-foreground">{r.label}</dt>
+            <dd className="truncate font-medium text-foreground" title={r.value}>{r.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};
+
 export interface WorkbenchPanelProps {
   currentSessionId: string | null;
   className?: string;
@@ -190,6 +250,8 @@ export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, clas
   const [activeTab, setActiveTab] = useState<WorkbenchTab>('progress');
   const todoSummary = useSessionTodos();
   const subAgents = useSessionSubAgents();
+  const files = useSessionFiles();
+  const context = useSessionContext();
 
   return (
     <aside
@@ -245,18 +307,24 @@ export const WorkbenchPanel: FC<WorkbenchPanelProps> = ({ currentSessionId, clas
               hint="When the agent delegates work via the Task tool, each sub-agent shows here with live status."
             />
           ))}
-        {activeTab === 'files' && (
-          <EmptyState
-            title="No files yet"
-            hint="Files and artifacts produced in this session's workspace will be listed here."
-          />
-        )}
-        {activeTab === 'context' && (
-          <EmptyState
-            title="Context & usage"
-            hint="Session memory, connectors, and this month's token usage will surface here."
-          />
-        )}
+        {activeTab === 'files' &&
+          (files.length > 0 ? (
+            <FilesList files={files} />
+          ) : (
+            <EmptyState
+              title="No files yet"
+              hint="Files the agent writes or edits in this session's workspace will be listed here."
+            />
+          ))}
+        {activeTab === 'context' &&
+          (context ? (
+            <ContextView ctx={context} />
+          ) : (
+            <EmptyState
+              title="Context & usage"
+              hint="Model, capabilities, and this session's token usage will surface here once a turn runs."
+            />
+          ))}
       </div>
 
       {/* Session-scope footer marker (skeleton — confirms per-session boundary) */}

--- a/src/lib/hooks/use-session-workbench.ts
+++ b/src/lib/hooks/use-session-workbench.ts
@@ -138,3 +138,74 @@ export function useSessionSubAgents(): SubAgentItem[] {
   const messages = useChatSessionStore((s) => s.messages);
   return useMemo(() => selectSubAgents(messages), [messages]);
 }
+
+// ───────────────────────── ③ Files ─────────────────────────
+
+export interface SessionFile {
+  path: string;
+  fileName: string;
+  /** The tool that last touched it (Write / Edit / …). */
+  tool: string;
+}
+
+const FILE_TOOLS = new Set(['write', 'edit', 'multiedit', 'notebookedit']);
+
+/**
+ * Files the agent produced/edited in this session's workspace, derived from
+ * Write/Edit tool-calls (latest touch wins, de-duped by path, in first-seen
+ * order). Store-only (no server round-trip) — a v1 approximation of the
+ * workspace tree; the sandbox-backed real FS listing is a later (sandbox) item.
+ */
+export function selectSessionFiles(messages: ThreadMessage[]): SessionFile[] {
+  const seen = new Map<string, SessionFile>();
+  for (const message of messages) {
+    for (const part of message.content) {
+      if (part.type !== 'tool-call') continue;
+      if (!FILE_TOOLS.has(part.toolName?.toLowerCase() ?? '')) continue;
+      const args = (part.args ?? {}) as Record<string, unknown>;
+      const fp =
+        readString(args.file_path) ?? readString(args.path) ?? readString(args.notebook_path);
+      if (!fp) continue;
+      const fileName = fp.split('/').pop() || fp;
+      seen.set(fp, { path: fp, fileName, tool: part.toolName });
+    }
+  }
+  return Array.from(seen.values());
+}
+
+export function useSessionFiles(): SessionFile[] {
+  const messages = useChatSessionStore((s) => s.messages);
+  return useMemo(() => selectSessionFiles(messages), [messages]);
+}
+
+// ───────────────────────── ④ Context ─────────────────────────
+
+export interface SessionContextInfo {
+  model?: string;
+  skills: number;
+  mcpServers: number;
+  tools: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalCostUsd?: number;
+  numTurns?: number;
+}
+
+/** Session context/usage from the store (model · skills · mcp · token usage). */
+export function useSessionContext(): SessionContextInfo | null {
+  const usage = useChatSessionStore((s) => s.usageData);
+  const meta = useChatSessionStore((s) => s.sessionMetadata);
+  return useMemo(() => {
+    if (!usage && !meta) return null;
+    return {
+      model: meta?.model,
+      skills: meta?.skills?.length ?? 0,
+      mcpServers: meta?.mcp_servers?.length ?? 0,
+      tools: meta?.tools?.length ?? 0,
+      inputTokens: usage?.usage?.input_tokens,
+      outputTokens: usage?.usage?.output_tokens,
+      totalCostUsd: usage?.total_cost_usd,
+      numTurns: usage?.num_turns,
+    };
+  }, [usage, meta]);
+}


### PR DESCRIPTION
Workbench 的 Files / Context 两个 tab 之前是从未实现的占位（硬编码空态）。接上真实会话数据（store-only selector，按当前会话作用域，和现有 Progress/Sub-agents 一致）：

- `use-session-workbench.ts`：
  - `selectSessionFiles`/`useSessionFiles` —— 本会话 agent 写/改的文件（从 Write/Edit/MultiEdit/NotebookEdit tool-call 推导，按路径去重）。v1 是 store 推导的近似 workspace 树；沙盒真 FS 列表留到沙盒轨道。
  - `useSessionContext` —— model · skills · MCP · tools · 轮数 · token 用量 · 成本（读已有 `usageData`+`sessionMetadata`）。
- `workbench-panel.tsx`：渲染 FilesList / ContextView（无数据回退空态）。

Phase A/B UI 修正之一（见 `research/2026-06-workbench-artifact-ordering-fix-plan.md`）。`pnpm build` + `oxlint` 0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)