### PR TITLE
fix(agent): register sandboxed bash tool when srt is available

### DIFF
--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -16,7 +16,7 @@ import { resolveMcpServerConfigs } from './src/claude/mcp/manager.js';
 import { runPython } from './src/claude/python/runner.js';
 import { generateImage } from './src/claude/glm-image/runner.js';
 import { runBash } from './src/claude/bash/runner.js';
-import { sandboxStatus } from './src/claude/execution/sandbox.js';
+import { ensureSandbox, sandboxStatus } from './src/claude/execution/sandbox.js';
 import { getExecutionRuntime } from './src/claude/execution/index.js';
 
 // Read configuration from environment
@@ -486,6 +486,11 @@ async function startRun(request) {
     //      the container IS the sandbox (--network none, --cap-drop ALL, non-root, etc.)
     // macOS local dev: set EXEC_RUNTIME=docker to enable bash (srt is off on macOS by design).
     // If neither is available → tool NOT registered; Claude cannot call bash at all.
+    // Initialize the OS sandbox (srt) FIRST — otherwise sandboxStatus() returns the
+    // uninitialized state (null) and bash is never registered even when srt IS available
+    // (Linux + seccomp=unconfined). ensureSandbox is idempotent + cached, so this is the
+    // single eager init; the per-exec runners reuse it. (Fixes: bash silently disabled.)
+    await ensureSandbox(config.cwd);
     const { state: sandboxState } = sandboxStatus();
     const runtimeName = getExecutionRuntime().name;
     const sandboxReady = sandboxState === 'active' || runtimeName === 'docker';


### PR DESCRIPTION
The bash-tool registration read `sandboxStatus().state` **before** `ensureSandbox()` ran → state was always `null` → bash was never registered, even on Linux containers where srt (bubblewrap) is available. The agent silently had no shell.

**Fix:** eagerly `await ensureSandbox(config.cwd)` right before the registration check (it's idempotent + cached, so this just moves the one-time init earlier). With srt initialized, `sandboxState === 'active'` → bash registers.

**Verified** in the live container: bwrap 0.8.0; `ensureSandbox('/tmp')` → `true`, status `{enabled:true, state:"active", srtAvailable:true}`. Sandbox is deny-network by design (bash/Python for non-network tasks; installs stay with the preview engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)