### PR TITLE
Phase C: real-preview v1 (backend + front-end seam)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,49 @@ PYTHON_RUNNER_MAX_CODE_BYTES="200000"
 # WS_IDLE_TIMEOUT_MS="900000"
 
 # =============================================================================
+# REAL APP PREVIEW (Phase C)
+# =============================================================================
+# Static preview is intentionally bounded separately from agent workers. Install
+# and build count as active preview work; idle previews are stopped and can be
+# restarted from the persisted workspace/node_modules cache.
+# MAX_ACTIVE_PREVIEWS="4"
+# PREVIEW_IDLE_TIMEOUT_MS="300000"
+# PREVIEW_CONTROLLER_URL="http://preview-controller:5055"
+# PREVIEW_CONTROLLER_PORT="5055"
+# PREVIEW_BOOTSTRAP_TTL_MS="90000"
+# PREVIEW_COOKIE_TTL_MS="900000"
+# PREVIEW_AUTH_SECRET="" # defaults to BETTER_AUTH_SECRET when omitted
+#
+# Local: use app.127-0-0-1.sslip.io for the main app and
+# <previewId>.127-0-0-1.sslip.io for previews.
+# Production: set PREVIEW_HOST_TEMPLATE="{previewId}.preview.example.com"
+# and configure wildcard DNS/TLS for *.preview.example.com.
+# PREVIEW_PROTOCOL="http"
+# PREVIEW_BASE_DOMAIN="127-0-0-1.sslip.io"
+# PREVIEW_HOST_TEMPLATE=""
+# PREVIEW_COOKIE_SECURE="0"
+#
+# Preview container/controller settings. The preview-controller sidecar is the
+# only component that should hold the Docker socket.
+# PREVIEW_IMAGE="node:24-bookworm-slim"
+# PREVIEW_MEMORY="768m"
+# PREVIEW_CPUS="1"
+# PREVIEW_PIDS="256"
+# PREVIEW_CONTAINER_USER="1001:1001"
+# PREVIEW_INTERNAL_PORT="4173"
+# PREVIEW_INSTALL_TIMEOUT_MS="300000"
+# PREVIEW_BUILD_TIMEOUT_MS="300000"
+# PREVIEW_DOCKER_NETWORK="bridge"
+#
+# Traefik labels generated for preview containers.
+# PREVIEW_TRAEFIK_ENABLED="1"
+# PREVIEW_TRAEFIK_NETWORK=""
+# PREVIEW_TRAEFIK_ENTRYPOINTS="web"
+# PREVIEW_TRAEFIK_TLS="0"
+# PREVIEW_TRAEFIK_CERTRESOLVER=""
+# PREVIEW_FORWARD_AUTH_URL="http://app:3001/__oxy/preview/authorize"
+
+# =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================
 # Local dev: use localhost below. Docker: migrate/app/worker build DATABASE_URL from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,10 +162,19 @@ Claude Agent SDK 文档相对较新，**无法通过 MCP 工具获取**，需要
 ### 环境变量
 
 ```bash
-# Anthropic API
-ANTHROPIC_API_KEY=<your-api-key>
-ANTHROPIC_BASE_URL=<optional-base-url>
-ANTHROPIC_MODEL=<optional-model-override>
+# Anthropic / ARK 网关
+# ⚠️ ARK（火山）coding 网关用 Bearer 鉴权：设 ANTHROPIC_AUTH_TOKEN，**不要**设 ANTHROPIC_API_KEY
+#    （设了 ws-server 会注入它，SDK 改走 x-api-key 而非 Bearer，ARK 会失败）。
+#    鉴权无需改代码：worker 继承 process.env，SDK 调起的 CLI 直接读以下环境变量。
+ANTHROPIC_AUTH_TOKEN=<ark-api-key>           # ARK：Bearer token（生产用这个）
+ANTHROPIC_API_KEY=<your-api-key>             # 仅原生 Anthropic / x-api-key 场景
+ANTHROPIC_BASE_URL=<gateway-base-url>        # ARK: https://ark.cn-beijing.volces.com/api/coding
+ANTHROPIC_MODEL=<model>                       # 主模型（如 glm-5.1）
+# 模型别名（按 ARK 可用模型映射；haiku=后台廉价档）
+ANTHROPIC_DEFAULT_SONNET_MODEL=<model>
+ANTHROPIC_DEFAULT_OPUS_MODEL=<model>
+ANTHROPIC_DEFAULT_HAIKU_MODEL=<model>        # 如 doubao-seed-2.0-lite
+CLAUDE_CODE_SUBAGENT_MODEL=<model>
 
 # WebSocket 服务器
 WS_PORT=3001
@@ -796,3 +805,17 @@ services:
 3. ✅ 确认 `docker-compose.dokploy.yml` 包含 `pull_policy: always`
 4. ✅ 在 Dokploy 触发重新部署
 5. ✅ 检查部署日志确认拉取了新镜像（看 digest 是否变化）
+
+### 生产部署（oxygenie.cc）决策与差异
+
+**完整决策记录 + 与 `docker-compose.dokploy.yml` 的精确差异 + runbook**：
+见 `docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md`。关键不变量（改部署前先读）：
+
+- **域名**：app=apex `oxygenie.cc`；预览=**单层 `*.oxygenie.cc`**（Cloudflare 免费 SSL 不覆盖两层
+  `*.preview.*`，勿用两层）。
+- **TLS**：Cloudflare 橙云 + **Full(Strict) + Origin CA 证书**，**不要用 Let's Encrypt**
+  （橙云下 HTTP-01 会失败）；compose 里所有 `certresolver=letsencrypt` 需去掉、改走 Traefik 默认证书。
+- **ARK 鉴权**：见上「环境变量」段 —— 用 `ANTHROPIC_AUTH_TOKEN`，**不设** `ANTHROPIC_API_KEY`。
+- **镜像 build-args**：`buildx` 需传 `--build-arg VITE_WS_URL=wss://oxygenie.cc/ws/agent`（前端域名烤在构建期）。
+- **preview-controller**：真预览引擎已硬化（`src/preview/controller.mjs`，`CapAdd:['CHOWN']` +
+  detached serve + 自写容器内 pid）；镜像必须从含该提交的分支构建。

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -275,12 +275,18 @@ services:
       # OAuth Providers (frontend - Client ID only)
       VITE_GITHUB_CLIENT_ID: ${VITE_GITHUB_CLIENT_ID:-}
       VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
-      # Mastra Agent (Zhipu AI GLM-5.0 via Mastra built-in gateway)
-      ZHIPU_API_KEY: ${ZHIPU_API_KEY:?}
-      # Claude Agent SDK configuration
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?}
+      # Mastra Agent (Zhipu AI GLM via Mastra built-in gateway) — optional, not used in ARK-only deploy
+      ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
+      # Claude Agent SDK configuration — ARK gateway uses Bearer (ANTHROPIC_AUTH_TOKEN);
+      # do NOT set ANTHROPIC_API_KEY (it would make the SDK use x-api-key instead of Bearer).
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:?}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
       ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${ANTHROPIC_DEFAULT_SONNET_MODEL:-}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${ANTHROPIC_DEFAULT_OPUS_MODEL:-}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${CLAUDE_CODE_SUBAGENT_MODEL:-}
       # Gemini API for skill icon generation
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       CLAUDE_SESSIONS_ROOT: /data/users
@@ -303,7 +309,7 @@ services:
       MAX_ACTIVE_PREVIEWS: ${MAX_ACTIVE_PREVIEWS:-4}
       PREVIEW_IDLE_TIMEOUT_MS: ${PREVIEW_IDLE_TIMEOUT_MS:-300000}
       PREVIEW_PROTOCOL: ${PREVIEW_PROTOCOL:-https}
-      PREVIEW_HOST_TEMPLATE: ${PREVIEW_HOST_TEMPLATE:-{previewId}.preview.${APP_HOSTNAME}}
+      PREVIEW_HOST_TEMPLATE: ${PREVIEW_HOST_TEMPLATE:-{previewId}.${APP_HOSTNAME}}
       PREVIEW_COOKIE_SECURE: ${PREVIEW_COOKIE_SECURE:-1}
       PREVIEW_BOOTSTRAP_TTL_MS: ${PREVIEW_BOOTSTRAP_TTL_MS:-90000}
       PREVIEW_COOKIE_TTL_MS: ${PREVIEW_COOKIE_TTL_MS:-900000}
@@ -346,16 +352,16 @@ services:
       # 1. Main HTTP service (Web) - exclude /ws
       # ---------------------------------------------------------
       # HTTP router (port 80) -> redirect to HTTPS
-      - "traefik.http.routers.main-web.rule=Host(`deeptoai.com`) && !PathPrefix(`/ws`)"
+      - "traefik.http.routers.main-web.rule=Host(`${APP_HOSTNAME}`) && !PathPrefix(`/ws`)"
       - "traefik.http.routers.main-web.entrypoints=web"
       - "traefik.http.routers.main-web.middlewares=redirect-to-https@file"
       - "traefik.http.routers.main-web.service=main-service"
       - "traefik.http.routers.main-web.priority=50"
 
       # HTTPS router (port 443)
-      - "traefik.http.routers.main-websecure.rule=Host(`deeptoai.com`) && !PathPrefix(`/ws`)"
+      - "traefik.http.routers.main-websecure.rule=Host(`${APP_HOSTNAME}`) && !PathPrefix(`/ws`)"
       - "traefik.http.routers.main-websecure.entrypoints=websecure"
-      - "traefik.http.routers.main-websecure.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.main-websecure.tls=true"
       - "traefik.http.routers.main-websecure.service=main-service"
       - "traefik.http.routers.main-websecure.priority=50"
 
@@ -365,9 +371,9 @@ services:
       # ---------------------------------------------------------
       # 2. WebSocket service (WS) - exclusive /ws + higher priority
       # ---------------------------------------------------------
-      - "traefik.http.routers.ws-router.rule=Host(`deeptoai.com`) && PathPrefix(`/ws`)"
+      - "traefik.http.routers.ws-router.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/ws`)"
       - "traefik.http.routers.ws-router.entrypoints=websecure"
-      - "traefik.http.routers.ws-router.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ws-router.tls=true"
       - "traefik.http.routers.ws-router.priority=100"
       - "traefik.http.routers.ws-router.service=ws-service"
 
@@ -380,9 +386,9 @@ services:
       # Preview content is served by dynamic preview containers. Their /__oxy/*
       # auth paths must route back to the ws-server (same process that issued the
       # one-time token and owns preview cookie sessions).
-      - "traefik.http.routers.preview-auth.rule=HostRegexp(`{preview:[a-z0-9-]+}.preview.${APP_HOSTNAME}`) && PathPrefix(`/__oxy`)"
+      - "traefik.http.routers.preview-auth.rule=HostRegexp(`{preview:[a-z0-9-]+}.${APP_HOSTNAME}`) && PathPrefix(`/__oxy`)"
       - "traefik.http.routers.preview-auth.entrypoints=websecure"
-      - "traefik.http.routers.preview-auth.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.preview-auth.tls=true"
       - "traefik.http.routers.preview-auth.priority=200"
       - "traefik.http.routers.preview-auth.service=ws-service"
     restart: unless-stopped
@@ -417,7 +423,9 @@ services:
       PREVIEW_TRAEFIK_NETWORK: ${PREVIEW_TRAEFIK_NETWORK:-dokploy-network}
       PREVIEW_TRAEFIK_ENTRYPOINTS: ${PREVIEW_TRAEFIK_ENTRYPOINTS:-websecure}
       PREVIEW_TRAEFIK_TLS: ${PREVIEW_TRAEFIK_TLS:-1}
-      PREVIEW_TRAEFIK_CERTRESOLVER: ${PREVIEW_TRAEFIK_CERTRESOLVER:-letsencrypt}
+      # Empty: previews use Traefik's default cert (Cloudflare Origin CA), not Let's Encrypt
+      # (orange-cloud blocks HTTP-01). See research/2026-06-oxygenie-cc-dokploy-deployment.md §3.
+      PREVIEW_TRAEFIK_CERTRESOLVER: ${PREVIEW_TRAEFIK_CERTRESOLVER:-}
       PREVIEW_FORWARD_AUTH_URL: ${PREVIEW_FORWARD_AUTH_URL:-http://app:3001/__oxy/preview/authorize}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -17,22 +17,13 @@
 
 version: '3.8'
 
-# Build configuration for Dokploy
-# Dokploy builds the image locally using environment variables from its UI
-# This ensures VITE_* variables are baked into the frontend bundle at build time
-x-app-build: &app_build
-  build:
-    context: .
-    dockerfile: Dockerfile
-    args:
-      # WebSocket URL (will be set via Traefik routing)
-      VITE_WS_URL: ${VITE_WS_URL:-wss://${APP_HOSTNAME}/ws/agent}
-      # OAuth Client IDs (optional - for social login, passed at build time)
-      VITE_GITHUB_CLIENT_ID: ${VITE_GITHUB_CLIENT_ID:-}
-      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
-      # PostHog product analytics (from Dokploy env config)
-      VITE_POSTHOG_KEY: ${VITE_POSTHOG_KEY:-}
-      VITE_POSTHOG_HOST: ${VITE_POSTHOG_HOST:-https://eu.i.posthog.com}
+# Image is built OFF-SERVER by CI (.github/workflows/build.yml, on push to main) and
+# pushed to GHCR; Dokploy only PULLS it. Building this heavy app on the Dokploy host
+# OOMs during the SSR bundle (rollup chunk rendering), so we never build in-place here.
+# Note: VITE_WS_URL is intentionally NOT baked — the frontend falls back to a runtime
+# wss://<current-host>/ws/agent (src/claude/adapters/ws-adapter.ts), so one image works
+# for any domain. OAuth/PostHog VITE_* can be added to build.yml build-args if needed.
+x-app-image: &app_image '${APP_IMAGE:-ghcr.io/foreveryh/oxygenie/app}:${APP_TAG:-latest}'
 
 services:
   # PostgreSQL database with pgvector extension
@@ -142,7 +133,8 @@ services:
   # Database migrations (runs before app starts)
   # Uses the same image built by the app service
   migrate:
-    <<: *app_build
+    image: *app_image
+    pull_policy: always
     container_name: ${APP_NAME:-OxyGenie}-migrate
     depends_on:
       db:
@@ -169,7 +161,8 @@ services:
   # Background workers for BullMQ (cron + indexing, etc.)
   # Uses the same image built by the app service
   worker:
-    <<: *app_build
+    image: *app_image
+    pull_policy: always
     container_name: ${APP_NAME:-OxyGenie}-worker
     depends_on:
       db:
@@ -212,7 +205,8 @@ services:
   # Dokploy builds the image locally to include VITE_* environment variables
   # Build args are passed from Dokploy's environment configuration
   app:
-    <<: *app_build
+    image: *app_image
+    pull_policy: always
     container_name: ${APP_NAME:-OxyGenie}-app
     # PR-C Step 0: enable srt (bubblewrap) sandbox for tool execution.
     # srt requires unprivileged user namespaces → seccomp=unconfined.
@@ -400,7 +394,8 @@ services:
   # socket; app calls it over the private network to create/remove preview
   # containers with Traefik labels.
   preview-controller:
-    <<: *app_build
+    image: *app_image
+    pull_policy: always
     container_name: ${APP_NAME_SANITIZED:-oxygenie}-preview-controller
     depends_on:
       app:

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -298,6 +298,15 @@ services:
       PYTHON_RUNNER_MAX_CODE_BYTES: ${PYTHON_RUNNER_MAX_CODE_BYTES:-200000}
       # Structured Outputs for Artifacts (auto-triggered on file-extension hints)
       ENABLE_STRUCTURED_OUTPUTS: ${ENABLE_STRUCTURED_OUTPUTS:-false}
+      # Phase C real preview runtime
+      PREVIEW_CONTROLLER_URL: ${PREVIEW_CONTROLLER_URL:-http://preview-controller:5055}
+      MAX_ACTIVE_PREVIEWS: ${MAX_ACTIVE_PREVIEWS:-4}
+      PREVIEW_IDLE_TIMEOUT_MS: ${PREVIEW_IDLE_TIMEOUT_MS:-300000}
+      PREVIEW_PROTOCOL: ${PREVIEW_PROTOCOL:-https}
+      PREVIEW_HOST_TEMPLATE: ${PREVIEW_HOST_TEMPLATE:-{previewId}.preview.${APP_HOSTNAME}}
+      PREVIEW_COOKIE_SECURE: ${PREVIEW_COOKIE_SECURE:-1}
+      PREVIEW_BOOTSTRAP_TTL_MS: ${PREVIEW_BOOTSTRAP_TTL_MS:-90000}
+      PREVIEW_COOKIE_TTL_MS: ${PREVIEW_COOKIE_TTL_MS:-900000}
       # WebSocket URL (frontend configuration)
       VITE_WS_URL: ${VITE_WS_URL:-wss://${APP_HOSTNAME}/ws/agent}
       # Polar billing (optional)
@@ -364,6 +373,56 @@ services:
 
       # WS service (ws-server)
       - "traefik.http.services.ws-service.loadbalancer.server.port=3001"
+
+      # ---------------------------------------------------------
+      # 3. Preview auth bootstrap/forward-auth endpoints
+      # ---------------------------------------------------------
+      # Preview content is served by dynamic preview containers. Their /__oxy/*
+      # auth paths must route back to the ws-server (same process that issued the
+      # one-time token and owns preview cookie sessions).
+      - "traefik.http.routers.preview-auth.rule=HostRegexp(`{preview:[a-z0-9-]+}.preview.${APP_HOSTNAME}`) && PathPrefix(`/__oxy`)"
+      - "traefik.http.routers.preview-auth.entrypoints=websecure"
+      - "traefik.http.routers.preview-auth.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.preview-auth.priority=200"
+      - "traefik.http.routers.preview-auth.service=ws-service"
+    restart: unless-stopped
+    networks:
+      - private
+      - dokploy
+
+  # Phase C preview controller. This is the only service that mounts the Docker
+  # socket; app calls it over the private network to create/remove preview
+  # containers with Traefik labels.
+  preview-controller:
+    <<: *app_build
+    container_name: ${APP_NAME_SANITIZED:-oxygenie}-preview-controller
+    depends_on:
+      app:
+        condition: service_started
+    user: root
+    environment:
+      NODE_ENV: production
+      PREVIEW_CONTROLLER_PORT: ${PREVIEW_CONTROLLER_PORT:-5055}
+      PREVIEW_CONTROLLER_CONTAINER: ${APP_NAME_SANITIZED:-oxygenie}-preview-controller
+      PREVIEW_IMAGE: ${PREVIEW_IMAGE:-node:24-bookworm-slim}
+      PREVIEW_MEMORY: ${PREVIEW_MEMORY:-768m}
+      PREVIEW_CPUS: ${PREVIEW_CPUS:-1}
+      PREVIEW_PIDS: ${PREVIEW_PIDS:-256}
+      PREVIEW_CONTAINER_USER: ${PREVIEW_CONTAINER_USER:-1001:1001}
+      PREVIEW_INTERNAL_PORT: ${PREVIEW_INTERNAL_PORT:-4173}
+      PREVIEW_INSTALL_TIMEOUT_MS: ${PREVIEW_INSTALL_TIMEOUT_MS:-300000}
+      PREVIEW_BUILD_TIMEOUT_MS: ${PREVIEW_BUILD_TIMEOUT_MS:-300000}
+      PREVIEW_DOCKER_NETWORK: ${PREVIEW_DOCKER_NETWORK:-dokploy-network}
+      PREVIEW_TRAEFIK_ENABLED: ${PREVIEW_TRAEFIK_ENABLED:-1}
+      PREVIEW_TRAEFIK_NETWORK: ${PREVIEW_TRAEFIK_NETWORK:-dokploy-network}
+      PREVIEW_TRAEFIK_ENTRYPOINTS: ${PREVIEW_TRAEFIK_ENTRYPOINTS:-websecure}
+      PREVIEW_TRAEFIK_TLS: ${PREVIEW_TRAEFIK_TLS:-1}
+      PREVIEW_TRAEFIK_CERTRESOLVER: ${PREVIEW_TRAEFIK_CERTRESOLVER:-letsencrypt}
+      PREVIEW_FORWARD_AUTH_URL: ${PREVIEW_FORWARD_AUTH_URL:-http://app:3001/__oxy/preview/authorize}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - claude-sessions:/data/users
+    command: ['node', 'src/preview/controller.mjs']
     restart: unless-stopped
     networks:
       - private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,6 +270,17 @@ services:
       PYTHON_RUNNER_MAX_CODE_BYTES: ${PYTHON_RUNNER_MAX_CODE_BYTES:-200000}
       # Structured Outputs for Artifacts (auto-triggered on file-extension hints)
       ENABLE_STRUCTURED_OUTPUTS: ${ENABLE_STRUCTURED_OUTPUTS:-true}
+      # Phase C real preview runtime (app talks to preview-controller; app does
+      # not mount Docker socket). Local preview domains use sslip.io by default.
+      PREVIEW_CONTROLLER_URL: ${PREVIEW_CONTROLLER_URL:-http://preview-controller:5055}
+      MAX_ACTIVE_PREVIEWS: ${MAX_ACTIVE_PREVIEWS:-4}
+      PREVIEW_IDLE_TIMEOUT_MS: ${PREVIEW_IDLE_TIMEOUT_MS:-300000}
+      PREVIEW_PROTOCOL: ${PREVIEW_PROTOCOL:-http}
+      PREVIEW_BASE_DOMAIN: ${PREVIEW_BASE_DOMAIN:-127-0-0-1.sslip.io}
+      PREVIEW_HOST_TEMPLATE: ${PREVIEW_HOST_TEMPLATE:-}
+      PREVIEW_COOKIE_SECURE: ${PREVIEW_COOKIE_SECURE:-0}
+      PREVIEW_BOOTSTRAP_TTL_MS: ${PREVIEW_BOOTSTRAP_TTL_MS:-90000}
+      PREVIEW_COOKIE_TTL_MS: ${PREVIEW_COOKIE_TTL_MS:-900000}
       # Schema generation debug logging (default: enabled)
       SCHEMA_GENERATION_DEBUG: ${SCHEMA_GENERATION_DEBUG:-true}
       # Schema generation trace logging (off|true|full)
@@ -282,6 +293,42 @@ services:
     ports:
       - '5050:5000'
       - '3051:3001'
+    profiles: ['selfhost', 'prod']
+
+  # Phase C preview controller. This is the only service that mounts the Docker
+  # socket; it creates/removes per-session preview containers on behalf of app.
+  preview-controller:
+    image: *app_image
+    pull_policy: never
+    container_name: ex0-preview-controller
+    depends_on:
+      app:
+        condition: service_started
+    user: root
+    environment:
+      NODE_ENV: production
+      PREVIEW_CONTROLLER_PORT: ${PREVIEW_CONTROLLER_PORT:-5055}
+      PREVIEW_CONTROLLER_CONTAINER: ex0-preview-controller
+      PREVIEW_IMAGE: ${PREVIEW_IMAGE:-node:24-bookworm-slim}
+      PREVIEW_MEMORY: ${PREVIEW_MEMORY:-768m}
+      PREVIEW_CPUS: ${PREVIEW_CPUS:-1}
+      PREVIEW_PIDS: ${PREVIEW_PIDS:-256}
+      PREVIEW_CONTAINER_USER: ${PREVIEW_CONTAINER_USER:-1001:1001}
+      PREVIEW_INTERNAL_PORT: ${PREVIEW_INTERNAL_PORT:-4173}
+      PREVIEW_INSTALL_TIMEOUT_MS: ${PREVIEW_INSTALL_TIMEOUT_MS:-300000}
+      PREVIEW_BUILD_TIMEOUT_MS: ${PREVIEW_BUILD_TIMEOUT_MS:-300000}
+      PREVIEW_DOCKER_NETWORK: ${PREVIEW_DOCKER_NETWORK:-bridge}
+      PREVIEW_TRAEFIK_ENABLED: ${PREVIEW_TRAEFIK_ENABLED:-1}
+      PREVIEW_TRAEFIK_NETWORK: ${PREVIEW_TRAEFIK_NETWORK:-}
+      PREVIEW_TRAEFIK_ENTRYPOINTS: ${PREVIEW_TRAEFIK_ENTRYPOINTS:-web}
+      PREVIEW_TRAEFIK_TLS: ${PREVIEW_TRAEFIK_TLS:-0}
+      PREVIEW_TRAEFIK_CERTRESOLVER: ${PREVIEW_TRAEFIK_CERTRESOLVER:-}
+      PREVIEW_FORWARD_AUTH_URL: ${PREVIEW_FORWARD_AUTH_URL:-http://app:3001/__oxy/preview/authorize}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - claude-sessions:/data/users
+    command: ['node', 'src/preview/controller.mjs']
+    restart: unless-stopped
     profiles: ['selfhost', 'prod']
 
 volumes:

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -201,6 +201,19 @@ file → done). The earlier GLM-plan blocker is resolved.
 
 ## Decision log
 
+- **2026-06-05** — **生产部署拍板：`oxygenie.cc` on Dokploy（待执行）+ preview-controller 硬化**。
+  完整决策/差异/runbook → `research/2026-06-oxygenie-cc-dokploy-deployment.md`。要点：
+  ① **域名**：app=apex `oxygenie.cc`，预览=**单层 `*.oxygenie.cc`**（CF 免费 SSL 不覆盖两层
+  `*.preview.`，故弃用 2 层）。② **TLS**：CF 橙云 + **Full(Strict) + Origin CA 证书**，**不用
+  Let's Encrypt**（橙云下 HTTP-01 会失败）；Origin CA 用带 `Zone>SSL&Certs>Edit` 的 API Token
+  签（Service Key 已弃用）。③ **ARK 鉴权**：用 **`ANTHROPIC_AUTH_TOKEN`（Bearer），不设
+  `ANTHROPIC_API_KEY`**；base=`https://ark.cn-beijing.volces.com/api/coding`；**无需改鉴权代码**
+  （worker 继承 `process.env`，SDK CLI 直接读环境）。④ **模型**：主/sonnet/opus/subagent=`glm-5.1`，
+  haiku=`doubao-seed-2.0-lite`；多模型切换延后。⑤ **镜像**：GHCR（既定），从 `codex/phasec-real-preview`
+  以 `--platform linux/amd64` + VITE build-args 重建。⑥ **dokploy compose 需改 6 处**（Host
+  deeptoai.com→oxygenie.cc、去 letsencrypt、预览单层、ARK auth-token、ZHIPU 改可选、VITE build-args）。
+  **preview-controller 硬化**（`d19621c`，本地真预览引擎已验证）：serve 改 detached `exec node`（修首跑竞态）、
+  服务器自写容器内 pid（修 restart/reap）、`CapAdd:['CHOWN']`（修 CapDrop ALL 下非-root 装依赖 EACCES）。
 - **2026-06-04** — **Ask/Act + HITL（Phase 3 Wave 2）实现 + owner 实测通过 + 合并 `main`**（merge
   `feat/ask-act-hitl`）。2 档(🖐 Ask 逐动作审批 / ⏩ Act 自主,默认),砍掉 explore/auto/Plan。实现:先
   **spike 验证** SDK `canUseTool` 能 async-await(0.2.112),再**对照官方文档**(canUseTool=官方 HITL 机制;

--- a/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
+++ b/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
@@ -20,7 +20,7 @@
 | 项 | 决策 | 备注 |
 |---|---|---|
 | 代码源 | GitHub `foreveryh/oxygenie` @ `codex/phasec-real-preview` | controller 硬化在 `d19621c` |
-| 镜像 | **GHCR**（既定方案）`ghcr.io/foreveryh/oxygenie/app`，`buildx --platform linux/amd64` | Dokploy 拉取，非 Dokploy 构建 |
+| 镜像 | **Dokploy 自建**（compose 用 `*app_build`，在 amd64 服务器构建）| 见 §8（已纠正；与 CLAUDE.md GHCR 段不一致，待 Owner 确认）|
 | Dokploy 项目 | 新建 `oxygenie` | |
 | App 域名 | `oxygenie.cc`（apex） | |
 | WebSocket | `wss://oxygenie.cc/ws/agent`（Traefik 按 `/ws` 路径转 3001） | |
@@ -127,8 +127,11 @@ ARK `/api/coding` 网关用 **Bearer（`ANTHROPIC_AUTH_TOKEN`）**，不是 `x-a
 5. **preview-controller 服务**（约 L396-421）：`PREVIEW_TRAEFIK_CERTRESOLVER` 默认 `letsencrypt` →
    清空（用默认 Origin 证书）；确认 `PREVIEW_TRAEFIK_NETWORK`/`PREVIEW_DOCKER_NETWORK=dokploy-network`
    （已是）；`PREVIEW_BASE_DOMAIN=oxygenie.cc`。镜像 = GHCR（含 controller 硬化，见 §7）。
-6. **VITE build args**（构建期烤入镜像，非 compose 运行期）：`VITE_WS_URL=wss://oxygenie.cc/ws/agent`、
-   `VITE_BASE_URL`（按需）必须在 `buildx` 构建镜像时通过 `--build-arg` 传入。
+6. **VITE build args**：已在 `x-app-build` 锚点按 `${APP_HOSTNAME}` 参数化（Dokploy 自建时自动烤入）；
+   只需设 `APP_HOSTNAME=oxygenie.cc`，无需手工传 `--build-arg`。
+
+> ✅ 第 6 处之外的 1–5 已于 2026-06-05 改完并 `docker compose config` 校验通过
+> （commit 见决策日志）。
 
 ---
 
@@ -149,18 +152,23 @@ ARK `/api/coding` 网关用 **Bearer（`ANTHROPIC_AUTH_TOKEN`）**，不是 `x-a
 
 ---
 
-## 8. GHCR 镜像构建（带 ARK/域名所需 build args）
+## 8. 镜像构建方式 —— Dokploy 自建（**已纠正**）
 
-```bash
-gh auth refresh -h github.com -s write:packages
-echo $(gh auth token) | docker login ghcr.io -u foreveryh --password-stdin
-docker buildx build --platform linux/amd64 \
-  --build-arg VITE_WS_URL=wss://oxygenie.cc/ws/agent \
-  -t ghcr.io/foreveryh/oxygenie/app:latest \
-  --push .
-```
-> ⚠️ 必须 `--platform linux/amd64`（Dokploy 服务器是 x86_64，Mac 是 arm64）。
-> ⚠️ 从 `codex/phasec-real-preview` 分支构建（含 Phase C + Ask/Act + controller 硬化）。
+**`docker-compose.dokploy.yml` 的全部 app 服务（migrate/worker/app/preview-controller）都用
+`<<: *app_build`（`build:` 锚点），即 Dokploy 克隆分支后在它自己的 amd64 服务器上构建。**
+因此：
+
+- **不需要**本地 `buildx` 跨架构构建，**不需要**推 GHCR、不需要 `--platform linux/amd64`。
+- VITE build-args 已在 `x-app-build` 锚点里按 `${APP_HOSTNAME}` 等参数化
+  （如 `VITE_WS_URL=wss://${APP_HOSTNAME}/ws/agent`）→ 只要在 Dokploy 设 `APP_HOSTNAME=oxygenie.cc`
+  即自动烤入正确前端域名。
+- Dokploy 端：Docker Compose 服务的 Git 源指向 `foreveryh/oxygenie` 分支 `codex/phasec-real-preview`，
+  compose 路径 `docker-compose.dokploy.yml`；部署即构建。
+
+> ⚠️ **与 CLAUDE.md 不一致**：CLAUDE.md「Dokploy 部署规则」写的是 GHCR + `pull_policy: always`
+> + 本地 `buildx --platform linux/amd64`。但当前 `docker-compose.dokploy.yml`（Phase C，commit
+> 0d05389）用的是 `*app_build`（Dokploy 自建）。本部署按**文件现状（自建）**走；CLAUDE.md 那段
+> 待与 Owner 确认后更正或保留为备选。
 
 ---
 
@@ -173,11 +181,12 @@ docker buildx build --platform linux/amd64 \
 - [x] **ARK `ANTHROPIC_AUTH_TOKEN` 已提供 + 实测通过**（2026-06-05：`/api/coding/v1/messages`
       + Bearer，`glm-5.1` 与 `doubao-seed-2.0-lite` 均 HTTP200 应答 `OK`）
 - [x] `doubao-seed-2.0-lite` 确认存在且可用（实测通过）
-- [ ] 按 §6 改 `docker-compose.dokploy.yml`
-- [ ] 按 §6/§5 补 `infra/deploy/env.dokploy.example` 的 ARK/模型/域名键
-- [ ] 从 phasec 分支构建并推送 GHCR 镜像（§8）
-- [ ] Dokploy 建 `oxygenie` 项目 + Docker Compose（compose 路径 `docker-compose.dokploy.yml`）+ 注入 env + 装 Origin 证书
-- [ ] 部署 → 冒烟 → **浏览器真预览路由 E2E** → 通过后合并 PR #107 到 main
+- [x] 按 §6 改 `docker-compose.dokploy.yml`（1–5 已改，`docker compose config` 校验通过）
+- [x] 按 §6/§5 补 `infra/deploy/env.dokploy.example` 的 ARK/模型键
+- [x] 镜像：Dokploy 自建（无需 GHCR，见 §8）
+- [ ] **【动生产】** Dokploy 建 `oxygenie` 项目 + Docker Compose（Git 源 `codex/phasec-real-preview`，
+      compose 路径 `docker-compose.dokploy.yml`）+ 注入 env（用 `secrets.env` 蓝本）+ 装 Origin 证书
+- [ ] **【动生产】** 部署 → 冒烟 → **浏览器真预览路由 E2E** → 通过后合并 PR #107 到 main
 
 ---
 

--- a/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
+++ b/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
@@ -1,0 +1,187 @@
+# OxyGenie 生产部署决策 + 差异规格（oxygenie.cc on Dokploy）
+
+> 状态：**决策已定，待执行**（2026-06-05）
+> 目标：把 `codex/phasec-real-preview`（Phase C 真预览 + Ask/Act + controller 硬化）部署到
+> Dokploy 服务器 `h.deeptoai.com`，对外域名 `oxygenie.cc`，并跑通 Traefik 路由的真预览 E2E。
+> 本文是**决策记录 + 与现有部署资产的精确差异**，执行时按"差异清单"逐条落地。
+
+---
+
+## 0. 为什么有这份文档
+
+部署涉及域名/TLS/鉴权/模型/预览路由多处决策，且现有 `docker-compose.dokploy.yml` 是为
+**上一套方案（deeptoai.com + Let's Encrypt + 2 层 `.preview.`）** 配的。若不落档，这些
+"为什么这么改"会彻底丢失，无法维护。
+
+---
+
+## 1. 决策总表
+
+| 项 | 决策 | 备注 |
+|---|---|---|
+| 代码源 | GitHub `foreveryh/oxygenie` @ `codex/phasec-real-preview` | controller 硬化在 `d19621c` |
+| 镜像 | **GHCR**（既定方案）`ghcr.io/foreveryh/oxygenie/app`，`buildx --platform linux/amd64` | Dokploy 拉取，非 Dokploy 构建 |
+| Dokploy 项目 | 新建 `oxygenie` | |
+| App 域名 | `oxygenie.cc`（apex） | |
+| WebSocket | `wss://oxygenie.cc/ws/agent`（Traefik 按 `/ws` 路径转 3001） | |
+| 预览域名 | **单层 `*.oxygenie.cc`**（`<id>.oxygenie.cc`） | **关键**：见 §2 |
+| TLS | **Cloudflare 橙云 + Full(Strict) + Origin CA 证书**；**不用 Let's Encrypt** | **关键**：见 §3 |
+| ARK 鉴权 | **`ANTHROPIC_AUTH_TOKEN`（Bearer），不用 `ANTHROPIC_API_KEY`** | **关键**：见 §4 |
+| ARK 网关 | `ANTHROPIC_BASE_URL=https://ark.cn-beijing.volces.com/api/coding` | |
+| 模型映射 | 主/sonnet/opus/subagent = `glm-5.1`；haiku = `doubao-seed-2.0-lite` | 见 §5 |
+| 多模型切换 | 延后 Phase | 需后端改造 |
+| 智谱(ZHIPU) | 本期不用 → 由必填改可选 | Mastra 侧 GLM，本期不配 |
+| 随机密钥 | DB / MinIO / Meili / `BETTER_AUTH_SECRET` 自动生成 | |
+
+---
+
+## 2. 为什么预览用单层 `*.oxygenie.cc` 而不是 `*.preview.oxygenie.cc`
+
+**Cloudflare 免费版 Universal SSL 的边缘证书只覆盖 apex + 单层 `*.oxygenie.cc`，不覆盖两层
+`*.preview.oxygenie.cc`。** 橙云模式下 TLS 在 CF 边缘终止，CF 没有两层泛域名的边缘证书 →
+浏览器访问 `<id>.preview.oxygenie.cc` 会证书失败（即使源站证书签了两层也没用）。
+
+- ✅ 选 `<id>.oxygenie.cc`：CF 免费 SSL 正好覆盖。
+- App 在 apex（不被 `*.` 通配匹配），预览 id 用随机串，与 `www/app/api` 等保留子域不冲突。
+- 备选（未采用）：CF Advanced Certificate Manager（付费）覆盖两层；或预览那条 DNS 灰云 +
+  Traefik Let's Encrypt DNS-01 签两层泛域名。都更复杂，故选单层。
+
+**DNS（已配，Cloudflare）**：
+- `oxygenie.cc` → A → 46.224.36.68（Proxied）
+- `*.oxygenie.cc` → A → 46.224.36.68（Proxied）
+
+---
+
+## 3. 为什么用 Cloudflare Origin CA 而不是 Let's Encrypt
+
+现有 dokploy compose 所有路由都用 `tls.certresolver=letsencrypt`。**橙云下 Let's Encrypt
+HTTP-01 质询会被 CF 拦截而失败。** 因此：
+
+- CF SSL 模式设 **Full (Strict)**。
+- 用 **Cloudflare Origin CA 证书**（签 `oxygenie.cc` + `*.oxygenie.cc`，15 年）作为源站证书，
+  装进 Dokploy/Traefik 作**默认证书**；Traefik 按 SNI 给 app 和所有 `<id>.oxygenie.cc` 预览路由使用。
+- 路由去掉 `certresolver=letsencrypt`，保留 `tls=true`（走默认证书）。
+
+**Origin CA 签发方式**（Service Key 已弃用）：用带 `Zone > SSL and Certificates > Edit`
+权限的 **API Token** 调 Origin CA API。本地已生成私钥 + CSR：
+- `~/oxygenie-deploy/certs/oxygenie.cc.origin.{key,csr}`（SAN：`oxygenie.cc`,`*.oxygenie.cc`）
+- 签发：`POST https://api.cloudflare.com/client/v4/certificates`，`Authorization: Bearer <token>`，
+  body `{hostnames:["oxygenie.cc","*.oxygenie.cc"], request_type:"origin-rsa", requested_validity:5475, csr:<PEM>}`
+- 后备：`~/oxygenie-deploy/certs/oxygenie.cc.{crt,key}` 自签通配证书（配 CF `Full` 非 Strict 可用）。
+
+> 安全补充：建议在 VPS 防火墙仅放行 Cloudflare IP 段到 443，缩小源站暴露面。
+
+---
+
+## 4. 为什么 ARK 用 ANTHROPIC_AUTH_TOKEN 且无需改鉴权代码
+
+ARK `/api/coding` 网关用 **Bearer（`ANTHROPIC_AUTH_TOKEN`）**，不是 `x-api-key`
+（`ANTHROPIC_API_KEY`）。鉴权流：
+
+- `ws-server.mjs` 给每条消息 spawn worker 时 `workerEnv = {...process.env}`（继承全部环境），
+  且**仅当 `ANTHROPIC_API_KEY` 存在时**才显式注入它（`ws-server.mjs` ~L1063）。
+- worker 里 SDK 的 `query()` **不显式传 apiKey**，靠环境；SDK 调起的 claude-code CLI 直接读
+  环境里的 `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` / 模型别名。
+
+**结论**：只要容器环境里有 `ANTHROPIC_AUTH_TOKEN`（+ base url + 模型别名），且**不设**
+`ANTHROPIC_API_KEY`（设了会让 SDK 走 x-api-key），即可走 ARK。**无需改鉴权代码**，只改 compose env。
+
+⚠️ SDK 版本钉死 `0.2.112`（ARK 兼容上限，见 CLAUDE.md）。
+
+---
+
+## 5. 模型映射（ARK）
+
+| SDK 槽位 | 环境变量 | 模型 |
+|---|---|---|
+| 主模型 | `ANTHROPIC_MODEL` | `glm-5.1` |
+| sonnet 档 | `ANTHROPIC_DEFAULT_SONNET_MODEL` | `glm-5.1` |
+| opus 档 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | `glm-5.1` |
+| 子代理 | `CLAUDE_CODE_SUBAGENT_MODEL` | `glm-5.1` |
+| haiku 档（后台廉价） | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `doubao-seed-2.0-lite` |
+
+> ARK 可用模型：doubao-seed-2.0-code / doubao-seed-2.0-pro / doubao-seed-2.0-lite /
+> doubao-seed-code / minimax-latest / glm-5.1 / deepseek-v4-flash / deepseek-v4-pro。
+> 多模型切换（用户自选）= 后续 Phase。
+
+---
+
+## 6. 差异清单：对 `docker-compose.dokploy.yml` 的精确改动
+
+> 现状是为 deeptoai.com + LE + 2 层预览配的，需改 6 处：
+
+1. **App Host（硬编码）**：约 L349/L356/L368 的 `Host(`deeptoai.com`)` → `Host(`oxygenie.cc`)`
+   （或参数化为 `${APP_HOSTNAME}`）。
+2. **去 Let's Encrypt**：所有 `tls.certresolver=letsencrypt`（app web/websecure、ws、preview-auth）
+   → 改为仅 `tls=true`，依赖 Traefik 默认证书（Origin CA）。
+3. **预览改单层**：
+   - L306 `PREVIEW_HOST_TEMPLATE` 默认 `{previewId}.preview.${APP_HOSTNAME}` → `{previewId}.${APP_HOSTNAME}`
+   - L383 preview-auth `HostRegexp(`{preview:[a-z0-9-]+}.preview.${APP_HOSTNAME}`)` → 去掉 `.preview`
+   - preview-controller（§见下）`PREVIEW_TRAEFIK_CERTRESOLVER` 清空；`PREVIEW_BASE_DOMAIN=oxygenie.cc`
+4. **ARK 鉴权**（app 服务 env，约 L279-283）：
+   - `ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?}` → 删除或改 `${ANTHROPIC_API_KEY:-}`（**不设值**）
+   - 新增 `ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:?}`
+   - 新增 4 个模型别名：`ANTHROPIC_DEFAULT_HAIKU_MODEL` / `ANTHROPIC_DEFAULT_SONNET_MODEL` /
+     `ANTHROPIC_DEFAULT_OPUS_MODEL` / `CLAUDE_CODE_SUBAGENT_MODEL`
+   - `ZHIPU_API_KEY: ${ZHIPU_API_KEY:?}` → `${ZHIPU_API_KEY:-}`（可选）
+5. **preview-controller 服务**（约 L396-421）：`PREVIEW_TRAEFIK_CERTRESOLVER` 默认 `letsencrypt` →
+   清空（用默认 Origin 证书）；确认 `PREVIEW_TRAEFIK_NETWORK`/`PREVIEW_DOCKER_NETWORK=dokploy-network`
+   （已是）；`PREVIEW_BASE_DOMAIN=oxygenie.cc`。镜像 = GHCR（含 controller 硬化，见 §7）。
+6. **VITE build args**（构建期烤入镜像，非 compose 运行期）：`VITE_WS_URL=wss://oxygenie.cc/ws/agent`、
+   `VITE_BASE_URL`（按需）必须在 `buildx` 构建镜像时通过 `--build-arg` 传入。
+
+---
+
+## 7. preview-controller 硬化（已合入 `d19621c`，必须进 GHCR 镜像）
+
+部署用的 GHCR 镜像**必须从 `codex/phasec-real-preview` 重建**，以包含本次三项修复
+（见 `src/preview/controller.mjs`，commit `d19621c`，本地真预览引擎已验证）：
+
+1. **serve 竞态** → detached `exec node`（守护进程托管，首跑可靠；原 `nohup &` 首跑会被 exec 拆除杀掉）。
+2. **pid 追踪** → 静态服务器自写**容器内** pid 到 `PREVIEW_PID_FILE`（exec API 给的是宿主 pid，
+   容器内 `kill` 用不了）；restart/idle-reap 才能正确命中。
+3. **沙箱属主** → `CapDrop:['ALL']` 会连 `CAP_CHOWN` 一起去掉，导致启动期 chown 静默失败、
+   非-root（1001）装依赖 EACCES。补 `CapAdd:['CHOWN']`（仅启动期 root 用）+ chown 工作目录根；
+   install/build/serve 仍以 1001 无有效 caps 跑不可信构建。
+
+> 验证记录：本地用真实 controller + docker 卷 + 1001 用户跑通 ensure→install→vite build→serve→
+> fetch→restart→stop。
+
+---
+
+## 8. GHCR 镜像构建（带 ARK/域名所需 build args）
+
+```bash
+gh auth refresh -h github.com -s write:packages
+echo $(gh auth token) | docker login ghcr.io -u foreveryh --password-stdin
+docker buildx build --platform linux/amd64 \
+  --build-arg VITE_WS_URL=wss://oxygenie.cc/ws/agent \
+  -t ghcr.io/foreveryh/oxygenie/app:latest \
+  --push .
+```
+> ⚠️ 必须 `--platform linux/amd64`（Dokploy 服务器是 x86_64，Mac 是 arm64）。
+> ⚠️ 从 `codex/phasec-real-preview` 分支构建（含 Phase C + Ask/Act + controller 硬化）。
+
+---
+
+## 9. 执行前待办（阻塞项）
+
+- [ ] CF：SSL/TLS 模式切 **Full (Strict)**
+- [ ] CF：创建 API Token（Origin CA 模板 / `Zone > SSL and Certificates > Edit`）→ 用它签 Origin CA 证书
+- [ ] 提供 **ARK `ANTHROPIC_AUTH_TOKEN`**
+- [ ] 确认 `doubao-seed-2.0-lite` 的确切 model id（不在最初给的可用列表里）
+- [ ] 按 §6 改 `docker-compose.dokploy.yml`
+- [ ] 按 §6/§5 补 `infra/deploy/env.dokploy.example` 的 ARK/模型/域名键
+- [ ] 从 phasec 分支构建并推送 GHCR 镜像（§8）
+- [ ] Dokploy 建 `oxygenie` 项目 + Docker Compose（compose 路径 `docker-compose.dokploy.yml`）+ 注入 env + 装 Origin 证书
+- [ ] 部署 → 冒烟 → **浏览器真预览路由 E2E** → 通过后合并 PR #107 到 main
+
+---
+
+## 10. 相关文件
+
+- `docker-compose.dokploy.yml` — 部署用 compose（待按 §6 改）
+- `infra/deploy/env.dokploy.example` — 环境变量模板（待补 ARK/模型）
+- `infra/deploy/DOKPLOY_DEPLOYMENT.md` / `DOKPLOY_ENV_CHECKLIST.md` — 既有部署指南
+- `src/preview/controller.mjs` — 真预览引擎（已硬化）
+- CLAUDE.md「Dokploy 部署规则」「环境变量」段 — 已同步 ARK auth-token 要点

--- a/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
+++ b/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
@@ -170,8 +170,9 @@ docker buildx build --platform linux/amd64 \
 - [x] CF：创建 API Token + **Origin CA 证书已签发**（2026-06-05，有效期至 2041，SAN
       `oxygenie.cc` + `*.oxygenie.cc`，issuer = CloudFlare Origin CA，与私钥匹配）
 - [x] DB / MinIO / Meili / `BETTER_AUTH_SECRET` 随机密钥已生成
-- [ ] 提供 **ARK `ANTHROPIC_AUTH_TOKEN`**（已留占位）
-- [ ] 确认 `doubao-seed-2.0-lite` 的确切 model id（不在最初给的可用列表里）
+- [x] **ARK `ANTHROPIC_AUTH_TOKEN` 已提供 + 实测通过**（2026-06-05：`/api/coding/v1/messages`
+      + Bearer，`glm-5.1` 与 `doubao-seed-2.0-lite` 均 HTTP200 应答 `OK`）
+- [x] `doubao-seed-2.0-lite` 确认存在且可用（实测通过）
 - [ ] 按 §6 改 `docker-compose.dokploy.yml`
 - [ ] 按 §6/§5 补 `infra/deploy/env.dokploy.example` 的 ARK/模型/域名键
 - [ ] 从 phasec 分支构建并推送 GHCR 镜像（§8）

--- a/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
+++ b/docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md
@@ -167,8 +167,10 @@ docker buildx build --platform linux/amd64 \
 ## 9. 执行前待办（阻塞项）
 
 - [ ] CF：SSL/TLS 模式切 **Full (Strict)**
-- [ ] CF：创建 API Token（Origin CA 模板 / `Zone > SSL and Certificates > Edit`）→ 用它签 Origin CA 证书
-- [ ] 提供 **ARK `ANTHROPIC_AUTH_TOKEN`**
+- [x] CF：创建 API Token + **Origin CA 证书已签发**（2026-06-05，有效期至 2041，SAN
+      `oxygenie.cc` + `*.oxygenie.cc`，issuer = CloudFlare Origin CA，与私钥匹配）
+- [x] DB / MinIO / Meili / `BETTER_AUTH_SECRET` 随机密钥已生成
+- [ ] 提供 **ARK `ANTHROPIC_AUTH_TOKEN`**（已留占位）
 - [ ] 确认 `doubao-seed-2.0-lite` 的确切 model id（不在最初给的可用列表里）
 - [ ] 按 §6 改 `docker-compose.dokploy.yml`
 - [ ] 按 §6/§5 补 `infra/deploy/env.dokploy.example` 的 ARK/模型/域名键
@@ -177,6 +179,19 @@ docker buildx build --platform linux/amd64 \
 - [ ] 部署 → 冒烟 → **浏览器真预览路由 E2E** → 通过后合并 PR #107 到 main
 
 ---
+
+## 9.1 本地密钥与证书位置（仓库外，勿提交）
+
+> 放在 repo 外（CLAUDE.md 禁止动 repo `.env`，且密钥进 git 会泄露）。**这就是"以后去哪找"的答案**：
+
+```
+~/oxygenie-deploy/secrets.env                  # CF token + 随机密钥 + ARK 占位 + 域名（chmod 600）
+~/oxygenie-deploy/certs/oxygenie.cc.origin.crt # Origin CA 证书（装进 Dokploy → Certificates）
+~/oxygenie-deploy/certs/oxygenie.cc.origin.key # 对应私钥（装进 Dokploy）
+~/oxygenie-deploy/certs/oxygenie.cc.{crt,key}  # 自签后备证书（CF Full 非 Strict 时用）
+```
+
+`secrets.env` 可作 Dokploy 环境变量导入蓝本。CF API Token 用完可在 CF 控制台撤销。
 
 ## 10. 相关文件
 

--- a/infra/deploy/env.dokploy.example
+++ b/infra/deploy/env.dokploy.example
@@ -175,17 +175,26 @@ VITE_GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 # AI 服务配置
 # ============================================================================
 
-# ✅ Claude Agent SDK API 密钥（Anthropic API Key）
-ANTHROPIC_API_KEY=sk-ant-api03-your-anthropic-api-key-here
+# ✅ Claude Agent SDK 鉴权
+# ⚠️ ARK（火山）coding 网关用 Bearer：设 ANTHROPIC_AUTH_TOKEN，**不要**设 ANTHROPIC_API_KEY
+#    （设了 SDK 会改走 x-api-key 而非 Bearer，ARK 会失败）。详见
+#    docs/project/research/2026-06-oxygenie-cc-dokploy-deployment.md §4。
+ANTHROPIC_AUTH_TOKEN=ark-your-ark-api-key-here
+# 仅原生 Anthropic / x-api-key 场景才填；ARK 部署留空：
+ANTHROPIC_API_KEY=
 
-# 🔵 Claude Agent SDK 基础 URL（可选，用于自定义端点）
-ANTHROPIC_BASE_URL=
+# ✅ ARK 网关基础 URL
+ANTHROPIC_BASE_URL=https://ark.cn-beijing.volces.com/api/coding
 
-# 🔵 Claude Agent SDK 模型名称（可选，使用默认模型）
-ANTHROPIC_MODEL=
+# ✅ 模型映射（按 ARK 可用模型）
+ANTHROPIC_MODEL=glm-5.1
+ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5.1
+ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.1
+CLAUDE_CODE_SUBAGENT_MODEL=glm-5.1
+ANTHROPIC_DEFAULT_HAIKU_MODEL=doubao-seed-2.0-lite
 
-# ✅ Zhipu AI API 密钥（Mastra AI SDK）
-ZHIPU_API_KEY=your_zhipu_api_key_here
+# 🔵 Zhipu AI API 密钥（Mastra AI SDK，可选；ARK-only 部署留空）
+ZHIPU_API_KEY=
 
 # ============================================================================
 # Claude Agent 配置

--- a/src/claude/adapters/index.ts
+++ b/src/claude/adapters/index.ts
@@ -7,6 +7,8 @@
 export {
   runChat,
   cancelActiveRun,
+  startPreview,
+  stopPreview,
   abort,
   resumeSession,
   createSession,

--- a/src/claude/adapters/ws-adapter.ts
+++ b/src/claude/adapters/ws-adapter.ts
@@ -17,6 +17,7 @@ import {
   type SDKMessage as StorageSDKMessage,
   type ContentPart as StoreContentPart,
   type ThreadMessage as StoreThreadMessage,
+  type PreviewState,
 } from '~/lib/chat-session-store';
 import type { SessionMetadata } from '~/components/claude-chat/session-info-panel';
 
@@ -110,6 +111,8 @@ type InboundMessage =
   | { type: 'chat'; content: string; sessionId?: string; skillSlug?: string; permissionTier?: string }
   | { type: 'resume'; sessionId: string }
   | { type: 'abort' }
+  | { type: 'start_preview'; sessionId?: string; mode?: 'static' | 'live' }
+  | { type: 'stop_preview'; sessionId?: string }
   | { type: 'ping' };
 
 type OutboundMessage =
@@ -120,6 +123,7 @@ type OutboundMessage =
   | { type: 'error'; code: string; message: string; retriable: boolean }
   | { type: 'done'; seq?: number }
   | { type: 'aborted' }
+  | { type: 'preview_state'; state: PreviewState; seq?: number }
   | { type: 'pong' };
 
 // Assistant UI Part Types
@@ -545,6 +549,14 @@ function getWebSocket(): Promise<WebSocket> {
           return;
         }
 
+        // Preview state is session-level and arrives asynchronously (outside a
+        // chat run), so handle it on the persistent socket rather than via the
+        // per-run messageHandler (which is only set during runChat()).
+        if (msg.type === 'preview_state') {
+          useChatSessionStore.getState().setPreviewState(msg.state);
+          return;
+        }
+
         // Forward to current handler
         if (messageHandler) {
           messageHandler(msg);
@@ -562,6 +574,22 @@ function getWebSocket(): Promise<WebSocket> {
 async function send(message: InboundMessage): Promise<void> {
   const socket = await getWebSocket();
   socket.send(JSON.stringify(message));
+}
+
+/**
+ * Start / stop the Phase C preview for a session (sent over the same /ws/agent
+ * socket). Defaults to the adapter's current session. The backend responds
+ * asynchronously via `preview_state` events (handled on the persistent socket).
+ */
+export async function startPreview(
+  sessionId?: string,
+  mode: 'static' | 'live' = 'static',
+): Promise<void> {
+  await send({ type: 'start_preview', sessionId: sessionId ?? currentSessionId, mode });
+}
+
+export async function stopPreview(sessionId?: string): Promise<void> {
+  await send({ type: 'stop_preview', sessionId: sessionId ?? currentSessionId });
 }
 
 /**

--- a/src/claude/index.ts
+++ b/src/claude/index.ts
@@ -27,6 +27,8 @@ export {
 export {
   runChat,
   cancelActiveRun,
+  startPreview,
+  stopPreview,
   abort,
   resumeSession,
   newSession,

--- a/src/components/claude-chat/artifact-html.tsx
+++ b/src/components/claude-chat/artifact-html.tsx
@@ -3,17 +3,18 @@
  *
  * Renders HTML artifacts in a sandboxed iframe.
  *
- * Graceful degradation: an HTML file that references RELATIVE external resources
- * (e.g. <script src="app.js">, <link href="style.css">) is a multi-file app. The
- * single-file blob: preview can't resolve those siblings, so its scripts never
- * load and interaction (add/edit, localStorage, form submit) silently fails or
- * breaks the preview. We detect that and show a clear notice instead of leaving
- * the user with a dead/broken page. A real, runnable multi-file preview is Phase C
- * (the sandbox line); see docs/project/research/2026-06-real-preview-v1-implementation-plan.md.
+ * Single-file HTML previews directly from a blob: URL. A multi-file app (HTML that
+ * references RELATIVE <script src>/<link href> siblings) can't run from a blob:
+ * preview — its scripts never load, so interaction (add/edit, localStorage, form
+ * submit) fails. For those we offer 「运行预览」 (Phase C): the preview backend runs
+ * the app in a per-session sandbox and returns a live URL we render here instead.
+ * See docs/project/research/2026-06-real-preview-v1-implementation-plan.md.
  */
 
-import { useEffect, useMemo, type FC, type Ref } from 'react'
-import { Info } from 'lucide-react'
+import { useEffect, useMemo, useState, type FC, type Ref } from 'react'
+import { AlertTriangle, Info, Loader2, Play } from 'lucide-react'
+import { startPreview } from '~/claude/adapters'
+import { useSessionPreview } from '~/lib/hooks/use-session-workbench'
 
 export interface HTMLArtifactProps {
   content: string
@@ -41,14 +42,31 @@ function referencesUnresolvableSiblings(html: string): boolean {
   return false
 }
 
+const SANDBOX = 'allow-scripts allow-same-origin allow-forms allow-popups allow-downloads'
+
+function statusLabel(status: string | undefined, error?: string): string {
+  switch (status) {
+    case 'detecting': return '检测项目…'
+    case 'installing': return '安装依赖…'
+    case 'building': return '构建中…'
+    case 'ready': return '预览就绪'
+    case 'stopped': return '预览已停止'
+    case 'error': return error || '预览失败'
+    default: return ''
+  }
+}
+
 export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef }) => {
-  // Create blob URL for iframe src
+  // Create blob URL for the single-file static preview
   const blobUrl = useMemo(() => {
     const blob = new Blob([content], { type: 'text/html;charset=utf-8' })
     return URL.createObjectURL(blob)
   }, [content])
 
   const isMultiFile = useMemo(() => referencesUnresolvableSiblings(content), [content])
+
+  const preview = useSessionPreview()
+  const [starting, setStarting] = useState(false)
 
   // Cleanup blob URL on unmount
   useEffect(() => {
@@ -57,6 +75,21 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
     }
   }, [blobUrl])
 
+  // Clear the local "starting" bridge once a real backend status arrives.
+  useEffect(() => {
+    if (preview?.status) setStarting(false)
+  }, [preview?.status])
+
+  const status = preview?.status
+  const busy = starting || status === 'detecting' || status === 'installing' || status === 'building'
+  const failed = status === 'error'
+  const liveUrl = status === 'ready' ? preview?.url : undefined
+
+  const runPreview = () => {
+    setStarting(true)
+    void startPreview().catch(() => setStarting(false))
+  }
+
   return (
     <div className="artifact-html-container h-full w-full flex flex-col">
       {title && (
@@ -64,21 +97,59 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
           {title}
         </div>
       )}
+
       {isMultiFile && (
-        <div className="flex items-start gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
-          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <span>
-            这是多文件 App（引用了外部 JS/CSS）。单文件预览只能看静态结构，交互（增删改、本地存储、表单提交）不会生效；完整可运行的预览将随沙盒（Phase&nbsp;C）上线。
-          </span>
+        <div className="flex flex-col gap-1.5 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+          <div className="flex items-center gap-2">
+            <Info className="h-3.5 w-3.5 shrink-0" />
+            <span className="flex-1">
+              {liveUrl
+                ? '正在运行实时预览（沙盒）。下方为可交互的真实应用。'
+                : '这是多文件 App（外部 JS/CSS）。下方是静态结构；点「运行预览」在沙盒里真正运行（可交互、本地存储生效）。'}
+            </span>
+            <button
+              type="button"
+              onClick={runPreview}
+              disabled={busy}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-300 bg-amber-100 px-2 py-1 font-medium text-amber-900 transition hover:bg-amber-200 disabled:opacity-60 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60"
+            >
+              {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+              {busy ? '运行中…' : liveUrl ? '重新运行' : '运行预览'}
+            </button>
+          </div>
+          {(busy || failed) && (
+            <div className="flex items-center gap-1.5 pl-5 text-[11px] text-amber-800 dark:text-amber-300">
+              {failed ? (
+                <AlertTriangle className="h-3 w-3 shrink-0" />
+              ) : (
+                <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+              )}
+              <span className="truncate">{statusLabel(status, preview?.error)}</span>
+            </div>
+          )}
         </div>
       )}
-      <iframe
-        ref={iframeRef}
-        src={blobUrl}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
-        className="artifact-iframe flex-1 w-full border-0 bg-white"
-        title={title || 'Artifact Preview'}
-      />
+
+      {liveUrl ? (
+        // Live, runnable preview from the Phase C sandbox (separate origin).
+        <iframe
+          key="live"
+          src={liveUrl}
+          sandbox={SANDBOX}
+          className="artifact-iframe flex-1 w-full border-0 bg-white"
+          title={title || 'App Preview'}
+        />
+      ) : (
+        // Static single-file preview.
+        <iframe
+          key="static"
+          ref={iframeRef}
+          src={blobUrl}
+          sandbox={SANDBOX}
+          className="artifact-iframe flex-1 w-full border-0 bg-white"
+          title={title || 'Artifact Preview'}
+        />
+      )}
     </div>
   )
 }

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -109,6 +109,17 @@ export type SDKMessage = {
   }>;
 };
 
+// Phase C preview runtime state — pushed by the preview backend over WS
+// (`preview_state` event). Session-scoped; the selector filters by currentSessionId.
+export type PreviewState = {
+  sessionId: string;
+  previewId: string;
+  mode: 'static' | 'live';
+  status: 'detecting' | 'installing' | 'building' | 'ready' | 'error' | 'stopped';
+  url?: string;
+  error?: string;
+};
+
 interface ChatSessionState {
   // Current session ID
   currentSessionId: string | null;
@@ -130,6 +141,9 @@ interface ChatSessionState {
 
   // Session metadata (tools, agents, configuration)
   sessionMetadata: SessionMetadata | null;
+
+  // Phase C preview runtime state (session-scoped; null when no preview running)
+  previewState: PreviewState | null;
 
   // Structured output from last query (for artifact metadata)
   lastStructuredOutput: unknown | null;
@@ -164,6 +178,7 @@ interface ChatSessionState {
   setCurrentToolName: (toolName: string | null) => void;
   setUsageData: (data: UsageData) => void;
   setSessionMetadata: (data: SessionMetadata) => void;
+  setPreviewState: (state: PreviewState | null) => void;
   setLastStructuredOutput: (data: unknown | null) => void;
   setShowThinking: (show: boolean) => void;
   setQueueCount: (count: number) => void;
@@ -373,6 +388,7 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
   currentToolName: null,
   usageData: null,
   sessionMetadata: null,
+  previewState: null,
   lastStructuredOutput: null,
   showThinking: true, // Default: show thinking/reasoning blocks
   queueCount: 0, // Number of pending runs waiting to be processed
@@ -459,6 +475,10 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
     set({ sessionMetadata: data });
   },
 
+  setPreviewState: (data) => {
+    set({ previewState: data });
+  },
+
   setLastStructuredOutput: (data) => {
     set({ lastStructuredOutput: data });
   },
@@ -498,7 +518,7 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
     // instead of a fragmented stack of "步骤已完成" cards with duplicate artifacts.
     let cur: {
       id: string;
-      createdAt: Date;
+      createdAt: Date | undefined;
       status: ThreadMessage['status'];
       parts: ContentPart[];
     } | null = null;

--- a/src/lib/hooks/use-session-workbench.ts
+++ b/src/lib/hooks/use-session-workbench.ts
@@ -9,7 +9,7 @@
  */
 
 import { useMemo } from 'react';
-import { useChatSessionStore, type ThreadMessage } from '~/lib/chat-session-store';
+import { useChatSessionStore, type ThreadMessage, type PreviewState } from '~/lib/chat-session-store';
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed';
 
@@ -208,4 +208,18 @@ export function useSessionContext(): SessionContextInfo | null {
       numTurns: usage?.num_turns,
     };
   }, [usage, meta]);
+}
+
+/**
+ * Phase C preview runtime state for the active session, or null. Guards by
+ * currentSessionId so a stale preview from a previous session never leaks.
+ */
+export function useSessionPreview(): PreviewState | null {
+  const preview = useChatSessionStore((s) => s.previewState);
+  const sessionId = useChatSessionStore((s) => s.currentSessionId);
+  return useMemo(() => {
+    if (!preview) return null;
+    if (sessionId && preview.sessionId && preview.sessionId !== sessionId) return null;
+    return preview;
+  }, [preview, sessionId]);
 }

--- a/src/preview/auth.js
+++ b/src/preview/auth.js
@@ -1,0 +1,153 @@
+import crypto from 'node:crypto';
+
+const DEFAULT_BOOTSTRAP_TTL_MS = 90 * 1000;
+const DEFAULT_COOKIE_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_COOKIE_NAME = 'oxy_preview';
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64url');
+}
+
+function sign(payload, secret) {
+  return crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('base64url');
+}
+
+function safeEqual(a, b) {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+function parseCookies(header = '') {
+  const out = new Map();
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const key = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (key) out.set(key, decodeURIComponent(value));
+  }
+  return out;
+}
+
+function trimExpired(map, now = Date.now()) {
+  for (const [key, value] of map.entries()) {
+    if (value.expiresAt <= now) map.delete(key);
+  }
+}
+
+export class PreviewAuth {
+  constructor(options = {}) {
+    this.secret = options.secret || crypto.randomBytes(32).toString('hex');
+    this.bootstrapTtlMs = Number(options.bootstrapTtlMs) || DEFAULT_BOOTSTRAP_TTL_MS;
+    this.cookieTtlMs = Number(options.cookieTtlMs) || DEFAULT_COOKIE_TTL_MS;
+    this.cookieName = options.cookieName || DEFAULT_COOKIE_NAME;
+    this.secureCookies = options.secureCookies ?? process.env.NODE_ENV === 'production';
+    this.bootstrap = new Map();
+    this.cookies = new Map();
+  }
+
+  issueBootstrapToken({ previewId, sessionId, userId, host }) {
+    trimExpired(this.bootstrap);
+    const now = Date.now();
+    const jti = crypto.randomBytes(16).toString('hex');
+    const payload = {
+      jti,
+      previewId,
+      sessionId,
+      userId,
+      host,
+      exp: Math.floor((now + this.bootstrapTtlMs) / 1000),
+    };
+    const header = { alg: 'HS256', typ: 'JWT' };
+    const encodedHeader = base64url(JSON.stringify(header));
+    const encodedPayload = base64url(JSON.stringify(payload));
+    const signature = sign(`${encodedHeader}.${encodedPayload}`, this.secret);
+    const token = `${encodedHeader}.${encodedPayload}.${signature}`;
+    this.bootstrap.set(jti, {
+      previewId,
+      sessionId,
+      userId,
+      host,
+      expiresAt: now + this.bootstrapTtlMs,
+    });
+    return token;
+  }
+
+  consumeBootstrapToken(token, { host } = {}) {
+    trimExpired(this.bootstrap);
+    const [encodedHeader, encodedPayload, signature] = String(token || '').split('.');
+    if (!encodedHeader || !encodedPayload || !signature) {
+      throw new Error('Invalid preview token');
+    }
+    const expected = sign(`${encodedHeader}.${encodedPayload}`, this.secret);
+    if (!safeEqual(signature, expected)) {
+      throw new Error('Invalid preview token signature');
+    }
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'));
+    if (!payload?.jti || !payload?.previewId || !payload?.sessionId || !payload?.userId) {
+      throw new Error('Invalid preview token payload');
+    }
+    if (Number(payload.exp) * 1000 <= Date.now()) {
+      this.bootstrap.delete(payload.jti);
+      throw new Error('Preview token expired');
+    }
+    const entry = this.bootstrap.get(payload.jti);
+    if (!entry) {
+      throw new Error('Preview token already used or expired');
+    }
+    this.bootstrap.delete(payload.jti);
+    if (entry.previewId !== payload.previewId || entry.sessionId !== payload.sessionId || entry.userId !== payload.userId) {
+      throw new Error('Preview token mismatch');
+    }
+    if (host && entry.host && host !== entry.host) {
+      throw new Error('Preview token host mismatch');
+    }
+    return entry;
+  }
+
+  createCookieSession(entry) {
+    trimExpired(this.cookies);
+    const sid = crypto.randomBytes(24).toString('base64url');
+    const expiresAt = Date.now() + this.cookieTtlMs;
+    this.cookies.set(sid, { ...entry, expiresAt });
+    return {
+      sid,
+      cookie: this.serializeCookie(sid, expiresAt),
+      entry: this.cookies.get(sid),
+    };
+  }
+
+  verifyCookie(cookieHeader, { host } = {}) {
+    trimExpired(this.cookies);
+    const sid = parseCookies(cookieHeader).get(this.cookieName);
+    if (!sid) return null;
+    const entry = this.cookies.get(sid);
+    if (!entry) return null;
+    if (host && entry.host && host !== entry.host) return null;
+    entry.expiresAt = Date.now() + this.cookieTtlMs;
+    return { sid, entry };
+  }
+
+  serializeCookie(sid, expiresAt) {
+    const maxAge = Math.max(1, Math.floor((expiresAt - Date.now()) / 1000));
+    const parts = [
+      `${this.cookieName}=${encodeURIComponent(sid)}`,
+      'Path=/',
+      'HttpOnly',
+      `Max-Age=${maxAge}`,
+      this.secureCookies ? 'SameSite=None' : 'SameSite=Lax',
+    ];
+    if (this.secureCookies) parts.push('Secure');
+    return parts.join('; ');
+  }
+
+  reapExpired() {
+    trimExpired(this.bootstrap);
+    trimExpired(this.cookies);
+  }
+}

--- a/src/preview/controller.mjs
+++ b/src/preview/controller.mjs
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+const PORT = Number(process.env.PREVIEW_CONTROLLER_PORT || 5055);
+const DOCKER_SOCKET = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
+const PREVIEW_IMAGE = process.env.PREVIEW_IMAGE || 'node:24-bookworm-slim';
+const PREVIEW_PORT = Number(process.env.PREVIEW_INTERNAL_PORT || 4173);
+const PREVIEW_USER = process.env.PREVIEW_CONTAINER_USER || '1001:1001';
+const PREVIEW_MEMORY = process.env.PREVIEW_MEMORY || '768m';
+const PREVIEW_CPUS = Number(process.env.PREVIEW_CPUS || 1);
+const PREVIEW_PIDS = Number(process.env.PREVIEW_PIDS || 256);
+const PREVIEW_NETWORK = process.env.PREVIEW_DOCKER_NETWORK || process.env.PREVIEW_TRAEFIK_NETWORK || 'bridge';
+const PREVIEW_AUTH_URL = process.env.PREVIEW_FORWARD_AUTH_URL || 'http://app:3001/__oxy/preview/authorize';
+const CONTROLLER_CONTAINER = process.env.PREVIEW_CONTROLLER_CONTAINER || os.hostname();
+
+function json(res, status, payload) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+function dockerRequest(method, requestPath, body = null) {
+  return new Promise((resolve, reject) => {
+    const payload = body ? Buffer.from(JSON.stringify(body)) : null;
+    const req = http.request(
+      {
+        socketPath: DOCKER_SOCKET,
+        method,
+        path: requestPath,
+        headers: payload
+          ? { 'content-type': 'application/json', 'content-length': payload.length }
+          : undefined,
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks);
+          const text = raw.toString('utf8');
+          let parsed = null;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {
+            parsed = text;
+          }
+          if (res.statusCode >= 400) {
+            const message = typeof parsed === 'object' && parsed?.message ? parsed.message : text;
+            const error = new Error(message || `Docker API ${method} ${requestPath} failed with ${res.statusCode}`);
+            error.statusCode = res.statusCode;
+            reject(error);
+            return;
+          }
+          resolve({ statusCode: res.statusCode, body: parsed, raw });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function parseBytes(value) {
+  const text = String(value || '').trim().toLowerCase();
+  const m = text.match(/^(\d+(?:\.\d+)?)([kmgt]?b?|)$/);
+  if (!m) return 768 * 1024 * 1024;
+  const n = Number(m[1]);
+  const unit = m[2].replace(/b$/, '');
+  const factor = unit === 'g' ? 1024 ** 3 : unit === 'm' ? 1024 ** 2 : unit === 'k' ? 1024 : 1;
+  return Math.floor(n * factor);
+}
+
+function safeName(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+}
+
+function containerName(previewId) {
+  return `oxy-preview-${safeName(previewId)}`;
+}
+
+function nodeModulesVolume(previewId) {
+  return `oxy-preview-node-modules-${safeName(previewId)}`;
+}
+
+function routerName(previewId) {
+  return `oxy-preview-${safeName(previewId)}`;
+}
+
+function serviceName(previewId) {
+  return `oxy-preview-${safeName(previewId)}`;
+}
+
+function middlewareName(previewId) {
+  return `oxy-preview-auth-${safeName(previewId)}`;
+}
+
+function traefikLabels({ previewId, host, port }) {
+  if (process.env.PREVIEW_TRAEFIK_ENABLED === '0') return {};
+  const router = routerName(previewId);
+  const service = serviceName(previewId);
+  const middleware = middlewareName(previewId);
+  const labels = {
+    'traefik.enable': 'true',
+    [`traefik.http.routers.${router}.rule`]: `Host(\`${host}\`) && !PathPrefix(\`/__oxy\`)`,
+    [`traefik.http.routers.${router}.priority`]: '100',
+    [`traefik.http.routers.${router}.service`]: service,
+    [`traefik.http.routers.${router}.middlewares`]: middleware,
+    [`traefik.http.services.${service}.loadbalancer.server.port`]: String(port),
+    [`traefik.http.middlewares.${middleware}.forwardauth.address`]: PREVIEW_AUTH_URL,
+    [`traefik.http.middlewares.${middleware}.forwardauth.trustForwardHeader`]: 'true',
+  };
+  if (process.env.PREVIEW_TRAEFIK_NETWORK) {
+    labels['traefik.docker.network'] = process.env.PREVIEW_TRAEFIK_NETWORK;
+  }
+  if (process.env.PREVIEW_TRAEFIK_ENTRYPOINTS) {
+    labels[`traefik.http.routers.${router}.entrypoints`] = process.env.PREVIEW_TRAEFIK_ENTRYPOINTS;
+  }
+  if (process.env.PREVIEW_TRAEFIK_TLS === '1') {
+    labels[`traefik.http.routers.${router}.tls`] = 'true';
+    if (process.env.PREVIEW_TRAEFIK_CERTRESOLVER) {
+      labels[`traefik.http.routers.${router}.tls.certresolver`] = process.env.PREVIEW_TRAEFIK_CERTRESOLVER;
+    }
+  }
+  return labels;
+}
+
+async function ensureImage(image) {
+  try {
+    await dockerRequest('GET', `/images/${encodeURIComponent(image)}/json`);
+    return;
+  } catch (error) {
+    if (error.statusCode !== 404) throw error;
+  }
+
+  const [fromImage, tag = 'latest'] = image.includes(':')
+    ? image.split(/:(.+)/)
+    : [image, 'latest'];
+  await dockerRequest('POST', `/images/create?fromImage=${encodeURIComponent(fromImage)}&tag=${encodeURIComponent(tag)}`);
+}
+
+async function inspectContainer(name) {
+  try {
+    const result = await dockerRequest('GET', `/containers/${encodeURIComponent(name)}/json`);
+    return result.body;
+  } catch (error) {
+    if (error.statusCode === 404) return null;
+    throw error;
+  }
+}
+
+async function startContainerIfNeeded(name) {
+  const existing = await inspectContainer(name);
+  if (!existing) return false;
+  if (!existing.State?.Running) {
+    await dockerRequest('POST', `/containers/${encodeURIComponent(name)}/start`);
+  }
+  return true;
+}
+
+async function createContainer({ previewId, sessionId, userId, host, workspacePath, manifest }) {
+  await ensureImage(PREVIEW_IMAGE);
+  const name = containerName(previewId);
+  if (await startContainerIfNeeded(name)) {
+    return { name, created: false };
+  }
+
+  const rootDir = manifest.rootDir || '';
+  const workdir = path.posix.join(workspacePath, rootDir).replaceAll('\\', '/');
+  const nodeModulesTarget = path.posix.join(workdir, 'node_modules');
+  const exposedPort = `${PREVIEW_PORT}/tcp`;
+  const labels = {
+    'oxygenie.preview': 'true',
+    'oxygenie.preview.id': previewId,
+    'oxygenie.preview.session': sessionId,
+    'oxygenie.preview.user': userId,
+    ...traefikLabels({ previewId, host, port: PREVIEW_PORT }),
+  };
+
+  const body = {
+    Image: PREVIEW_IMAGE,
+    name,
+    Hostname: name,
+    WorkingDir: workdir,
+    Env: [
+      'COREPACK_ENABLE_DOWNLOAD_PROMPT=0',
+      'HOME=/tmp',
+      'CI=1',
+    ],
+    Cmd: [
+      'sh',
+      '-lc',
+      [
+        'corepack enable >/dev/null 2>&1 || true',
+        `mkdir -p ${shellQuote(workdir)} ${shellQuote(nodeModulesTarget)} ${shellQuote(path.posix.join(workdir, '.oxygenie'))}`,
+        `chown -R ${shellQuote(PREVIEW_USER)} ${shellQuote(nodeModulesTarget)} ${shellQuote(path.posix.join(workdir, '.oxygenie'))} 2>/dev/null || true`,
+        'tail -f /dev/null',
+      ].join(' && '),
+    ],
+    ExposedPorts: { [exposedPort]: {} },
+    Labels: labels,
+    HostConfig: {
+      NetworkMode: PREVIEW_NETWORK,
+      VolumesFrom: [CONTROLLER_CONTAINER],
+      Mounts: [
+        {
+          Type: 'volume',
+          Source: nodeModulesVolume(previewId),
+          Target: nodeModulesTarget,
+        },
+      ],
+      Memory: parseBytes(PREVIEW_MEMORY),
+      NanoCpus: Math.max(0.25, PREVIEW_CPUS) * 1_000_000_000,
+      PidsLimit: PREVIEW_PIDS,
+      CapDrop: ['ALL'],
+      SecurityOpt: ['no-new-privileges'],
+    },
+  };
+
+  const created = await dockerRequest('POST', `/containers/create?name=${encodeURIComponent(name)}`, body);
+  await dockerRequest('POST', `/containers/${created.body.Id}/start`);
+  return { name, created: true };
+}
+
+function demuxDockerStream(buffer) {
+  const chunks = [];
+  let offset = 0;
+  while (offset + 8 <= buffer.length) {
+    const size = buffer.readUInt32BE(offset + 4);
+    const start = offset + 8;
+    const end = start + size;
+    if (end > buffer.length) break;
+    chunks.push(buffer.slice(start, end));
+    offset = end;
+  }
+  if (chunks.length === 0) return buffer.toString('utf8');
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function execInContainer({ previewId, command, workdir, env = [], user = PREVIEW_USER, detach = false, timeoutMs = 10 * 60 * 1000 }) {
+  const name = containerName(previewId);
+  const create = await dockerRequest('POST', `/containers/${encodeURIComponent(name)}/exec`, {
+    AttachStdout: !detach,
+    AttachStderr: !detach,
+    Tty: false,
+    User: user || '',
+    WorkingDir: workdir,
+    Env: env,
+    Cmd: ['sh', '-lc', command],
+  });
+
+  const execId = create.body.Id;
+  const startedAt = Date.now();
+  const startPromise = dockerRequest('POST', `/exec/${encodeURIComponent(execId)}/start`, {
+    Detach: detach,
+    Tty: false,
+  });
+
+  if (detach) {
+    await startPromise;
+    return { exitCode: 0, output: '', durationMs: Date.now() - startedAt };
+  }
+
+  const timeout = new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(`Command timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  const result = await Promise.race([startPromise, timeout]);
+  const inspect = await dockerRequest('GET', `/exec/${encodeURIComponent(execId)}/json`);
+  const output = demuxDockerStream(result.raw);
+  if (inspect.body.ExitCode !== 0) {
+    const error = new Error(output || `Command failed with exit code ${inspect.body.ExitCode}`);
+    error.output = output;
+    error.exitCode = inspect.body.ExitCode;
+    throw error;
+  }
+  return { exitCode: inspect.body.ExitCode, output, durationMs: Date.now() - startedAt };
+}
+
+function appWorkdir(workspacePath, manifest) {
+  return path.posix.join(workspacePath, manifest.rootDir || '').replaceAll('\\', '/');
+}
+
+function staticServerScript() {
+  return `
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const root = path.resolve(process.env.PREVIEW_ROOT || 'dist');
+const port = Number(process.env.PORT || ${PREVIEW_PORT});
+const types = {'.html':'text/html; charset=utf-8','.js':'text/javascript; charset=utf-8','.mjs':'text/javascript; charset=utf-8','.css':'text/css; charset=utf-8','.json':'application/json; charset=utf-8','.svg':'image/svg+xml','.png':'image/png','.jpg':'image/jpeg','.jpeg':'image/jpeg','.gif':'image/gif','.webp':'image/webp','.ico':'image/x-icon','.txt':'text/plain; charset=utf-8'};
+function send(res, status, body, type='text/plain; charset=utf-8') { res.writeHead(status, {'content-type': type, 'cache-control': 'no-store'}); res.end(body); }
+http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://preview.local');
+  let rel = decodeURIComponent(url.pathname);
+  if (rel.includes('\\0')) return send(res, 400, 'Bad request');
+  if (rel === '/') rel = '/index.html';
+  let target = path.resolve(root, '.' + rel);
+  if (!target.startsWith(root + path.sep) && target !== root) return send(res, 403, 'Forbidden');
+  fs.stat(target, (statErr, stat) => {
+    if (!statErr && stat.isDirectory()) target = path.join(target, 'index.html');
+    fs.readFile(target, (err, data) => {
+      if (err) {
+        fs.readFile(path.join(root, 'index.html'), (fallbackErr, fallback) => {
+          if (fallbackErr) return send(res, 404, 'Not found');
+          send(res, 200, fallback, 'text/html; charset=utf-8');
+        });
+        return;
+      }
+      send(res, 200, data, types[path.extname(target).toLowerCase()] || 'application/octet-stream');
+    });
+  });
+}).listen(port, '0.0.0.0', () => console.log('OxyGenie preview static server listening on :' + port + ' root=' + root));
+`;
+}
+
+async function installDeps(body) {
+  const workdir = appWorkdir(body.workspacePath, body.manifest);
+  const command = [
+    'corepack enable >/dev/null 2>&1 || true',
+    body.manifest.installCommand,
+  ].join(' && ');
+  return execInContainer({
+    previewId: body.previewId,
+    command,
+    workdir,
+    timeoutMs: Number(process.env.PREVIEW_INSTALL_TIMEOUT_MS || 5 * 60 * 1000),
+  });
+}
+
+async function startPreview(body) {
+  const workdir = appWorkdir(body.workspacePath, body.manifest);
+  const build = await execInContainer({
+    previewId: body.previewId,
+    command: body.manifest.buildCommand,
+    workdir,
+    timeoutMs: Number(process.env.PREVIEW_BUILD_TIMEOUT_MS || 5 * 60 * 1000),
+  });
+
+  const outputDir = body.manifest.outputDir || 'dist';
+  const script = staticServerScript();
+  const command = [
+    'mkdir -p .oxygenie',
+    'if [ -f .oxygenie/preview.pid ]; then kill "$(cat .oxygenie/preview.pid)" 2>/dev/null || true; fi',
+    `PORT=${PREVIEW_PORT} PREVIEW_ROOT=${shellQuote(path.posix.join(workdir, outputDir))} nohup node -e ${shellQuote(script)} > .oxygenie/preview.log 2>&1 & echo $! > .oxygenie/preview.pid`,
+  ].join(' && ');
+  await execInContainer({
+    previewId: body.previewId,
+    command,
+    workdir,
+    timeoutMs: 30 * 1000,
+  });
+  return { build };
+}
+
+async function stopPreview(body) {
+  const name = containerName(body.previewId);
+  const existing = await inspectContainer(name);
+  if (!existing) return { stopped: false };
+  try {
+    await dockerRequest('POST', `/containers/${encodeURIComponent(name)}/kill`);
+  } catch (error) {
+    if (error.statusCode !== 304 && error.statusCode !== 409) throw error;
+  }
+  try {
+    await dockerRequest('DELETE', `/containers/${encodeURIComponent(name)}?force=true&v=false`);
+  } catch (error) {
+    if (error.statusCode !== 404) throw error;
+  }
+  return { stopped: true };
+}
+
+async function route(req, res) {
+  if (req.method === 'GET' && req.url === '/health') {
+    json(res, 200, { ok: true });
+    return;
+  }
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  const body = await readBody(req);
+  if (req.url === '/v1/sandbox/ensure') {
+    const result = await createContainer(body);
+    json(res, 200, { ok: true, ...result });
+    return;
+  }
+  if (req.url === '/v1/deps/install') {
+    const result = await installDeps(body);
+    json(res, 200, { ok: true, output: result.output, durationMs: result.durationMs });
+    return;
+  }
+  if (req.url === '/v1/preview/start') {
+    const result = await startPreview(body);
+    json(res, 200, { ok: true, output: result.build.output, durationMs: result.build.durationMs });
+    return;
+  }
+  if (req.url === '/v1/preview/stop') {
+    const result = await stopPreview(body);
+    json(res, 200, { ok: true, ...result });
+    return;
+  }
+  json(res, 404, { error: 'Not found' });
+}
+
+const server = http.createServer((req, res) => {
+  route(req, res).catch((error) => {
+    console.error('[Preview Controller]', error);
+    json(res, 500, {
+      error: error instanceof Error ? error.message : String(error),
+      ...(error?.output && { output: error.output }),
+    });
+  });
+});
+
+server.listen(PORT, () => {
+  console.error(`[Preview Controller] Listening on :${PORT}`);
+  console.error(`[Preview Controller] Docker socket: ${DOCKER_SOCKET}`);
+  console.error(`[Preview Controller] Preview image: ${PREVIEW_IMAGE}`);
+});

--- a/src/preview/controller.mjs
+++ b/src/preview/controller.mjs
@@ -209,6 +209,9 @@ async function createContainer({ previewId, sessionId, userId, host, workspacePa
         'corepack enable >/dev/null 2>&1 || true',
         `mkdir -p ${shellQuote(workdir)} ${shellQuote(nodeModulesTarget)} ${shellQuote(path.posix.join(workdir, '.oxygenie'))}`,
         `chown -R ${shellQuote(PREVIEW_USER)} ${shellQuote(nodeModulesTarget)} ${shellQuote(path.posix.join(workdir, '.oxygenie'))} 2>/dev/null || true`,
+        // Non-recursive: give the preview user write access to the workspace root
+        // (lockfiles, build output dir) without rewriting ownership of user source files.
+        `chown ${shellQuote(PREVIEW_USER)} ${shellQuote(workdir)} 2>/dev/null || true`,
         'tail -f /dev/null',
       ].join(' && '),
     ],
@@ -227,7 +230,12 @@ async function createContainer({ previewId, sessionId, userId, host, workspacePa
       Memory: parseBytes(PREVIEW_MEMORY),
       NanoCpus: Math.max(0.25, PREVIEW_CPUS) * 1_000_000_000,
       PidsLimit: PREVIEW_PIDS,
+      // Drop everything, then re-add only CHOWN: the root-run startup step needs it to
+      // hand the node_modules volume + workspace root to the unprivileged preview user.
+      // install/build/serve still run as PREVIEW_USER (non-root) with no effective caps,
+      // so untrusted build code remains unprivileged.
       CapDrop: ['ALL'],
+      CapAdd: ['CHOWN'],
       SecurityOpt: ['no-new-privileges'],
     },
   };
@@ -300,6 +308,7 @@ function staticServerScript() {
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+try { if (process.env.PREVIEW_PID_FILE) fs.writeFileSync(process.env.PREVIEW_PID_FILE, String(process.pid)); } catch (e) {}
 const root = path.resolve(process.env.PREVIEW_ROOT || 'dist');
 const port = Number(process.env.PORT || ${PREVIEW_PORT});
 const types = {'.html':'text/html; charset=utf-8','.js':'text/javascript; charset=utf-8','.mjs':'text/javascript; charset=utf-8','.css':'text/css; charset=utf-8','.json':'application/json; charset=utf-8','.svg':'image/svg+xml','.png':'image/png','.jpg':'image/jpeg','.jpeg':'image/jpeg','.gif':'image/gif','.webp':'image/webp','.ico':'image/x-icon','.txt':'text/plain; charset=utf-8'};
@@ -352,17 +361,32 @@ async function startPreview(body) {
   });
 
   const outputDir = body.manifest.outputDir || 'dist';
+  const previewRoot = path.posix.join(workdir, outputDir);
+  const logPath = path.posix.join(workdir, '.oxygenie/preview.log');
+  const pidPath = path.posix.join(workdir, '.oxygenie/preview.pid');
   const script = staticServerScript();
-  const command = [
-    'mkdir -p .oxygenie',
-    'if [ -f .oxygenie/preview.pid ]; then kill "$(cat .oxygenie/preview.pid)" 2>/dev/null || true; fi',
-    `PORT=${PREVIEW_PORT} PREVIEW_ROOT=${shellQuote(path.posix.join(workdir, outputDir))} nohup node -e ${shellQuote(script)} > .oxygenie/preview.log 2>&1 & echo $! > .oxygenie/preview.pid`,
-  ].join(' && ');
+
+  // Stop any previous server (best-effort) before (re)starting.
   await execInContainer({
     previewId: body.previewId,
-    command,
+    command:
+      'mkdir -p .oxygenie && if [ -f .oxygenie/preview.pid ]; then kill "$(cat .oxygenie/preview.pid)" 2>/dev/null || true; fi',
     workdir,
-    timeoutMs: 30 * 1000,
+    timeoutMs: 10 * 1000,
+  });
+
+  // Start the static server as a DETACHED exec running node in the foreground via
+  // `exec` (so the exec's PID *is* the node PID). A backgrounded `nohup ... &` inside
+  // an attached exec races with exec-session teardown and can be reaped before it is
+  // useful; a detached exec is owned by the daemon and survives reliably.
+  // The server writes its own (container-namespace) PID to PREVIEW_PID_FILE on startup —
+  // the exec API only exposes the host-namespace PID, which is useless for an in-container
+  // `kill`, so we let the process self-record the PID that restart/idle-reap actually need.
+  await execInContainer({
+    previewId: body.previewId,
+    command: `PORT=${PREVIEW_PORT} PREVIEW_ROOT=${shellQuote(previewRoot)} PREVIEW_PID_FILE=${shellQuote(pidPath)} exec node -e ${shellQuote(script)} > ${shellQuote(logPath)} 2>&1`,
+    workdir,
+    detach: true,
   });
   return { build };
 }

--- a/src/preview/manifest.js
+++ b/src/preview/manifest.js
@@ -1,0 +1,250 @@
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const MANIFEST_DIR = '.oxygenie';
+export const MANIFEST_PATH = path.join(MANIFEST_DIR, 'app.json');
+
+const SUPPORTED_TYPES = new Set(['spa', 'static', 'server']);
+const DEFAULT_STATIC_PORT = 4173;
+const MAX_SCAN_DEPTH = 3;
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isSafeRelativePath(value) {
+  if (typeof value !== 'string') return false;
+  if (value === '') return true;
+  if (value.includes('\0')) return false;
+  if (path.isAbsolute(value)) return false;
+  const normalized = path.posix.normalize(value.split(path.sep).join('/'));
+  if (normalized === '.' || normalized === '') return true;
+  return !normalized.startsWith('../') && normalized !== '..';
+}
+
+function normalizeRelativePath(value, fallback = '') {
+  if (typeof value !== 'string' || !isSafeRelativePath(value)) return fallback;
+  const normalized = path.posix.normalize(value.split(path.sep).join('/'));
+  return normalized === '.' ? '' : normalized;
+}
+
+function readString(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function readPort(value, fallback = DEFAULT_STATIC_PORT) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1024 || n > 65535) return fallback;
+  return n;
+}
+
+async function fileExists(filePath) {
+  try {
+    await readFile(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findPackageJson(workspacePath, dir = '', depth = 0) {
+  const candidate = path.join(workspacePath, dir, 'package.json');
+  if (await fileExists(candidate)) return dir;
+  if (depth >= MAX_SCAN_DEPTH) return null;
+
+  let entries;
+  try {
+    entries = await readdir(path.join(workspacePath, dir), { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const child = dir ? path.join(dir, entry.name) : entry.name;
+    const found = await findPackageJson(workspacePath, child, depth + 1);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+async function readJson(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function detectPackageManager(appDir) {
+  if (await fileExists(path.join(appDir, 'pnpm-lock.yaml'))) {
+    return {
+      installCommand: 'pnpm install --frozen-lockfile',
+      buildCommand: 'pnpm build',
+      devCommand: 'pnpm dev',
+    };
+  }
+  if (await fileExists(path.join(appDir, 'package-lock.json'))) {
+    return {
+      installCommand: 'npm ci',
+      buildCommand: 'npm run build',
+      devCommand: 'npm run dev',
+    };
+  }
+  if (await fileExists(path.join(appDir, 'yarn.lock'))) {
+    return {
+      installCommand: 'yarn install --frozen-lockfile',
+      buildCommand: 'yarn build',
+      devCommand: 'yarn dev',
+    };
+  }
+  return {
+    installCommand: 'npm install',
+    buildCommand: 'npm run build',
+    devCommand: 'npm run dev',
+  };
+}
+
+function detectFramework(pkg) {
+  const deps = {
+    ...(isPlainObject(pkg.dependencies) ? pkg.dependencies : {}),
+    ...(isPlainObject(pkg.devDependencies) ? pkg.devDependencies : {}),
+  };
+  if (deps.vite || deps['@vitejs/plugin-react']) return 'vite';
+  if (deps['react-scripts']) return 'cra';
+  if (deps.next) return 'next';
+  if (deps.react) return 'react';
+  return 'static';
+}
+
+function inferType(framework) {
+  return framework === 'next' ? 'server' : 'spa';
+}
+
+function inferOutputDir(framework) {
+  if (framework === 'cra') return 'build';
+  return 'dist';
+}
+
+function parseScriptCommand(command) {
+  const parts = String(command || '').trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return null;
+  const [bin, a, b] = parts;
+  if (bin === 'npm' && a === 'run' && b) return b;
+  if ((bin === 'pnpm' || bin === 'yarn') && a) return a;
+  if (bin === 'bun' && a === 'run' && b) return b;
+  if (bin === 'bun' && a) return a;
+  return null;
+}
+
+function isAllowedInstallCommand(command) {
+  const normalized = String(command || '').trim();
+  return [
+    'npm install',
+    'npm ci',
+    'pnpm install',
+    'pnpm install --frozen-lockfile',
+    'yarn install',
+    'yarn install --frozen-lockfile',
+    'bun install',
+  ].includes(normalized);
+}
+
+function assertAllowedBuildCommand(command, pkg, field) {
+  const scriptName = parseScriptCommand(command);
+  const scripts = isPlainObject(pkg.scripts) ? pkg.scripts : {};
+  if (!scriptName || typeof scripts[scriptName] !== 'string') {
+    throw new Error(`${field} must call an existing package.json script`);
+  }
+}
+
+export async function normalizeManifest(workspacePath, manifest) {
+  if (!isPlainObject(manifest)) {
+    throw new Error('Preview manifest must be an object');
+  }
+
+  const rootDir = normalizeRelativePath(manifest.rootDir ?? '', '');
+  const appDir = path.join(workspacePath, rootDir);
+  const pkg = await readJson(path.join(appDir, 'package.json'));
+  const scripts = isPlainObject(pkg.scripts) ? pkg.scripts : {};
+  const framework = readString(manifest.framework, detectFramework(pkg));
+  const type = SUPPORTED_TYPES.has(String(manifest.type)) ? String(manifest.type) : inferType(framework);
+  const defaults = await detectPackageManager(appDir);
+
+  const installCommand = readString(manifest.installCommand, defaults.installCommand);
+  if (!isAllowedInstallCommand(installCommand)) {
+    throw new Error('installCommand must be a supported package-manager install command');
+  }
+
+  const buildCommand = readString(manifest.buildCommand, defaults.buildCommand);
+  assertAllowedBuildCommand(buildCommand, pkg, 'buildCommand');
+
+  const defaultDevCommand = typeof scripts.dev === 'string' ? defaults.devCommand : '';
+  const devCommand = readString(manifest.devCommand, defaultDevCommand);
+  if (devCommand) assertAllowedBuildCommand(devCommand, pkg, 'devCommand');
+
+  const outputDir = normalizeRelativePath(manifest.outputDir ?? inferOutputDir(framework), inferOutputDir(framework));
+  if (!outputDir) throw new Error('outputDir must be a workspace-relative path');
+
+  const entryFiles = Array.isArray(manifest.entryFiles)
+    ? manifest.entryFiles.filter(isSafeRelativePath).map((v) => path.posix.normalize(v.split(path.sep).join('/')))
+    : ['package.json'];
+
+  return {
+    rootDir,
+    title: readString(manifest.title ?? manifest.name, readString(pkg.name, 'App Preview')),
+    name: readString(manifest.name, readString(manifest.title ?? pkg.name, 'App Preview')),
+    type,
+    framework,
+    installCommand,
+    buildCommand,
+    devCommand,
+    outputDir,
+    port: readPort(manifest.port, DEFAULT_STATIC_PORT),
+    entryFiles,
+  };
+}
+
+async function detectManifest(workspacePath) {
+  const rootDir = await findPackageJson(workspacePath);
+  if (rootDir === null) {
+    throw new Error('No package.json found in the session workspace');
+  }
+
+  const appDir = path.join(workspacePath, rootDir);
+  const pkg = await readJson(path.join(appDir, 'package.json'));
+  const framework = detectFramework(pkg);
+  const defaults = await detectPackageManager(appDir);
+  const scripts = isPlainObject(pkg.scripts) ? pkg.scripts : {};
+
+  return normalizeManifest(workspacePath, {
+    rootDir,
+    title: readString(pkg.name, 'App Preview'),
+    type: inferType(framework),
+    framework,
+    installCommand: defaults.installCommand,
+    buildCommand: defaults.buildCommand,
+    devCommand: typeof scripts.dev === 'string' ? defaults.devCommand : '',
+    outputDir: inferOutputDir(framework),
+    port: DEFAULT_STATIC_PORT,
+    entryFiles: ['package.json'],
+  });
+}
+
+export async function loadOrDetectManifest(workspacePath) {
+  const manifestFile = path.join(workspacePath, MANIFEST_PATH);
+  let manifest;
+  let source = 'detected';
+
+  try {
+    manifest = await normalizeManifest(workspacePath, await readJson(manifestFile));
+    source = 'file';
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      console.error('[Preview] Ignoring invalid .oxygenie/app.json:', error.message);
+    }
+    manifest = await detectManifest(workspacePath);
+    await mkdir(path.dirname(manifestFile), { recursive: true });
+    await writeFile(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  }
+
+  return { manifest, source };
+}

--- a/src/preview/runtime.js
+++ b/src/preview/runtime.js
@@ -1,0 +1,317 @@
+import crypto from 'node:crypto';
+import { Semaphore } from '../server/concurrency/semaphore.js';
+import { loadOrDetectManifest } from './manifest.js';
+
+const DEFAULT_PREVIEW_CONTROLLER_URL = 'http://localhost:5055';
+const DEFAULT_PREVIEW_BASE_DOMAIN = '127-0-0-1.sslip.io';
+const DEFAULT_PREVIEW_PROTOCOL = 'http';
+const DEFAULT_MAX_ACTIVE_PREVIEWS = 4;
+const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+function cfgNumber(name, fallback) {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+function stablePreviewId(userId, sessionId, rootDir = '') {
+  const digest = crypto
+    .createHash('sha256')
+    .update(`${userId}:${sessionId}:${rootDir}`)
+    .digest('hex')
+    .slice(0, 18);
+  return `p-${digest}`;
+}
+
+function normalizeHostSegment(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+export function makePreviewHost(previewId) {
+  const domain = process.env.PREVIEW_BASE_DOMAIN || DEFAULT_PREVIEW_BASE_DOMAIN;
+  const template = process.env.PREVIEW_HOST_TEMPLATE;
+  if (template) {
+    return template.replaceAll('{previewId}', normalizeHostSegment(previewId));
+  }
+  return `${normalizeHostSegment(previewId)}.${domain}`;
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { error: text };
+  }
+  if (!response.ok) {
+    throw new Error(body?.error || body?.message || `Preview controller returned ${response.status}`);
+  }
+  return body;
+}
+
+export class DockerPreviewProvider {
+  constructor(options = {}) {
+    this.controllerUrl = (options.controllerUrl || process.env.PREVIEW_CONTROLLER_URL || DEFAULT_PREVIEW_CONTROLLER_URL).replace(/\/+$/, '');
+  }
+
+  async request(path, body) {
+    const response = await fetch(`${this.controllerUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return readJsonResponse(response);
+  }
+
+  async ensureSessionSandbox(input) {
+    return this.request('/v1/sandbox/ensure', input);
+  }
+
+  async installDeps(input) {
+    return this.request('/v1/deps/install', input);
+  }
+
+  async startPreview(input) {
+    return this.request('/v1/preview/start', input);
+  }
+
+  async stopPreview(input) {
+    return this.request('/v1/preview/stop', input);
+  }
+}
+
+export class PreviewRuntime {
+  constructor({ provider, auth } = {}) {
+    this.provider = provider || new DockerPreviewProvider();
+    this.auth = auth;
+    this.maxActive = cfgNumber('MAX_ACTIVE_PREVIEWS', DEFAULT_MAX_ACTIVE_PREVIEWS);
+    this.idleTimeoutMs = cfgNumber('PREVIEW_IDLE_TIMEOUT_MS', DEFAULT_IDLE_TIMEOUT_MS);
+    this.protocol = process.env.PREVIEW_PROTOCOL || DEFAULT_PREVIEW_PROTOCOL;
+    this.semaphore = new Semaphore(this.maxActive);
+    this.active = new Map();
+    this.inFlight = new Map();
+  }
+
+  getPreviewUrl(previewId, token) {
+    const state = this.active.get(previewId);
+    const host = state?.host || makePreviewHost(previewId);
+    return `${this.protocol}://${host}/__oxy/preview/auth?t=${encodeURIComponent(token)}`;
+  }
+
+  getState(previewId) {
+    return this.active.get(previewId) || null;
+  }
+
+  touchPreview(previewId) {
+    const state = this.active.get(previewId);
+    if (!state) return null;
+    state.lastAccessAt = Date.now();
+    return state;
+  }
+
+  async stopPreview(previewId, reason = 'stopped') {
+    const state = this.active.get(previewId);
+    if (!state) return null;
+    await this.provider.stopPreview({ previewId });
+    this.active.delete(previewId);
+    this.semaphore.release();
+    return {
+      sessionId: state.sessionId,
+      previewId,
+      mode: state.mode,
+      status: 'stopped',
+      error: reason === 'stopped' ? undefined : reason,
+      manifest: state.manifest,
+    };
+  }
+
+  async reapIdlePreviews(sendState) {
+    const now = Date.now();
+    const stopped = [];
+    for (const [previewId, state] of this.active.entries()) {
+      if (state.status !== 'ready') continue;
+      if (now - state.lastAccessAt <= this.idleTimeoutMs) continue;
+      try {
+        const next = await this.stopPreview(previewId, 'idle timeout');
+        if (next) {
+          stopped.push(next);
+          sendState?.(next);
+        }
+      } catch (error) {
+        console.error('[Preview] Idle reap failed:', previewId, error);
+      }
+    }
+    return stopped;
+  }
+
+  async startStaticPreview({ userId, sessionId, workspacePath, sendState }) {
+    if (!userId || !sessionId || !workspacePath) {
+      throw new Error('Missing preview start context');
+    }
+    if (this.inFlight.has(sessionId)) {
+      return this.inFlight.get(sessionId);
+    }
+
+    const task = this.#startStaticPreview({ userId, sessionId, workspacePath, sendState })
+      .finally(() => this.inFlight.delete(sessionId));
+    this.inFlight.set(sessionId, task);
+    return task;
+  }
+
+  async #startStaticPreview({ userId, sessionId, workspacePath, sendState }) {
+    const status = (state) => {
+      sendState?.(state);
+      return state;
+    };
+
+    let manifest;
+    let previewId;
+    let host;
+    let acquired = false;
+
+    try {
+      status({
+        sessionId,
+        previewId: stablePreviewId(userId, sessionId),
+        mode: 'static',
+        status: 'detecting',
+      });
+
+      const detected = await loadOrDetectManifest(workspacePath);
+      manifest = detected.manifest;
+      previewId = stablePreviewId(userId, sessionId, manifest.rootDir);
+      host = makePreviewHost(previewId);
+
+      if (manifest.type === 'server') {
+        return status({
+          sessionId,
+          previewId,
+          mode: 'static',
+          status: 'error',
+          error: 'Static preview v1 supports frontend SPA/static apps only. Use live preview in a later version for server apps.',
+          manifest,
+        });
+      }
+
+      if (this.active.has(previewId)) {
+        const existing = this.active.get(previewId);
+        existing.lastAccessAt = Date.now();
+        if (existing.status !== 'ready') {
+          return status({
+            sessionId,
+            previewId,
+            mode: 'static',
+            status: existing.status,
+            manifest,
+          });
+        }
+        const token = this.auth?.issueBootstrapToken({
+          previewId,
+          sessionId,
+          userId,
+          host,
+        });
+        const readyState = status({
+          sessionId,
+          previewId,
+          mode: 'static',
+          status: 'ready',
+          url: token ? this.getPreviewUrl(previewId, token) : existing.url,
+          manifest,
+        });
+        return readyState;
+      }
+
+      if (this.semaphore.activeCount >= this.semaphore.max) {
+        return status({
+          sessionId,
+          previewId,
+          mode: 'static',
+          status: 'error',
+          error: `Preview capacity reached (${this.semaphore.max} active previews). Try again after another preview goes idle.`,
+          manifest,
+        });
+      }
+      await this.semaphore.acquire();
+      acquired = true;
+
+      const baseState = {
+        sessionId,
+        previewId,
+        mode: 'static',
+        host,
+        manifest,
+        workspacePath,
+        lastAccessAt: Date.now(),
+        status: 'installing',
+      };
+      this.active.set(previewId, baseState);
+      status({ sessionId, previewId, mode: 'static', status: 'installing', manifest });
+
+      await this.provider.ensureSessionSandbox({
+        previewId,
+        sessionId,
+        userId,
+        host,
+        workspacePath,
+        manifest,
+      });
+      await this.provider.installDeps({
+        previewId,
+        workspacePath,
+        manifest,
+      });
+
+      baseState.status = 'building';
+      status({ sessionId, previewId, mode: 'static', status: 'building', manifest });
+      await this.provider.startPreview({
+        previewId,
+        workspacePath,
+        manifest,
+        mode: 'static',
+      });
+
+      const token = this.auth?.issueBootstrapToken({
+        previewId,
+        sessionId,
+        userId,
+        host,
+      });
+      const url = token ? this.getPreviewUrl(previewId, token) : `${this.protocol}://${host}/`;
+      baseState.status = 'ready';
+      baseState.url = url;
+      baseState.lastAccessAt = Date.now();
+
+      return status({
+        sessionId,
+        previewId,
+        mode: 'static',
+        status: 'ready',
+        url,
+        manifest,
+      });
+    } catch (error) {
+      if (previewId) {
+        this.active.delete(previewId);
+        try {
+          await this.provider.stopPreview({ previewId });
+        } catch (stopError) {
+          console.error('[Preview] Failed to clean up failed preview:', stopError?.message || stopError);
+        }
+      }
+      if (acquired) this.semaphore.release();
+      return status({
+        sessionId,
+        previewId: previewId || stablePreviewId(userId, sessionId),
+        mode: 'static',
+        status: 'error',
+        error: error instanceof Error ? error.message : String(error),
+        ...(manifest && { manifest }),
+      });
+    }
+  }
+}

--- a/tests/unit/preview-auth.test.ts
+++ b/tests/unit/preview-auth.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import { PreviewAuth } from '../../src/preview/auth.js';
 

--- a/tests/unit/preview-auth.test.ts
+++ b/tests/unit/preview-auth.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { PreviewAuth } from '../../src/preview/auth.js';
+
+describe('PreviewAuth', () => {
+  it('consumes bootstrap tokens exactly once and creates a host-scoped cookie session', () => {
+    const auth = new PreviewAuth({
+      secret: 'test-secret',
+      bootstrapTtlMs: 60_000,
+      cookieTtlMs: 60_000,
+      secureCookies: false,
+    });
+
+    const token = auth.issueBootstrapToken({
+      previewId: 'p-test',
+      sessionId: 's-test',
+      userId: 'u-test',
+      host: 'p-test.127-0-0-1.sslip.io',
+    });
+
+    const entry = auth.consumeBootstrapToken(token, { host: 'p-test.127-0-0-1.sslip.io' });
+    expect(entry.previewId).toBe('p-test');
+    expect(() => auth.consumeBootstrapToken(token, { host: 'p-test.127-0-0-1.sslip.io' })).toThrow(
+      /already used|expired/,
+    );
+
+    const session = auth.createCookieSession(entry);
+    expect(session.cookie).toContain('HttpOnly');
+    const verified = auth.verifyCookie(session.cookie, { host: 'p-test.127-0-0-1.sslip.io' });
+    expect(verified?.entry.sessionId).toBe('s-test');
+    expect(auth.verifyCookie(session.cookie, { host: 'other.127-0-0-1.sslip.io' })).toBeNull();
+  });
+});

--- a/tests/unit/preview-manifest.test.ts
+++ b/tests/unit/preview-manifest.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/tests/unit/preview-manifest.test.ts
+++ b/tests/unit/preview-manifest.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadOrDetectManifest, normalizeManifest } from '../../src/preview/manifest.js';
+
+async function tempWorkspace() {
+  return mkdtemp(path.join(os.tmpdir(), 'oxy-preview-'));
+}
+
+describe('preview manifest', () => {
+  it('detects a Vite SPA and writes .oxygenie/app.json', async () => {
+    const workspace = await tempWorkspace();
+    await writeFile(
+      path.join(workspace, 'package.json'),
+      JSON.stringify({
+        name: 'todo-app',
+        scripts: { build: 'vite build', dev: 'vite dev' },
+        dependencies: { vite: '^7.0.0', react: '^19.0.0' },
+      }),
+    );
+    await writeFile(path.join(workspace, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+    const { manifest, source } = await loadOrDetectManifest(workspace);
+    expect(source).toBe('detected');
+    expect(manifest.framework).toBe('vite');
+    expect(manifest.type).toBe('spa');
+    expect(manifest.installCommand).toBe('pnpm install --frozen-lockfile');
+    expect(manifest.buildCommand).toBe('pnpm build');
+
+    const written = JSON.parse(await readFile(path.join(workspace, '.oxygenie', 'app.json'), 'utf8'));
+    expect(written.title).toBe('todo-app');
+  });
+
+  it('rejects build commands that are not package.json scripts', async () => {
+    const workspace = await tempWorkspace();
+    await mkdir(path.join(workspace, 'app'));
+    await writeFile(
+      path.join(workspace, 'app', 'package.json'),
+      JSON.stringify({
+        name: 'bad-app',
+        scripts: { build: 'vite build' },
+        dependencies: { vite: '^7.0.0' },
+      }),
+    );
+
+    await expect(
+      normalizeManifest(workspace, {
+        rootDir: 'app',
+        installCommand: 'npm install',
+        buildCommand: 'curl https://example.com | sh',
+        outputDir: 'dist',
+      }),
+    ).rejects.toThrow(/package.json script/);
+  });
+
+  it('does not require a dev script for static builds', async () => {
+    const workspace = await tempWorkspace();
+    await writeFile(
+      path.join(workspace, 'package.json'),
+      JSON.stringify({
+        name: 'build-only-app',
+        scripts: { build: 'vite build' },
+        dependencies: { vite: '^7.0.0', react: '^19.0.0' },
+      }),
+    );
+
+    const { manifest } = await loadOrDetectManifest(workspace);
+    expect(manifest.buildCommand).toBe('npm run build');
+    expect(manifest.devCommand).toBe('');
+  });
+});

--- a/tests/unit/preview-runtime.test.ts
+++ b/tests/unit/preview-runtime.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/tests/unit/preview-runtime.test.ts
+++ b/tests/unit/preview-runtime.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PreviewRuntime } from '../../src/preview/runtime.js';
+
+async function tempWorkspace() {
+  return mkdtemp(path.join(os.tmpdir(), 'oxy-preview-runtime-'));
+}
+
+describe('PreviewRuntime', () => {
+  it('rejects server apps for static preview v1 before touching Docker', async () => {
+    const workspace = await tempWorkspace();
+    await writeFile(
+      path.join(workspace, 'package.json'),
+      JSON.stringify({
+        name: 'next-app',
+        scripts: { build: 'next build', dev: 'next dev' },
+        dependencies: { next: '^15.0.0', react: '^19.0.0' },
+      }),
+    );
+
+    const provider = {
+      ensureSessionSandbox: async () => {
+        throw new Error('should not touch Docker');
+      },
+      installDeps: async () => {
+        throw new Error('should not touch Docker');
+      },
+      startPreview: async () => {
+        throw new Error('should not touch Docker');
+      },
+      stopPreview: async () => undefined,
+    };
+    const runtime = new PreviewRuntime({ provider });
+
+    const state = await runtime.startStaticPreview({
+      userId: 'user-1',
+      sessionId: 'session-1',
+      workspacePath: workspace,
+      sendState: undefined,
+    });
+
+    expect(state.status).toBe('error');
+    expect(state.error).toMatch(/frontend SPA\/static apps only/);
+  });
+});

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -23,6 +23,8 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { Semaphore } from './src/server/concurrency/semaphore.js';
 import { shouldReapIdle } from './src/server/concurrency/idle-reaper.js';
 import { resolveEffectivePermission } from './src/lib/permission-tier.js';
+import { PreviewAuth } from './src/preview/auth.js';
+import { PreviewRuntime } from './src/preview/runtime.js';
 
 // Get directory of current module
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -107,6 +109,16 @@ const config = {
   model: process.env.ANTHROPIC_MODEL,
   cwd: process.cwd(),
 };
+
+const previewAuth = new PreviewAuth({
+  secret: process.env.PREVIEW_AUTH_SECRET || process.env.BETTER_AUTH_SECRET,
+  bootstrapTtlMs: Number(process.env.PREVIEW_BOOTSTRAP_TTL_MS) || undefined,
+  cookieTtlMs: Number(process.env.PREVIEW_COOKIE_TTL_MS) || undefined,
+  secureCookies: process.env.PREVIEW_COOKIE_SECURE
+    ? process.env.PREVIEW_COOKIE_SECURE === '1'
+    : process.env.NODE_ENV === 'production',
+});
+const previewRuntime = new PreviewRuntime({ auth: previewAuth });
 
 const PERMISSION_MODES = new Set([
   'default',
@@ -278,6 +290,8 @@ const BUSINESS_MESSAGE_TYPES = new Set([
   'chat',
   'resume',
   'abort',
+  'start_preview',
+  'stop_preview',
 ]);
 
 // Track initialized directories
@@ -750,6 +764,68 @@ function sendMessage(ws, msg) {
   return 0;
 }
 
+function nextPreviewSeq(ws) {
+  ws.__previewSeq = (ws.__previewSeq || 0) + 1;
+  return ws.__previewSeq;
+}
+
+function sendPreviewState(ws, state) {
+  return sendMessage(ws, {
+    type: 'preview_state',
+    state,
+    seq: nextPreviewSeq(ws),
+  });
+}
+
+function normalizeHost(headerValue) {
+  if (!headerValue) return '';
+  return String(headerValue).split(',')[0].trim().replace(/:\d+$/, '').toLowerCase();
+}
+
+function redirect(res, location, headers = {}) {
+  res.writeHead(302, { location, ...headers });
+  res.end();
+}
+
+async function handlePreviewHttp(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host || 'preview.local'}`);
+  const forwardedHost = normalizeHost(req.headers['x-forwarded-host']);
+  const host = forwardedHost || normalizeHost(req.headers.host);
+
+  if (req.method === 'GET' && url.pathname === '/__oxy/preview/auth') {
+    try {
+      const token = url.searchParams.get('t');
+      const entry = previewAuth.consumeBootstrapToken(token, { host });
+      previewRuntime.touchPreview(entry.previewId);
+      const session = previewAuth.createCookieSession(entry);
+      redirect(res, '/', { 'set-cookie': session.cookie });
+    } catch (error) {
+      res.writeHead(401, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end(error instanceof Error ? error.message : 'Unauthorized preview');
+    }
+    return true;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/__oxy/preview/authorize') {
+    const verified = previewAuth.verifyCookie(req.headers.cookie || '', { host });
+    if (!verified) {
+      res.writeHead(401, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Unauthorized preview');
+      return true;
+    }
+    previewRuntime.touchPreview(verified.entry.previewId);
+    res.writeHead(200, {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-oxygenie-preview-id': verified.entry.previewId,
+      'x-oxygenie-session-id': verified.entry.sessionId,
+    });
+    res.end('ok');
+    return true;
+  }
+
+  return false;
+}
+
 // C4 backpressure (consumer side): bytes queued on the WS socket above/below
 // which we pause/resume reading the worker's stdout, so a fast agent stream +
 // slow client can't grow the server's send buffer without bound.
@@ -811,6 +887,84 @@ async function handleCreateSession(ws) {
     sendMessage(ws, {
       type: 'error',
       code: 'server_error',
+      message: error instanceof Error ? error.message : String(error),
+      retriable: true,
+    });
+  }
+}
+
+async function resolvePreviewWorkspace(ws, sessionId) {
+  if (!sessionId) {
+    throw new Error('Missing sessionId for preview');
+  }
+
+  if (ws.cookie) {
+    const sessionData = await loadSessionFromDb(ws.cookie, sessionId);
+    if (sessionData) {
+      return getSessionWorkspace(ws.userId, sessionId);
+    }
+  }
+
+  // Newly-created empty sessions are persisted immediately, but keep a narrow
+  // fallback for the current socket while the DB/API write is settling.
+  if (ws.workspaceSessionId === sessionId) {
+    return getSessionWorkspace(ws.userId, sessionId);
+  }
+
+  throw new Error('Session not found or not accessible');
+}
+
+async function handleStartPreview(ws, message) {
+  const sessionId = message.sessionId || ws.workspaceSessionId;
+  const mode = message.mode === 'live' ? 'live' : 'static';
+  if (mode !== 'static') {
+    sendPreviewState(ws, {
+      sessionId,
+      previewId: 'pending',
+      mode,
+      status: 'error',
+      error: 'Live preview is best-effort and not enabled in v1. Use static preview.',
+    });
+    return;
+  }
+
+  try {
+    const workspacePath = await resolvePreviewWorkspace(ws, sessionId);
+    await previewRuntime.startStaticPreview({
+      userId: ws.userId,
+      sessionId,
+      workspacePath,
+      sendState: (state) => sendPreviewState(ws, state),
+    });
+  } catch (error) {
+    sendPreviewState(ws, {
+      sessionId,
+      previewId: 'pending',
+      mode,
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleStopPreview(ws, message) {
+  try {
+    const previewId = message.previewId;
+    if (!previewId) {
+      sendMessage(ws, {
+        type: 'error',
+        code: 'invalid_message',
+        message: 'Missing previewId for stop_preview',
+        retriable: false,
+      });
+      return;
+    }
+    const state = await previewRuntime.stopPreview(previewId);
+    if (state) sendPreviewState(ws, state);
+  } catch (error) {
+    sendMessage(ws, {
+      type: 'error',
+      code: 'preview_stop_failed',
       message: error instanceof Error ? error.message : String(error),
       retriable: true,
     });
@@ -1425,6 +1579,14 @@ async function handleMessage(ws, msg) {
       }
       break;
 
+    case 'start_preview':
+      await handleStartPreview(ws, message);
+      break;
+
+    case 'stop_preview':
+      await handleStopPreview(ws, message);
+      break;
+
     case 'ping':
       sendMessage(ws, { type: 'pong' });
       break;
@@ -1466,7 +1628,18 @@ async function handleMessage(ws, msg) {
  */
 export function startWebSocketServer(port = WS_PORT) {
   // Create HTTP server for WebSocket
-  const httpServer = http.createServer((req, res) => {
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      if (await handlePreviewHttp(req, res)) {
+        return;
+      }
+    } catch (error) {
+      console.error('[WS Server] Preview HTTP handler failed:', error);
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Preview endpoint failed');
+      return;
+    }
+
     // Health check endpoint
     if (req.url === '/health') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -1565,6 +1738,7 @@ wss.on('connection', async (ws, request) => {
 // Heartbeat (+ S3 idle reaping)
 const heartbeat = setInterval(() => {
   const now = Date.now();
+  previewAuth.reapExpired();
   wss.clients.forEach((ws) => {
     // S3 — close alive-but-idle connections before the liveness ping. Guards
     // (active worker / never-stamped / disabled) live in shouldReapIdle().
@@ -1598,6 +1772,15 @@ const heartbeat = setInterval(() => {
     }
     ws.isAlive = false;
     ws.ping();
+  });
+  previewRuntime.reapIdlePreviews((state) => {
+    wss.clients.forEach((ws) => {
+      if (ws.workspaceSessionId === state.sessionId) {
+        sendPreviewState(ws, state);
+      }
+    });
+  }).catch((error) => {
+    console.error('[WS Server] Preview idle reap failed:', error);
   });
 }, HEARTBEAT_INTERVAL_MS);
 


### PR DESCRIPTION
Phase C 真预览 v1。

**已完成(评审过 + build/lint 绿 + 5/5 单测):**
- 后端: PreviewRuntime / preview-controller sidecar / 一次性 token→cookie 鉴权 / .oxygenie/app.json manifest / Traefik 子域名 / ws-server(start_preview·stop_preview·preview_state)。
- P1 前端接缝: chat-session-store.previewState + ws-adapter 收发 + useSessionPreview selector + artifact-html「运行预览」CTA→ready 换 live iframe。
- P3: preview 测试 @vitest-environment node(默认配置可跑);secret-from-env 已在 ws-server。

**待办(合并前):**
- P2 端到端: 全栈 docker-compose(preview-controller+Traefik)+ 浏览器交互验收(SPA install→build→serve→可交互+localStorage;鉴权隔离;回收;限流;失败优雅)。owner 选延后。
- 已知回退(仅本地、非紧急): phasec 构建上历史会话聊天记录加载不出(main 正常)。已排除 历史逻辑/后端发送/intlayer;疑为 artifact-html 新增 ~/claude/adapters import 边改变 Vite chunk 切分→客户端初始化问题。**连同 P2 全栈那轮看 browser console 精确 pin+fix(把 artifact-html 与 adapter/store 解耦)。**

详见 docs/project/research/2026-06-phasec-implementation-guide-for-architect.md。