### PR TITLE
fix(artifacts): A3 — one deliverable artifact card per message (not per file)

### DIFF
--- a/src/lib/hooks/use-artifact-detection.ts
+++ b/src/lib/hooks/use-artifact-detection.ts
@@ -145,6 +145,31 @@ function extractImageGroupsFromToolResults(
   return groups
 }
 
+// A3: collapse a multi-file generation (e.g. a React+Vite app writing App.tsx,
+// main.tsx, package.json, vite.config.ts …) to ONE "deliverable" artifact card
+// per message instead of one card per file. The other files still show in the
+// Workbench → Files tab. The single "real app preview" is Phase C (sandbox).
+const CONFIG_FILE_RE =
+  /(^|\/)(package(-lock)?\.json|pnpm-lock\.yaml|yarn\.lock|tsconfig[^/]*\.json|[^/]*\.config\.(js|ts|cjs|mjs)|vite\.config\.[^/]*|\.eslintrc[^/]*|\.prettierrc[^/]*)$/i
+const TYPE_RANK: Record<ArtifactType, number> = {
+  html: 5, react: 4, svg: 3, markdown: 2, csv: 1, json: 0, image: 0,
+}
+const ENTRY_HINT_RE = /(^|\/)(app|main|index)\.[jt]sx?$/i
+
+/** Choose the single most "previewable" target among a message's write/edit targets. */
+function pickPrimaryArtifactTarget(targets: ArtifactTarget[]): ArtifactTarget | null {
+  if (targets.length <= 1) return targets[0] ?? null
+  const nonConfig = targets.filter((t) => !CONFIG_FILE_RE.test(t.filePath))
+  const pool = nonConfig.length > 0 ? nonConfig : targets
+  return [...pool].sort((a, b) => {
+    const tr = (TYPE_RANK[b.type] ?? 0) - (TYPE_RANK[a.type] ?? 0)
+    if (tr !== 0) return tr
+    const ae = ENTRY_HINT_RE.test(a.filePath) ? 1 : 0
+    const be = ENTRY_HINT_RE.test(b.filePath) ? 1 : 0
+    return be - ae
+  })[0]
+}
+
 /**
  * Hook to detect and create artifacts from message content
  * Implements hybrid detection mode:
@@ -172,7 +197,11 @@ export function useArtifactDetection(messageId: string, content: ContentPart[] |
 
     // ✅ FIX: Only detect artifacts from completed tool calls (with result)
     // This prevents rendering loops caused by detecting incomplete tool-use events
-    const toolTargets = extractArtifactTargets(content, { requireResult: true })
+    // A3: collapse to one primary deliverable per message (rest live in Files tab).
+    const primaryTarget = pickPrimaryArtifactTarget(
+      extractArtifactTargets(content, { requireResult: true }),
+    )
+    const toolTargets = primaryTarget ? [primaryTarget] : []
 
     if (toolTargets.length > 0) {
       const pending = toolTargets.filter((target) => {
@@ -387,7 +416,11 @@ export function useArtifactDetection(messageId: string, content: ContentPart[] |
     }
 
     // Map existing artifacts to this message using file path (for historical sessions)
-    const linkTargets = extractArtifactTargets(content, { requireResult: false })
+    // A3: same one-primary-per-message collapse as the live path.
+    const linkPrimary = pickPrimaryArtifactTarget(
+      extractArtifactTargets(content, { requireResult: false }),
+    )
+    const linkTargets = linkPrimary ? [linkPrimary] : []
     if (linkTargets.length > 0 && sessionId) {
       let isCancelled = false
       const runLink = async () => {


### PR DESCRIPTION
多文件生成（React+Vite 写 App.tsx/main.tsx/package.json/vite.config.ts…）会**每文件一张「打开成果物」卡**。收敛为**每条消息一张主交付物卡**；其余文件改在 Workbench → Files tab 展示（Phase B）。真正「一个运行的 App」预览是 Phase C（沙盒）。

- `use-artifact-detection.ts`：新增 `pickPrimaryArtifactTarget()` —— 选单一最可预览的目标（用 `CONFIG_FILE_RE` 降权 config/lock 文件；类型排序 html>react>svg>markdown>csv>json/image；偏好 app/main/index 入口）。live 与 historical-link 两条路径都改为每条消息至多建一个 artifact。

单文件生成不变。Phase A/B UI 修正之一。`pnpm build`+`oxlint` 0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)