### PR TITLE
feat(deploy): Path A — plain Docker Compose VPS stack (bundled Traefik + TLS + preview)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,9 @@ loadtest-results/
 # Both are generated from your tunnel token — commit only config.yml.example.
 infra/tunnel/credentials.json
 infra/tunnel/config.yml
+
+# Path A (prod) Traefik dynamic — Cloudflare Origin CA cert/key (the key is secret) + the
+# activated config. Commit only origin-ca.yml.example + README.
+infra/prod/dynamic/origin.crt
+infra/prod/dynamic/origin.key
+infra/prod/dynamic/origin-ca.yml

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,403 @@
+# OxyGenie — Path A: plain Docker Compose on a single Linux VPS (public IP).
+#
+# Full guide: docs/deployment/docker-compose.md
+#
+# Self-contained production stack: datastores + app + worker + preview-controller + a
+# BUNDLED Traefik that terminates TLS. NO cloudflared, NO dockerproxy, NO Swarm — on a
+# normal Linux Docker host Traefik talks to the socket directly (the macOS-only API
+# version-pin problem doesn't exist here). The self-managed host gives the elevated
+# privileges preview + sandbox need (seccomp/apparmor=unconfined, NET_ADMIN).
+#
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# ── TLS (two supported options) ───────────────────────────────────────────────────────
+# DEFAULT = Let's Encrypt via DNS-01 (Cloudflare), which issues ONE wildcard cert covering
+#   <domain> + *.<domain> (previews need the wildcard; HTTP-01 can't do wildcards). Set
+#   ACME_EMAIL + CF_DNS_API_TOKEN (a Cloudflare token with Zone:DNS:Edit on the zone).
+# ALTERNATIVE = Cloudflare orange-cloud + Origin CA (proven on the Dokploy path). See the
+#   "ALTERNATIVE: Cloudflare Origin CA" comments in the `traefik` service + the guide; in
+#   short: drop the cert into infra/prod/dynamic/, and the routers serve it as the default
+#   cert (remove `tls.certresolver=le` from the app labels).
+# ───────────────────────────────────────────────────────────────────────────────────────
+#
+# Image: defaults to GHCR (build off-server → pull). To build on the VPS instead, set
+# APP_IMAGE=oxygenie APP_TAG=local APP_PULL_POLICY=never and `docker build -t oxygenie:local .`.
+x-app-image: &app_image '${APP_IMAGE:-ghcr.io/foreveryh/oxygenie/app}:${APP_TAG:-latest}'
+
+services:
+  db:
+    image: pgvector/pgvector:0.8.0-pg17
+    container_name: ${APP_NAME:-OxyGenie}-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
+      POSTGRES_DB: ${POSTGRES_DB:?}
+    volumes:
+      - ex0-data:/var/lib/postgresql/data
+    expose:
+      - '5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - private
+
+  minio:
+    image: quay.io/minio/minio:latest
+    container_name: ${APP_NAME:-OxyGenie}-minio
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?}
+    command: server /data --console-address ":9001"
+    volumes:
+      - ex0-minio-data:/data
+    expose:
+      - '9000'
+      - '9001'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - private
+
+  provision-minio:
+    image: minio/mc:latest
+    container_name: ${APP_NAME:-OxyGenie}-provision-minio
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?}
+      MINIO_BUCKET: ${MINIO_BUCKET:?}
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 \"$MINIO_ROOT_USER\" \"$MINIO_ROOT_PASSWORD\" &&
+      mc mb --ignore-existing local/\"$MINIO_BUCKET\" &&
+      mc anonymous set none local/\"$MINIO_BUCKET\" || true
+      "
+    restart: 'no'
+    networks:
+      - private
+
+  redis:
+    image: redis:7-alpine
+    container_name: ${APP_NAME:-OxyGenie}-redis
+    restart: unless-stopped
+    command: ['redis-server', '--save', '60', '1', '--loglevel', 'warning']
+    volumes:
+      - ex0-redis-data:/data
+    expose:
+      - '6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - private
+
+  meilisearch:
+    image: getmeili/meilisearch:latest
+    container_name: ${APP_NAME:-OxyGenie}-meili
+    restart: unless-stopped
+    environment:
+      MEILI_ENV: production
+      MEILI_MASTER_KEY: ${MEILI_MASTER_KEY:?changeme}
+    volumes:
+      - ex0-meili-data:/meili_data
+    expose:
+      - '7700'
+    healthcheck:
+      test: ['CMD', 'curl', '-sSf', 'http://localhost:7700/health']
+      interval: 5s
+      timeout: 3s
+      retries: 40
+    networks:
+      - private
+
+  migrate:
+    image: *app_image
+    pull_policy: ${APP_PULL_POLICY:-always}
+    container_name: ${APP_NAME:-OxyGenie}-migrate
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:?}
+      NODE_ENV: production
+    entrypoint: >
+      sh -c "
+      n=0; until pnpm run db:migrate; do n=$$((n+1)); [ $$n -ge 20 ] && { echo '[migrate] FAILED after 20 attempts'; exit 1; }; echo \"[migrate] attempt $$n failed (db not ready), retrying in 3s...\"; sleep 3; done &&
+      ( pnpm run db:seed || echo '[seed] WARNING: curated skills seed failed (non-fatal)' )
+      "
+    restart: 'no'
+    networks:
+      - private
+
+  worker:
+    image: *app_image
+    pull_policy: ${APP_PULL_POLICY:-always}
+    container_name: ${APP_NAME:-OxyGenie}-worker
+    depends_on:
+      db: { condition: service_healthy }
+      redis: { condition: service_healthy }
+      meilisearch: { condition: service_healthy }
+      migrate: { condition: service_completed_successfully }
+      provision-minio: { condition: service_completed_successfully }
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:?}
+      S3_ENDPOINT: http://minio:9000
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?}
+      S3_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?}
+      S3_BUCKET: ${MINIO_BUCKET:?}
+      REDIS_URL: redis://redis:6379
+      BULLMQ_PREFIX: ${BULLMQ_PREFIX:-oxygenie}
+      DAILY_CREDIT_REFILL_CRON: ${DAILY_CREDIT_REFILL_CRON:-0 3 * * *}
+      JOB_DAILY_CREDIT_REFILL_URL: ${JOB_DAILY_CREDIT_REFILL_URL:-http://app:5000/api/jobs/daily-credit-refill}
+      JOBS_SECRET: ${JOBS_SECRET:-}
+      MEILI_HOST: http://meilisearch:7700
+      MEILI_API_KEY: ${MEILI_API_KEY:-${MEILI_MASTER_KEY}}
+      SEARCH_REINDEX_ON_BOOT: ${SEARCH_REINDEX_ON_BOOT:-false}
+    command: ['npx', 'tsx', 'src/worker/index.ts']
+    restart: unless-stopped
+    networks:
+      - private
+
+  app:
+    image: *app_image
+    pull_policy: ${APP_PULL_POLICY:-always}
+    container_name: ${APP_NAME:-OxyGenie}-app
+    # Preview + sandbox need unprivileged user namespaces; lift seccomp + AppArmor and add
+    # NET_ADMIN (a self-managed VPS gives you this; a hardened managed PaaS may not).
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
+    cap_add:
+      - NET_ADMIN
+    depends_on:
+      db: { condition: service_healthy }
+      minio: { condition: service_healthy }
+      redis: { condition: service_healthy }
+      meilisearch: { condition: service_healthy }
+      migrate: { condition: service_completed_successfully }
+      provision-minio: { condition: service_completed_successfully }
+    environment:
+      NODE_ENV: production
+      PORT: 5000
+      WS_PORT: 3001
+      AUTO_MIGRATE: 'false'
+      DATABASE_URL: postgresql://${POSTGRES_USER:?}:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:?}
+      S3_ENDPOINT: http://minio:9000
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER:?}
+      S3_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD:?}
+      S3_BUCKET: ${MINIO_BUCKET:?}
+      EMAIL_PROVIDER: ${EMAIL_PROVIDER:-smtp}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@${APP_HOSTNAME}}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_SECURE: ${SMTP_SECURE:-true}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      REDIS_URL: redis://redis:6379
+      MEILI_HOST: http://meilisearch:7700
+      MEILI_API_KEY: ${MEILI_API_KEY:-${MEILI_MASTER_KEY}}
+      BETTER_AUTH_URL: https://${APP_HOSTNAME}
+      BETTER_AUTH_INTERNAL_URL: http://localhost:5000
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      VITE_GITHUB_CLIENT_ID: ${VITE_GITHUB_CLIENT_ID:-}
+      VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
+      # Optional: Zhipu key — only for the GLM image tool + Zhipu MCP servers (unset if unused)
+      ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
+      # Claude Agent SDK — ARK uses Bearer (ANTHROPIC_AUTH_TOKEN); do NOT set ANTHROPIC_API_KEY.
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:?}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
+      ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${ANTHROPIC_DEFAULT_SONNET_MODEL:-}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${ANTHROPIC_DEFAULT_OPUS_MODEL:-}
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: ${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${CLAUDE_CODE_SUBAGENT_MODEL:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      CLAUDE_SESSIONS_ROOT: /data/users
+      APP_URL: http://localhost:5000
+      ENABLE_EXEC_SANDBOX: '1'
+      CLAUDE_MCP_STORE_DIR: ${CLAUDE_MCP_STORE_DIR:-src/mcp-store}
+      MCP_STORE_DIR: ${MCP_STORE_DIR:-src/mcp-store}
+      SKILLS_STORE_DIR: /data/skills-store
+      PYTHON_RUNNER_TIMEOUT_MS: ${PYTHON_RUNNER_TIMEOUT_MS:-10000}
+      PYTHON_RUNNER_MAX_OUTPUT_BYTES: ${PYTHON_RUNNER_MAX_OUTPUT_BYTES:-512000}
+      PYTHON_RUNNER_MAX_CODE_BYTES: ${PYTHON_RUNNER_MAX_CODE_BYTES:-200000}
+      ENABLE_STRUCTURED_OUTPUTS: ${ENABLE_STRUCTURED_OUTPUTS:-false}
+      PREVIEW_CONTROLLER_URL: ${PREVIEW_CONTROLLER_URL:-http://preview-controller:5055}
+      MAX_ACTIVE_PREVIEWS: ${MAX_ACTIVE_PREVIEWS:-4}
+      PREVIEW_IDLE_TIMEOUT_MS: ${PREVIEW_IDLE_TIMEOUT_MS:-300000}
+      PREVIEW_PROTOCOL: ${PREVIEW_PROTOCOL:-https}
+      PREVIEW_HOST_TEMPLATE: ${PREVIEW_HOST_TEMPLATE:-{previewId}.${APP_HOSTNAME}}
+      PREVIEW_COOKIE_SECURE: ${PREVIEW_COOKIE_SECURE:-1}
+      PREVIEW_BOOTSTRAP_TTL_MS: ${PREVIEW_BOOTSTRAP_TTL_MS:-90000}
+      PREVIEW_COOKIE_TTL_MS: ${PREVIEW_COOKIE_TTL_MS:-900000}
+      VITE_WS_URL: ${VITE_WS_URL:-wss://${APP_HOSTNAME}/ws/agent}
+      POLAR_SERVER: ${POLAR_SERVER:-production}
+      POLAR_ACCESS_TOKEN: ${POLAR_ACCESS_TOKEN:-}
+      POLAR_WEBHOOK_SECRET: ${POLAR_WEBHOOK_SECRET:-}
+      POLAR_ORGANIZATION_ID: ${POLAR_ORGANIZATION_ID:-}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+    volumes:
+      - claude-sessions:/data/users
+      - skills-store:/data/skills-store
+    expose:
+      - '5000'
+      - '3001'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=oxygenie-net"
+      # Main app (everything except /ws) — websecure + TLS, and this router REQUESTS the
+      # wildcard cert (<domain> + *.<domain>) via the `le` DNS-01 resolver so previews are covered.
+      - "traefik.http.routers.main.rule=Host(`${APP_HOSTNAME}`) && !PathPrefix(`/ws`)"
+      - "traefik.http.routers.main.entrypoints=websecure"
+      - "traefik.http.routers.main.tls=true"
+      - "traefik.http.routers.main.tls.certresolver=le"
+      - "traefik.http.routers.main.tls.domains[0].main=${APP_HOSTNAME}"
+      - "traefik.http.routers.main.tls.domains[0].sans=*.${APP_HOSTNAME}"
+      - "traefik.http.routers.main.service=main-service"
+      - "traefik.http.routers.main.priority=50"
+      - "traefik.http.services.main-service.loadbalancer.server.port=5000"
+      # WebSocket (/ws)
+      - "traefik.http.routers.ws.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/ws`)"
+      - "traefik.http.routers.ws.entrypoints=websecure"
+      - "traefik.http.routers.ws.tls=true"
+      - "traefik.http.routers.ws.service=ws-service"
+      - "traefik.http.routers.ws.priority=100"
+      - "traefik.http.services.ws-service.loadbalancer.server.port=3001"
+      # Preview forward-auth (/__oxy on any preview subdomain) → ws-server. Traefik v3
+      # Go-regexp (the v2 {name:regexp} form silently never matches → preview 404).
+      # `\\.` → `\.` (YAML); `$$` → `$` (compose) for the regex end-anchor. tls=true serves
+      # the wildcard cert issued by the main router (no per-subdomain cert request).
+      - "traefik.http.routers.preview-auth.rule=HostRegexp(`^[a-z0-9-]+\\.${APP_HOSTNAME}$$`) && PathPrefix(`/__oxy`)"
+      - "traefik.http.routers.preview-auth.entrypoints=websecure"
+      - "traefik.http.routers.preview-auth.tls=true"
+      - "traefik.http.routers.preview-auth.service=ws-service"
+      - "traefik.http.routers.preview-auth.priority=200"
+    restart: unless-stopped
+    networks:
+      - private
+      - proxy
+
+  # Phase C preview controller — the ONLY service that mounts the Docker socket; the app
+  # calls it over the private network to create/remove preview containers with Traefik labels.
+  preview-controller:
+    image: *app_image
+    pull_policy: ${APP_PULL_POLICY:-always}
+    container_name: ${APP_NAME_SANITIZED:-oxygenie}-preview-controller
+    depends_on:
+      app:
+        condition: service_started
+    user: root
+    environment:
+      NODE_ENV: production
+      PREVIEW_CONTROLLER_PORT: ${PREVIEW_CONTROLLER_PORT:-5055}
+      PREVIEW_CONTROLLER_CONTAINER: ${APP_NAME_SANITIZED:-oxygenie}-preview-controller
+      PREVIEW_IMAGE: ${PREVIEW_IMAGE:-node:24-bookworm-slim}
+      PREVIEW_MEMORY: ${PREVIEW_MEMORY:-768m}
+      PREVIEW_CPUS: ${PREVIEW_CPUS:-1}
+      PREVIEW_PIDS: ${PREVIEW_PIDS:-256}
+      PREVIEW_CONTAINER_USER: ${PREVIEW_CONTAINER_USER:-1001:1001}
+      PREVIEW_INTERNAL_PORT: ${PREVIEW_INTERNAL_PORT:-4173}
+      PREVIEW_INSTALL_TIMEOUT_MS: ${PREVIEW_INSTALL_TIMEOUT_MS:-300000}
+      PREVIEW_BUILD_TIMEOUT_MS: ${PREVIEW_BUILD_TIMEOUT_MS:-300000}
+      PREVIEW_DOCKER_NETWORK: ${PREVIEW_DOCKER_NETWORK:-oxygenie-net}
+      PREVIEW_TRAEFIK_ENABLED: ${PREVIEW_TRAEFIK_ENABLED:-1}
+      PREVIEW_TRAEFIK_NETWORK: ${PREVIEW_TRAEFIK_NETWORK:-oxygenie-net}
+      # Previews are served on websecure with TLS, using the WILDCARD cert the main router
+      # already obtained (so leave CERTRESOLVER empty — no per-preview cert requests).
+      PREVIEW_TRAEFIK_ENTRYPOINTS: ${PREVIEW_TRAEFIK_ENTRYPOINTS:-websecure}
+      PREVIEW_TRAEFIK_TLS: ${PREVIEW_TRAEFIK_TLS:-1}
+      PREVIEW_TRAEFIK_CERTRESOLVER: ${PREVIEW_TRAEFIK_CERTRESOLVER:-}
+      PREVIEW_FORWARD_AUTH_URL: ${PREVIEW_FORWARD_AUTH_URL:-http://app:3001/__oxy/preview/authorize}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - claude-sessions:/data/users
+    command: ['node', 'src/preview/controller.mjs']
+    restart: unless-stopped
+    networks:
+      - private
+      - proxy
+
+  # Reverse proxy + TLS terminator. Reads container labels via the Docker provider, talking
+  # to the socket DIRECTLY (native on Linux — no version-rewrite shim needed).
+  traefik:
+    image: traefik:v3.5
+    container_name: ${APP_NAME_SANITIZED:-oxygenie}-traefik
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=oxygenie-net"
+      - "--entrypoints.web.address=:80"
+      # Redirect all plain HTTP → HTTPS
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      # ── DEFAULT TLS: Let's Encrypt via DNS-01 (Cloudflare) → wildcard cert ──
+      - "--certificatesresolvers.le.acme.email=${ACME_EMAIL:?set ACME_EMAIL (Let's Encrypt) — or switch to Origin CA}"
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.le.acme.dnschallenge=true"
+      - "--certificatesresolvers.le.acme.dnschallenge.provider=cloudflare"
+      # File provider for the ALTERNATIVE (Cloudflare Origin CA): drop a *.yml + cert into
+      # infra/prod/dynamic/ and the routers serve it as the default cert (see the guide).
+      - "--providers.file.directory=/etc/traefik/dynamic"
+      - "--providers.file.watch=true"
+    environment:
+      # Cloudflare DNS-01 token (Zone:DNS:Edit on your zone). Only used by the `le` resolver.
+      CF_DNS_API_TOKEN: ${CF_DNS_API_TOKEN:-}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - le-data:/letsencrypt
+      - ./infra/prod/dynamic:/etc/traefik/dynamic:ro
+    restart: unless-stopped
+    networks:
+      - proxy
+
+networks:
+  private:
+    driver: bridge
+    name: ${APP_NAME_SANITIZED:-oxygenie}-private
+  # Proxy network: Traefik + app + preview-controller + the dynamic preview containers.
+  # Its NAME must match the Traefik labels + PREVIEW_*_NETWORK (oxygenie-net).
+  proxy:
+    driver: bridge
+    name: oxygenie-net
+
+volumes:
+  ex0-data:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-data
+  ex0-minio-data:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-minio-data
+  ex0-redis-data:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-redis-data
+  ex0-meili-data:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-meili-data
+  claude-sessions:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-claude-sessions
+  skills-store:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-skills-store
+  le-data:
+    name: ${APP_NAME_SANITIZED:-oxygenie}-letsencrypt

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -1,131 +1,138 @@
-# Docker Compose Deployment
+# Path A — Docker Compose on a single Linux VPS
 
-Deploy OxyGenie on a single server using Docker Compose. Best for self-hosted, VPS, or local testing with production-like setup.
+Self-host the **full** OxyGenie stack — chat, the Phase C **live preview**, and the **code
+sandbox** — on one Linux server with a public IP, using a **bundled Traefik** that terminates
+TLS. This is the recommended baseline for anyone running their own box. **No Cloudflare Tunnel,
+no Dokploy, no Swarm.** (For a workstation behind NAT, use [Path C / tunnel](tunnel.md); for a
+managed UI, [Path B / Dokploy](dokploy.md).)
 
-## Prerequisites
+**Compose file:** [`docker-compose.prod.yml`](../../docker-compose.prod.yml)
 
-- Docker & Docker Compose
-- (Optional) Domain name and reverse proxy for HTTPS
-- (Optional) Caddy or nginx for SSL
+```
+Internet ──TLS──▶ Traefik (:443, bundled)  ──reads container labels──▶
+   ├─ your-domain        → app (5000) ;  /ws → ws-server (3001)
+   └─ <id>.your-domain   → preview sandbox container (4173), forward-auth gated
+```
+
+> On a normal Linux Docker host Traefik talks to the docker socket **directly** — the macOS
+> `dockerproxy` shim from the tunnel path is **not needed here**.
 
 ---
 
-## Step 1: Clone and Configure
+## Critical invariants (get any wrong → it won't serve)
 
-```bash
-git clone https://github.com/foreveryh/oxygenie.git
-cd OxyGenie
-pnpm install
-```
-
-## Step 2: Environment Variables
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` and set at minimum:
-
-```bash
-# Database (Docker builds DATABASE_URL from these; do NOT set DATABASE_URL)
-POSTGRES_USER="postgres"
-POSTGRES_PASSWORD="your-secure-password"
-POSTGRES_DB="oxygenie"
-
-# MinIO
-MINIO_ROOT_USER="minioadmin"
-MINIO_ROOT_PASSWORD="your-minio-password"
-MINIO_BUCKET="oxygenie-files"
-
-# Meilisearch
-MEILI_MASTER_KEY="your-strong-master-key"
-
-# Auth (use http://localhost:5050 when accessing via Docker ports)
-BETTER_AUTH_SECRET="your-secret-at-least-32-chars"
-BETTER_AUTH_URL="http://localhost:5050"
-
-# AI
-ANTHROPIC_API_KEY="sk-ant-..."
-ZHIPU_API_KEY="your-zhipu-key"
-```
-
-See [.env.example](../../.env.example) for all options. [.env.docker](../../.env.docker) provides Docker-specific defaults (container hostnames, `VITE_WS_URL`).
+1. **Secrets live OUTSIDE the repo** in `~/oxygenie-deploy/secrets.env` (chmod 600). Never edit
+   `.env` / commit secrets.
+2. **`APP_NAME_SANITIZED` must be unique** on the host — volume names (`${APP_NAME_SANITIZED}-data`
+   etc.) are global; a collision reuses another stack's data (→ Postgres `28P01`).
+3. **`DATABASE_URL` is built from `POSTGRES_*` inside the compose** — don't pass a separate
+   `DATABASE_URL` (it would drift from `POSTGRES_PASSWORD`).
+4. **ARK auth = `ANTHROPIC_AUTH_TOKEN` (Bearer)** — do **not** set `ANTHROPIC_API_KEY` (it flips
+   the SDK to `x-api-key` and ARK rejects it).
+5. **Previews need a wildcard**: DNS `*.<domain>` → the VPS, and a **wildcard TLS cert**
+   (`*.<domain>`). The cert is issued once (see TLS below); preview subdomains reuse it — Traefik
+   does **not** request a cert per preview.
+6. **Image is built off-server → pulled** by default (the SSR build peaks >8 GB; don't build on a
+   small VPS). Set `APP_PULL_POLICY=never` + build locally only if the VPS has ≥16 GB RAM.
 
 ---
 
-## Step 3: Start Services
+## TLS — two supported options
 
-```bash
-pnpm docker:up
-```
+| Option | When | What you set |
+|---|---|---|
+| **A. Let's Encrypt DNS-01 (default)** | Pure VPS; you want your own free, auto-renewing certs | `ACME_EMAIL` + `CF_DNS_API_TOKEN` (a Cloudflare token with **Zone:DNS:Edit**). Traefik issues ONE cert for `<domain>` + `*.<domain>` via DNS-01 (HTTP-01 can't do wildcards). |
+| **B. Cloudflare Origin CA** | Domain already on Cloudflare, orange-cloud | Origin CA cert in `infra/prod/dynamic/` (see [its README](../../infra/prod/dynamic/README.md)); drop the `tls.certresolver=le` lines from the app `main` router. Proven on the Dokploy path. |
 
-Or the full command:
-```bash
-docker compose --env-file .env.docker --env-file .env --profile selfhost up -d --build
-```
-
-**Why two env files?** `.env.docker` provides container hostnames (e.g. `redis://redis`, `meilisearch:7700`); `.env` provides your secrets and overrides. Both are needed for correct container-to-container communication.
-
-This starts:
-
-- PostgreSQL (port 5432)
-- MinIO (9000, 9001)
-- Redis (6379)
-- Meilisearch (7700)
-- Runs migrations
-- Starts app and worker
+The compose **defaults to option A**. Both are wired; see the comments in the `traefik` service.
 
 ---
 
-## Step 4: Access
+## Steps
 
-| Service | URL | Port |
-|---------|-----|------|
-| **App** | http://localhost:5050 | 5050 |
-| **Claude Chat** | http://localhost:5050/agents/claude-chat | 5050 |
-| **WebSocket** | ws://localhost:3051/ws/agent | 3051 |
+### 1. Server + DNS
+- A Linux VPS with **Docker + the Compose plugin**, ports **80 + 443** open.
+- DNS for your domain (examples use `oxygenie.cc`):
+  - `A  @  → <vps-ip>`
+  - `A  *  → <vps-ip>`  (wildcard, for previews)
+  - For TLS option A you also need the domain in **Cloudflare** (for the DNS-01 token); for
+    option B, set both records **proxied** (orange).
 
----
-
-## Production: Reverse Proxy + HTTPS
-
-For production with a domain:
-
-1. **Point DNS** to your server IP
-2. **Use a reverse proxy** (Caddy, nginx, Traefik)
-3. **Set** in `.env`:
-   ```bash
-   BETTER_AUTH_URL="https://your-domain.com"
-   VITE_WS_URL="wss://your-domain.com/ws/agent"
-   ```
-4. **Rebuild** so `VITE_WS_URL` is baked into the frontend:
-   ```bash
-   docker compose --env-file .env.docker --env-file .env --profile selfhost up -d --build
-   ```
-
-Example Caddy config (see [infra/deploy/Caddyfile](../../infra/deploy/Caddyfile)):
-
+### 2. Get the code + secrets
+```bash
+git clone https://github.com/foreveryh/oxygenie.git && cd oxygenie
+mkdir -p ~/oxygenie-deploy && chmod 700 ~/oxygenie-deploy
+cat > ~/oxygenie-deploy/secrets.env <<'EOF'
+APP_HOSTNAME=oxygenie.cc
+APP_NAME=oxygenie
+APP_NAME_SANITIZED=oxygenie            # unique per host (volume names)
+POSTGRES_USER=oxygenie
+POSTGRES_PASSWORD=__FILL__
+POSTGRES_DB=oxygenie
+MINIO_ROOT_USER=oxygenie
+MINIO_ROOT_PASSWORD=__FILL__
+MINIO_BUCKET=oxygenie
+MEILI_MASTER_KEY=__FILL__
+BETTER_AUTH_SECRET=__FILL__
+# TLS option A (Let's Encrypt DNS-01):
+ACME_EMAIL=you@example.com
+CF_DNS_API_TOKEN=__cloudflare_token_Zone_DNS_Edit__
+# LLM gateway (ARK / Volcengine) — Bearer; do NOT set ANTHROPIC_API_KEY
+ANTHROPIC_AUTH_TOKEN=ark-your-key
+ANTHROPIC_BASE_URL=https://ark.cn-beijing.volces.com/api/coding
+ANTHROPIC_MODEL=glm-5.1
+ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5.1
+ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.1
+ANTHROPIC_DEFAULT_HAIKU_MODEL=doubao-seed-2.0-lite
+CLAUDE_CODE_SUBAGENT_MODEL=glm-5.1
+EOF
+chmod 600 ~/oxygenie-deploy/secrets.env
+for k in POSTGRES_PASSWORD MINIO_ROOT_PASSWORD MEILI_MASTER_KEY BETTER_AUTH_SECRET; do
+  sed -i "s|^$k=__FILL__|$k=$(openssl rand -hex 32)|" ~/oxygenie-deploy/secrets.env
+done
+# then edit secrets.env: real ANTHROPIC_AUTH_TOKEN, ACME_EMAIL, CF_DNS_API_TOKEN, APP_HOSTNAME
 ```
-your-domain.com {
-    reverse_proxy localhost:5050
-}
 
-# WebSocket
-your-domain.com {
-    handle_path /ws/* {
-        reverse_proxy localhost:3051
-    }
-}
+### 3. Image — pull (default) or build on the VPS
+Default pulls `ghcr.io/foreveryh/oxygenie/app:latest`. To build on the VPS instead (needs ≥16 GB
+RAM): `docker build -t oxygenie:local .` then set `APP_IMAGE=oxygenie APP_TAG=local APP_PULL_POLICY=never`.
+
+### 4. Bring it up
+```bash
+set -a; . ~/oxygenie-deploy/secrets.env; set +a
+docker compose -f docker-compose.prod.yml up -d
 ```
+Traefik obtains the wildcard cert via DNS-01 on first boot — watch:
+`docker logs ${APP_NAME_SANITIZED}-traefik 2>&1 | grep -i acme`.
+
+### 5. Verify
+```bash
+set -a; . ~/oxygenie-deploy/secrets.env; set +a
+docker compose -f docker-compose.prod.yml ps                            # all healthy
+curl -sS -o /dev/null -w '%{http_code}\n' https://$APP_HOSTNAME/health   # → 200
+docker exec ${APP_NAME}-app sh -c 'unshare -Urn echo userns-ok'         # → userns-ok (sandbox)
+```
+Then open `https://<domain>`, sign in, ask for a small web app → **运行预览 / Run preview** →
+it loads at `https://<id>.<domain>`. (Optional speed-up: `bash infra/preview/warm-cache.sh`.)
 
 ---
 
 ## Troubleshooting
 
-| Issue | Solution |
-|-------|----------|
-| `database "oxygenie" does not exist` | Run `docker compose down -v` then `up -d --build` (⚠️ deletes data) |
-| Keep existing DB (ex0/constructa) | Set only `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` in `.env` to match; do NOT set `DATABASE_URL` |
-| WebSocket 426 / fails | Ensure reverse proxy supports WebSocket upgrade; check VITE_WS_URL matches your domain |
+| Symptom | Fix |
+|---|---|
+| No cert / `https` fails | `docker logs <stack>-traefik \| grep -i acme`. DNS-01 needs `CF_DNS_API_TOKEN` (Zone:DNS:Edit) + the domain on Cloudflare. Wildcard requires DNS-01 (not HTTP-01). |
+| Preview subdomain → cert warning | The wildcard covers `*.<domain>` (one level only). Previews are single-level `<id>.<domain>` by design. |
+| Preview opens but **404** | Needs the Traefik **v3 `HostRegexp`** fix — this compose has it. |
+| migrate `28P01` | `APP_NAME_SANITIZED` collided with an old stack's volume → set a unique one. |
+| Build OOM on the VPS | Don't build on a small box — pull from GHCR (default). Building needs ≥16 GB. |
+| Chat auth/model error | `ANTHROPIC_AUTH_TOKEN` set, `ANTHROPIC_API_KEY` **unset**. |
 
-See [Troubleshooting](../troubleshooting.md) for more.
+---
+
+## Notes
+- This path grants the app the privileges preview + sandbox need (`seccomp/apparmor=unconfined`,
+  `NET_ADMIN`) — fine on a VPS you control.
+- Backups: the stateful volumes are `${APP_NAME_SANITIZED}-{data,claude-sessions,minio-data,meili-data}`
+  (same `docker run --rm -v … tar` recipe as [mac-mini.md](mac-mini.md#operations)).
+- All three paths run the **same images + app**; only the edge (proxy / TLS / DNS) differs.

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -18,7 +18,7 @@
 
 | Path | Who it's for | What you manage | Compose file |
 |---|---|---|---|
-| **A. Docker Compose (self-managed)** | **Anyone self-hosting on a VPS / their own box. Recommended baseline.** | The host + a reverse proxy (Traefik, bundled) | `docker-compose.yml` |
+| **A. Docker Compose (self-managed)** | **Anyone self-hosting on a VPS / their own box. Recommended baseline.** | The host + a reverse proxy (Traefik, bundled) | `docker-compose.prod.yml` |
 | **B. Dokploy (managed PaaS)** | Teams who want a UI + managed Traefik/TLS/domains (this is how the maintainers run it) | A Dokploy install | `docker-compose.dokploy.yml` |
 | **C. Cloudflare Tunnel (workstation / behind NAT)** | A dev box, home server, or workstation with **no public inbound** — full-feature trials with the least infra | The host only (TLS + DNS handled by Cloudflare; tunnel is outbound-only) | `docker-compose.tunnel.yml` |
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -33,11 +33,14 @@ plan for what's left. Owner-set: **Now = Slimming only.**
 one-time package→repo link); zero Mastra references ✅.
 
 ### 🔵 NEXT — Deployment completeness + capability lists
-- **Path A completeness** — `docker-compose.yml` bundles Traefik + the `preview-auth` router
-  (Traefik **v3** `HostRegexp`) so the "recommended baseline" self-host path actually runs previews.
-- **Agent code sandbox** — fix the registration sequencing bug (call `ensureSandbox()` *before*
-  checking `sandboxStatus().state`; today it reads `state=null` and never registers bash) + ensure
-  bubblewrap in the image → chat-side bash/Python execution works on the deploys.
+- [x] **Agent code sandbox** — fixed the registration sequencing bug (eager `ensureSandbox()`
+      before the check; `state=null` → bash never registered). Verified live (srt active). *(PR #112)*
+- [~] **Path A completeness** — new **`docker-compose.prod.yml`**: bundled Traefik (direct socket,
+      no shim) + websecure/TLS + the `preview-auth` router (v3 `HostRegexp`) + the preview wildcard
+      cert. **Two TLS options**: Let's Encrypt DNS-01 (default) + Cloudflare Origin CA (`infra/prod/dynamic/`).
+      Locally verified (compose parses, labels interpolate, Traefik flags valid, services = the proven
+      tunnel stack); **definitive test = a real Linux VPS** (direct-socket routing + LE wildcard issuance
+      + public HTTPS). Guide: `docs/deployment/docker-compose.md`.
 - **Skills / MCP curation ("lists")** — content refresh (skills-api `scrapedAt`/ETag), admin
   curation UI for the official catalog, an **MCP catalog/picker**, and fix the stale "coming soon" copy.
 

--- a/infra/prod/dynamic/README.md
+++ b/infra/prod/dynamic/README.md
@@ -1,0 +1,22 @@
+# Traefik dynamic config (Path A) — optional, for the **Cloudflare Origin CA** TLS option
+
+`docker-compose.prod.yml` mounts this directory into Traefik as a **file provider**
+(`/etc/traefik/dynamic`). By default it's empty of `*.yml`, so Traefik uses the
+**Let's Encrypt DNS-01** resolver (the compose default) and nothing here is active.
+
+To switch to the **Cloudflare Origin CA** option instead (domain on Cloudflare, orange-cloud
+proxied, Full(Strict)) — the approach proven on the Dokploy path:
+
+1. Create an Origin CA cert in Cloudflare (Zone → SSL/TLS → Origin Server) covering
+   `your-domain` **and** `*.your-domain`. Save the cert + key here as:
+   - `infra/prod/dynamic/origin.crt`
+   - `infra/prod/dynamic/origin.key`   (gitignored — it's a private key; never commit it)
+2. `cp origin-ca.yml.example origin-ca.yml` (Traefik loads `*.yml` from here automatically).
+3. In `docker-compose.prod.yml`, on the **app** service labels, remove the three
+   `...tls.certresolver=le` / `...tls.domains[0]...` lines from the `main` router (the routers
+   keep `tls=true` and will serve this default cert). You can also drop the
+   `--certificatesresolvers.le...` flags + `CF_DNS_API_TOKEN` from the `traefik` service.
+4. Set Cloudflare DNS: `A @ → <vps-ip>` and `A * → <vps-ip>` (or CNAMEs), both **proxied**.
+
+That's it — Traefik serves the Origin CA cert as the default for the apex + all preview
+subdomains, and Cloudflare terminates the public TLS at its edge (Full(Strict) to your origin).

--- a/infra/prod/dynamic/origin-ca.yml.example
+++ b/infra/prod/dynamic/origin-ca.yml.example
@@ -1,0 +1,12 @@
+# Cloudflare Origin CA — Traefik file-provider config (the ALTERNATIVE TLS option for Path A).
+# Activate by copying to `origin-ca.yml` and dropping origin.crt / origin.key in this dir.
+# See README.md. (Default Path A TLS is Let's Encrypt DNS-01; you don't need this file for that.)
+tls:
+  certificates:
+    - certFile: /etc/traefik/dynamic/origin.crt
+      keyFile: /etc/traefik/dynamic/origin.key
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/dynamic/origin.crt
+        keyFile: /etc/traefik/dynamic/origin.key


### PR DESCRIPTION
Gives the 'recommended baseline' self-host path a real, complete production compose so it can actually run previews (it previously had no bundled proxy).

**New `docker-compose.prod.yml`** — single Linux VPS, public IP, **bundled Traefik** talking to the docker socket **directly** (native on Linux; no macOS dockerproxy shim). websecure/:443 + http→https redirect; the app `main` router obtains the **wildcard cert** (`<domain>` + `*.<domain>`) so preview subdomains reuse it; preview-auth router uses Traefik **v3 HostRegexp**; app gets `seccomp/apparmor=unconfined` + `NET_ADMIN` for preview/sandbox.

**Two TLS options** (you asked for both): Let's Encrypt **DNS-01** (Cloudflare) as default; **Cloudflare Origin CA** via a Traefik file provider (`infra/prod/dynamic/`). Image pulled from GHCR by default; build-on-VPS supported. `docker-compose.yml` stays the local-dev compose.

**Verified locally**: compose parses, labels interpolate, Traefik flags valid, services = the proven tunnel stack. **Definitive test = a real Linux VPS** (direct-socket routing + LE wildcard issuance + public HTTPS) — documented in `docs/deployment/docker-compose.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)