### PR TITLE
fix(security): R4 — gate sandboxed Bash by permission tier (#69)

### DIFF
--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -47,11 +47,15 @@ Historical note below (kept for context).
 > tenants or the public internet.**
 
 - **R4 — Bash tier-gating gap** ([Issue #69](https://github.com/foreveryh/oxygenie/issues/69),
-  labels: `security` `release-blocker`). `wantsBash` is not threaded front-end → ws-server → worker,
-  so the permission tiers (Explore/Auto/Act) don't fully gate Bash; a tier could reach Bash it
-  shouldn't, or the gate is bypassed. Fix = thread `wantsBash` so the worker's `resolveDisallowedTools`
-  gates by tier + wantsBash; verify on real runs across all three tiers. ~2-line core fix, but it's a
-  **security boundary** — do not ship multi-user with it open.
+  labels: `security` `release-blocker`) — **FIXED in PR #108 (pending merge + cross-tier verify)**.
+  Root cause: the 3-tier `wantsBash` (explore=false, auto/act=true) was never threaded to the worker,
+  so the sandboxed Bash tool (`mcp__bash__run`) was registered purely on sandbox readiness — explore
+  could still run bash. Fix: thread `wantsBash` ws-server (`resolveEffectivePermission`) → worker, and
+  gate registration on `sandboxReady && wantsBash` (worker falls back to `sdkMode !== 'plan'` when
+  absent = secure default). Native Bash stays in `disallowedTools` regardless. `ws-server.mjs` +
+  `ws-query-worker.mjs`, node --check + lint green. **Remaining = cross-tier live verify** (needs a
+  ready sandbox `EXEC_RUNTIME=docker` to observe: explore→no bash, act→bash; the `wantsBash` threading
+  is visible in the worker log on any run). Then merge #108 + close it before multi-user.
 
 ### Historical snapshot (2026-05-30, first browser-verified run)
 

--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -199,6 +199,7 @@ process.stdin.on('end', async () => {
       permissionMode: requestedPermissionMode,
       disallowedTools: requestedDisallowedTools,
       allowBash: requestedAllowBash = false,
+      wantsBash: requestedWantsBash,
       userId,
     } = request;
     const permissionMode = resolvePermissionMode(requestedPermissionMode, userId);
@@ -230,6 +231,12 @@ process.stdin.on('end', async () => {
       : permissionMode === 'plan'
         ? 'plan'
         : 'acceptEdits';
+    // R4 (#69): the tier's bash preference. Explicit from ws-server
+    // (resolveEffectivePermission); when absent (legacy/direct caller), fall back to
+    // "no bash in plan/explore mode" so the secure default matches the tier model.
+    const wantsBash = typeof requestedWantsBash === 'boolean'
+      ? requestedWantsBash
+      : sdkPermissionMode !== 'plan';
     const { canUseTool, debugInfo } = createPathSecurity({
       workspace: config.cwd,
       userId,
@@ -244,6 +251,7 @@ process.stdin.on('end', async () => {
     console.error(`[Worker]   Model: ${config.model || 'default'}`);
     console.error(`[Worker]   Permission Mode: ${permissionMode}`);
     console.error(`[Worker]   Disallowed Tools: ${disallowedTools.join(', ') || '(none)'}`);
+    console.error(`[Worker]   Sandboxed Bash (tier wantsBash): ${wantsBash}`);
     if (process.env.CLAUDE_SECURITY_DEBUG === 'true') {
       console.error(`[Worker]   Path Security: ${JSON.stringify(debugInfo)}`);
     }
@@ -382,9 +390,12 @@ process.stdin.on('end', async () => {
     const { state: sandboxState } = sandboxStatus();
     const runtimeName = getExecutionRuntime().name;
     const sandboxReady = sandboxState === 'active' || runtimeName === 'docker';
+    // R4 (#69): also gate by the tier's bash preference. explore (wantsBash=false)
+    // gets NO sandboxed Bash even when a sandbox is ready; auto/act do.
+    const bashAllowed = sandboxReady && wantsBash;
 
     const bashSdkServers = {};
-    if (sandboxReady) {
+    if (bashAllowed) {
       const bashRunTool = tool(
         'run',
         'Execute a shell (bash) command inside the session workspace sandbox. ' +
@@ -443,7 +454,9 @@ process.stdin.on('end', async () => {
         tools: [bashRunTool],
       });
       bashSdkServers['bash'] = bashMcpServer;
-      console.error('[Worker] Sandbox bash tool: REGISTERED (sandbox active)');
+      console.error('[Worker] Sandbox bash tool: REGISTERED (sandbox ready + tier wantsBash)');
+    } else if (sandboxReady && !wantsBash) {
+      console.error('[Worker] Sandbox bash tool: NOT registered (tier wantsBash=false — e.g. explore)');
     } else {
       console.error(`[Worker] Sandbox bash tool: NOT registered (sandbox state=${sandboxState ?? 'null'} — srt inactive or unavailable)`);
     }

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -939,8 +939,10 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     // for legacy clients that send no tier). Single source: src/lib/permission-tier.js.
     const effective = resolveEffectivePermission({ requestedTier: permissionTier });
     permissionMode = effective.permissionMode;
-    // wantsBash: tier's preference; actual bash availability gated by sandbox in PR-C.
-    // For now keeps existing allowBash logic (native Bash still in disallowedTools).
+    // R4 (#69): thread the tier's bash preference to the worker so the SANDBOXED
+    // Bash tool (mcp__bash__run) is gated by tier — explore (read-only) gets no bash
+    // even when a sandbox is ready. Native Bash stays in disallowedTools regardless.
+    const wantsBash = effective.wantsBash;
     if (permissionTier) {
       console.log(`[WS Server] Permission tier: ${effective.tier} → mode=${permissionMode}`);
     }
@@ -1004,6 +1006,7 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
       permissionMode,
       disallowedTools,
       allowBash,  // Pass allowBash flag so worker can trust org-based bypass mode
+      wantsBash,  // R4 (#69): tier's bash preference; gates the sandboxed Bash tool
       userId: ws.userId,
     });
     worker.stdin.write(request);


### PR DESCRIPTION
Closes #69 (release blocker). Threads the tier's `wantsBash` (explore=false, auto/act=true) from ws-server → worker and gates the sandboxed `mcp__bash__run` tool on `sandboxReady && wantsBash`. explore now truly read-only (no bash even with a ready sandbox); auto/act unchanged; native Bash stays disallowed. Pure backend .mjs (no front-end / rebuild). node --check + lint green. Cross-tier live verify pending (explore: agent can't run bash; act: can).