### PR TITLE
feat(chat): S2 — Cowork turn-card collapse summary + thinking dedup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,13 @@ CLAUDE_SESSIONS_ROOT="/tmp/claude-sessions"
 # CLAUDE_ALLOW_BASH="false"
 # CLAUDE_BYPASS_USER_IDS=""
 
-# Artifact metadata via Structured Outputs (set in .env.docker for Docker)
-# ENABLE_STRUCTURED_OUTPUTS="false"
+# Artifact metadata via Structured Outputs.
+# ENFORCED DEFAULT = false. Enabling it triggers the SDK outputFormat Stop-hook:
+# when the model doesn't call StructuredOutput it runs an extra loop AND leaks
+# "You MUST call the StructuredOutput tool" into the chat. Root-fix is coupled to
+# the artifact/structured-output strategy (Phase C / real-preview line) — keep off
+# until that lands. See docs/project/research/2026-06-real-preview-architect-brief.md.
+ENABLE_STRUCTURED_OUTPUTS="false"
 
 # WebSocket URL for Claude Agent communication (build-time variable for Vite)
 # Development: not needed (uses same origin)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,11 @@ ANTHROPIC_MODEL=<optional-model-override>
 WS_PORT=3001
 APP_URL=http://localhost:5000
 CLAUDE_SESSIONS_ROOT=/data/users
-ENABLE_STRUCTURED_OUTPUTS=true  # 可选
+# 默认关闭（强制默认）。开启会触发 SDK outputFormat 的 Stop-hook 强制机制：
+# 模型未调用 StructuredOutput 时会多跑一轮，并把 “You MUST call the StructuredOutput tool”
+# 内部反馈漏进对话。根因与 artifact/结构化输出策略耦合，归 Phase C/real-preview 线统一定，
+# 在此之前一律保持关闭。重启命令里用 `ENABLE_STRUCTURED_OUTPUTS=false` 覆盖。
+ENABLE_STRUCTURED_OUTPUTS=false  # 默认关闭，详见 docs/.../2026-06-real-preview-architect-brief.md
 ```
 
 ---

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -200,6 +200,13 @@ file → done). The earlier GLM-plan blocker is resolved.
 
 ## Decision log
 
+- **2026-06-04** — **Cowork S2 实现（turn 卡渲染收尾）+ S3 决定（暂不修，挂 artifact 线）**。S2：
+  `turn-builder.ts` 折叠头改 Cowork 式 **「Worked Xs · N steps · 改 K 文件」**（耗时=工具 `elapsedSeconds`
+  之和、步数=工具/搜索组渲染行、改动文件=Write/Edit/MultiEdit/NotebookEdit 去重计数；纯思考轮 stepCount=0
+  回退实时 previewText），并**去重连续重复的 thinking/intermediate** 行；运行中仍显示实时 preview + 步数 Tag。
+  历史/实时同组件（S1 P4 合并后天然成立）。**S3（结构化输出泄漏）决定不在本 PR 修**：owner 选「维持 env-off
+  + 不加投机文本过滤」——泄漏当前不触发（`ENABLE_STRUCTURED_OUTPUTS` **强制默认 false**，已写进 `.env.example`/
+  `CLAUDE.md`/worker 注释），根因与 artifact/结构化输出策略耦合，**备案到 `research/2026-06-real-preview-architect-brief.md` §9**，随 Phase C/artifact 线统一定。分支 `feat/cowork-s2-turn-card`。
 - **2026-06-04** — **Cowork 单源重做 S1 实现 + owner 实测通过 + 合并 `main`**（merge `feat/cowork-s1-single-source`）。
   落地：`useLocalRuntime`→`useExternalStoreRuntime`，`chat-session-store.messages` 成唯一有序真相源，
   ws-adapter `runChat()` 把每个 chunk 写进 store（带单调 `seq`），左侧流 + 右侧 Workbench 同读一份

--- a/docs/project/research/2026-06-real-preview-architect-brief.md
+++ b/docs/project/research/2026-06-real-preview-architect-brief.md
@@ -127,4 +127,16 @@
 8. **v1 硬验收 = 纯前端 SPA：install→build→static→iframe 可见**；Next/Express/带 API = best-effort/下一版。
 
 **归属**：在「沙盒 + 与沙盒交互」新对话执行；与 `…-fix-plan.md` 的 Phase A/B（消息顺序、过程折叠、Files/Context、artifact 去重）并行不冲突。
+
+---
+
+## 9. 备案：结构化输出泄漏（Cowork S3 根因，挂本线）
+
+> 记录时间：2026-06-04 ｜ 来源：Cowork 单源重做 S3（见 `2026-06-cowork-s1-review-and-s2s3-handoff.md` §4）。**根因与本「artifact 元数据/结构化输出」策略耦合，统一在本线定，S2 PR 不做文本过滤。**
+
+- **现象**：开启结构化输出后，模型未调用 StructuredOutput 时，SDK 的 `outputFormat` **Stop-hook 强制机制**会①多跑一轮、②把 “You MUST call the StructuredOutput tool” 内部反馈漏进对话。
+- **触发条件（双重门）**：`ENABLE_STRUCTURED_OUTPUTS=true` **且** prompt 命中 `hasStructuredOutputFileHint`（`ws-query-worker.mjs` 的 `query().options.outputFormat`，约 588 行）。
+- **当前状态（已强制默认关）**：`ENABLE_STRUCTURED_OUTPUTS` 强制默认 `false`（`.env.example` / `CLAUDE.md` / worker 注释均已写明）；关闭状态下泄漏与多跑一轮均不发生。artifact 元数据改由被动探测（`use-artifact-detection.ts`）兜底，不依赖结构化输出。
+- **根治选项（待本线定）**：① 维持关闭，artifact 元数据继续走探测；或 ② 若要重新启用，需先解决 Stop-hook 泄漏（过滤该内部反馈文本 + 抑制多跑一轮），并与本节的 manifest/`declare_app` 策略统一——`.oxygenie/app.json` 若成为 artifact 声明的唯一来源，结构化输出可能整体不再需要。**建议 ①，重启用须随本线 artifact 策略一并评审。**
+- **不做**：评审已决定 S2 PR **不**加投机性文本过滤（实现者无法离线复现确切注入格式，且只治标不治本——多跑一轮只有关 env 才能消除）。
 </content>

--- a/src/components/claude-chat/assistant-turn-card.tsx
+++ b/src/components/claude-chat/assistant-turn-card.tsx
@@ -550,13 +550,31 @@ export const AssistantTurnCard: FC<AssistantTurnCardProps> = ({
   onUrlClick,
 }) => {
   const isRunning = status?.type === 'running';
-  const { activities, responseText, responseIsStreaming, hasPendingText, previewText, renderItems } = useMemo(
-    () => buildAssistantTurn(content, isRunning),
-    [content, isRunning]
-  );
+  const {
+    activities,
+    responseText,
+    responseIsStreaming,
+    hasPendingText,
+    previewText,
+    renderItems,
+    elapsedSeconds,
+    stepCount,
+    changedFileCount,
+  } = useMemo(() => buildAssistantTurn(content, isRunning), [content, isRunning]);
 
   const hasResponse = Boolean(responseText);
   const hasActivities = activities.length > 0;
+
+  // D1.4 Cowork 折叠头：完成后用「Worked Xs · N steps · 改 K 文件」概览（有耗时/步数才显示），
+  // 运行中仍用实时 previewText。stepCount=0（纯思考轮）回退到 previewText 避免「0 steps」。
+  const summaryText = useMemo(() => {
+    const parts: string[] = [];
+    if (elapsedSeconds > 0) parts.push(`Worked ${formatElapsed(elapsedSeconds)}`);
+    parts.push(`${stepCount} ${stepCount === 1 ? 'step' : 'steps'}`);
+    if (changedFileCount > 0) parts.push(`改 ${changedFileCount} 文件`);
+    return parts.join(' · ');
+  }, [elapsedSeconds, stepCount, changedFileCount]);
+  const headerText = isRunning || stepCount === 0 ? previewText : summaryText;
 
   const [isExpanded, setIsExpanded] = useState(hasActivities && isRunning);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -592,10 +610,12 @@ export const AssistantTurnCard: FC<AssistantTurnCardProps> = ({
             ) : (
               <ChevronRight className="h-4 w-4" />
             )}
-            <Tag tone="ghost" className="tabular-nums">
-              {renderItems.length}
-            </Tag>
-            <span className="truncate flex-1">{previewText}</span>
+            {isRunning && (
+              <Tag tone="ghost" className="tabular-nums">
+                {stepCount}
+              </Tag>
+            )}
+            <span className="truncate flex-1">{headerText}</span>
           </button>
 
           {isExpanded && (

--- a/src/lib/turn-builder.ts
+++ b/src/lib/turn-builder.ts
@@ -48,6 +48,13 @@ export type AssistantTurn = {
   previewText: string;
   runningLabel: string | null;
   renderItems: RenderItem[];
+  // Cowork collapse-header summary inputs (S2): "Worked Xs · N steps · 改 K 文件".
+  /** Sum of per-tool elapsed seconds (from tool_progress); 0 when unavailable. */
+  elapsedSeconds: number;
+  /** Number of work steps shown when expanded (tool rows + each search group). */
+  stepCount: number;
+  /** Distinct files touched by Write/Edit/MultiEdit/NotebookEdit in this turn. */
+  changedFileCount: number;
 };
 
 export function stripMarkdown(text: string): string {
@@ -126,11 +133,19 @@ function buildTurnData(content: ContentPart[] | undefined, isRunning: boolean) {
     return { activities, responseText: '', responseIsStreaming: false, hasPendingText: false };
   }
 
+  // Dedup consecutive duplicate thinking rows (S2.2): the SDK / historical merge
+  // can surface the same reasoning text twice in a row. Track the previous
+  // reasoning/intermediate text; a tool call or final-answer text resets the run.
+  let lastThoughtKey: string | null = null;
+
   for (let i = 0; i < content.length; i++) {
     const part = content[i];
     if (part.type === 'text') {
       const textPart = part as TextContentPart;
       if (textPart.isIntermediate || textPart.isPending) {
+        const key = textPart.text.trim();
+        if (key && key === lastThoughtKey) continue;
+        if (key) lastThoughtKey = key;
         activities.push({
           id: `intermediate-${i}`,
           kind: 'intermediate',
@@ -138,9 +153,13 @@ function buildTurnData(content: ContentPart[] | undefined, isRunning: boolean) {
           status: textPart.isPending ? 'running' : 'completed',
         });
       } else {
+        lastThoughtKey = null;
         responseParts.push(textPart);
       }
     } else if (part.type === 'reasoning') {
+      const key = part.text.trim();
+      if (key && key === lastThoughtKey) continue;
+      if (key) lastThoughtKey = key;
       activities.push({
         id: `reasoning-${i}`,
         kind: 'reasoning',
@@ -148,6 +167,7 @@ function buildTurnData(content: ContentPart[] | undefined, isRunning: boolean) {
         status: isRunning ? 'running' : 'completed',
       });
     } else if (part.type === 'tool-call') {
+      lastThoughtKey = null;
       const toolPart = part as ToolCallContentPart;
       const displayName = formatToolDisplayName(toolPart.toolName);
       activities.push({
@@ -306,9 +326,40 @@ function getPreviewText(activities: StepActivity[], isRunning: boolean, hasRespo
   return '开始中…';
 }
 
+const FILE_EDIT_TOOLS = new Set(['write', 'edit', 'multiedit', 'notebookedit']);
+
+/** Distinct files touched by Write/Edit/MultiEdit/NotebookEdit tool steps. */
+function countChangedFiles(activities: StepActivity[]): number {
+  const files = new Set<string>();
+  for (const activity of activities) {
+    if (activity.kind !== 'tool') continue;
+    if (!FILE_EDIT_TOOLS.has(activity.toolName.toLowerCase())) continue;
+    const args = (activity.args ?? {}) as Record<string, unknown>;
+    const fp =
+      (typeof args.file_path === 'string' && args.file_path) ||
+      (typeof args.path === 'string' && args.path) ||
+      (typeof args.notebook_path === 'string' && args.notebook_path) ||
+      '';
+    if (fp) files.add(fp);
+  }
+  return files.size;
+}
+
+/** Number of work steps to advertise in the header: tool rows + each search group. */
+function countSteps(renderItems: RenderItem[]): number {
+  return renderItems.filter(
+    (item) => item.type === 'search-group' || (item.type === 'activity' && item.activity.kind === 'tool')
+  ).length;
+}
+
 export function buildAssistantTurn(content: ContentPart[] | undefined, isRunning: boolean): AssistantTurn {
   const { activities, responseText, responseIsStreaming, hasPendingText } = buildTurnData(content, isRunning);
   const hasResponse = Boolean(responseText);
+  const renderItems = buildRenderItems(activities);
+  const elapsedSeconds = activities.reduce(
+    (sum, activity) => sum + (activity.kind === 'tool' && activity.elapsedSeconds ? activity.elapsedSeconds : 0),
+    0
+  );
   return {
     activities,
     responseText,
@@ -316,6 +367,9 @@ export function buildAssistantTurn(content: ContentPart[] | undefined, isRunning
     hasPendingText,
     previewText: getPreviewText(activities, isRunning, hasResponse),
     runningLabel: getRunningLabel(activities, isRunning),
-    renderItems: buildRenderItems(activities),
+    renderItems,
+    elapsedSeconds,
+    stepCount: countSteps(renderItems),
+    changedFileCount: countChangedFiles(activities),
   };
 }

--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -255,6 +255,13 @@ process.stdin.on('end', async () => {
       console.error(`[Worker]   Selected Skill: ${skillSlug}`);
     }
 
+    // ENFORCED DEFAULT = OFF. Enabling outputFormat triggers the SDK's StructuredOutput
+    // Stop-hook: if the model doesn't call StructuredOutput it runs an extra loop AND
+    // leaks "You MUST call the StructuredOutput tool" into the chat. The root-fix is
+    // coupled to the artifact/structured-output strategy (Phase C / real-preview line),
+    // so this stays off until that lands. Opt-in requires ENABLE_STRUCTURED_OUTPUTS=true
+    // AND a structured-output file hint in the prompt. See
+    // docs/project/research/2026-06-real-preview-architect-brief.md.
     const useStructuredOutputs = process.env.ENABLE_STRUCTURED_OUTPUTS === 'true';
     const shouldUseStructuredOutputs = useStructuredOutputs && hasStructuredOutputFileHint(prompt);
 


### PR DESCRIPTION
S2 of the Cowork-faithful chat redesign (S1 merged to main).

## turn-builder.ts
- AssistantTurn gains elapsedSeconds (Σ per-tool elapsed), stepCount (tool/search-group render rows), changedFileCount (distinct Write/Edit/MultiEdit/NotebookEdit paths).
- Dedup consecutive duplicate thinking/intermediate rows (tool / final-answer resets the run) — fixes the doubled reasoning line from review.

## assistant-turn-card.tsx
- Collapsed/done header → Cowork-style **Worked Xs · N steps · 改 K 文件** (parts shown only when present); running still shows live previewText + step Tag; pure-thinking turns (stepCount=0) fall back to previewText. Historical/live share the component (true since S1 P4).

## S3 (StructuredOutput stop-hook leak) — deferred per owner
- No speculative text filter (can't reproduce exact injected format offline; only treats the symptom, doesn't stop the extra loop).
- `ENABLE_STRUCTURED_OUTPUTS` is now the **enforced default = false**, documented in `.env.example` / `CLAUDE.md` / `ws-query-worker.mjs`. Root cause filed to the artifact strategy line (real-preview brief §9) + decision log. Leak doesn't occur with the flag off (current op).

## Gate
- `pnpm build` ✓ (Node 20 needs `NODE_OPTIONS=--max-old-space-size=8192`) · `oxlint` 0 errors · no new type errors.
- Restart test: `source .env` then `ENABLE_STRUCTURED_OUTPUTS=false PORT=3000 APP_URL=http://localhost:3000 node start-production.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)