### PR TITLE
fix(deploy): Path A needs the dockerproxy shim on Docker 28/29+ (not just macOS)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -348,6 +348,9 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--providers.docker.network=oxygenie-net"
+      # Talk to docker through the version-rewrite shim: Docker 28/29+ raised the daemon's
+      # minimum API to 1.40, which rejects Traefik's pinned v1.24 client. See `dockerproxy`.
+      - "--providers.docker.endpoint=tcp://dockerproxy:2375"
       - "--entrypoints.web.address=:80"
       # Redirect all plain HTTP → HTTPS
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
@@ -369,9 +372,25 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - le-data:/letsencrypt
       - ./infra/prod/dynamic:/etc/traefik/dynamic:ro
+    depends_on:
+      - dockerproxy
+    restart: unless-stopped
+    networks:
+      - proxy
+
+  # Version-rewrite proxy for the docker socket. **Docker 28/29+ raised the daemon's minimum
+  # API to 1.40**, which rejects Traefik's pinned v1.24 client ("client version 1.24 is too
+  # old. Minimum supported API version is 1.40"). This nginx rewrites /vX.Y/ → /v1.44/ so
+  # Traefik works on modern Docker — this is NOT macOS-specific; verified needed on Docker 29
+  # / Ubuntu too. Harmless on older Docker. (Shares infra/tunnel/nginx.conf.)
+  dockerproxy:
+    image: nginx:alpine
+    container_name: ${APP_NAME_SANITIZED:-oxygenie}-dockerproxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./infra/tunnel/nginx.conf:/etc/nginx/nginx.conf:ro
     restart: unless-stopped
     networks:
       - proxy

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -14,8 +14,10 @@ Internet ──TLS──▶ Traefik (:443, bundled)  ──reads container label
    └─ <id>.your-domain   → preview sandbox container (4173), forward-auth gated
 ```
 
-> On a normal Linux Docker host Traefik talks to the docker socket **directly** — the macOS
-> `dockerproxy` shim from the tunnel path is **not needed here**.
+> The compose bundles a tiny `dockerproxy` (nginx) in front of the docker socket. **Docker
+> 28/29+ raised the daemon's minimum API to 1.40, which rejects Traefik's pinned v1.24 client**
+> ("client version 1.24 is too old") — on *any* OS, not just macOS. The shim rewrites the API
+> version so Traefik works; it's harmless on older Docker. (Verified live on Docker 29 / Ubuntu.)
 
 ---
 

--- a/docs/deployment/tunnel.md
+++ b/docs/deployment/tunnel.md
@@ -43,10 +43,12 @@ Cloudflare edge (TLS, *.oxygenie.cc)
    `APP_TAG=local`, and every app service uses `pull_policy: never` (don't try to pull a local tag).
 5. **ARK auth** uses `ANTHROPIC_AUTH_TOKEN` (Bearer) — do **not** set `ANTHROPIC_API_KEY`
    (setting it makes the SDK switch to `x-api-key` and ARK rejects it). Same as every other path.
-6. **macOS only (OrbStack / Docker Desktop): the `dockerproxy` shim is required.** Traefik's
-   docker provider pins API `v1.24`; the macOS daemon's minimum is `1.40` → `"client version
-   1.24 is too old"`. `dockerproxy` (nginx) rewrites `/vX.Y/...` → `/v1.44/...`. **On a plain
-   Linux Docker host you don't need it** — point Traefik at the socket directly (see the bottom).
+6. **The `dockerproxy` shim is required on OrbStack/Docker Desktop AND on Docker 28/29+.**
+   Traefik's docker provider pins API `v1.24`; a daemon whose minimum is `1.40` rejects it →
+   `"client version 1.24 is too old"`. This hits **macOS (OrbStack/Docker Desktop)** *and*
+   **modern Docker on any OS** (Docker 28/29 raised the minimum to 1.40 — verified on Docker 29
+   / Ubuntu). `dockerproxy` (nginx) rewrites `/vX.Y/...` → `/v1.44/...`. Only **old Linux Docker
+   (≤27)** can skip it and point Traefik at the socket directly (see the bottom).
 
 ---
 
@@ -165,11 +167,12 @@ This applies to **all** deploy paths (the cache lives in the preview controller,
 
 ---
 
-## Running on a plain Linux host (no `dockerproxy` needed)
+## Old Linux Docker (≤27): you may drop `dockerproxy`
 
-The `dockerproxy` shim exists **only** because macOS Docker daemons reject Traefik's pinned API
-version. On a normal Linux Docker host, delete the `dockerproxy` service and point Traefik at
-the socket directly:
+The `dockerproxy` shim exists because Traefik's docker provider pins API `v1.24`, which daemons
+with a minimum of `1.40` reject — that's **macOS (OrbStack/Docker Desktop)** *and* **Docker
+28/29+ on any OS**. Only on **older Linux Docker (≤27)** can you delete the `dockerproxy` service
+and point Traefik at the socket directly:
 
 ```yaml
   traefik:


### PR DESCRIPTION
Tested Path A end-to-end on a **real Linux VM** (Multipass, Ubuntu 22.04, **Docker 29.5.3**) — which caught a real bug: the Traefik docker-provider version-pin (`client version 1.24 is too old. Minimum supported API version is 1.40`) is **not macOS-specific**. Docker 28/29 raised the daemon minimum API to 1.40; Traefik v3.5 still pins v1.24, so the direct-socket Traefik in `docker-compose.prod.yml` failed → routed 404. (`DOCKER_API_VERSION=1.44` is ignored by Traefik — re-confirmed.)

**Fix:** bundle the nginx version-rewrite `dockerproxy` (shares `infra/tunnel/nginx.conf`) and point Traefik at `tcp://dockerproxy:2375`. Harmless on old Docker.

**Re-verified live on the VM after the fix:** `/health` 200, `/ws/agent` 426, http→https 301, migrate exit 0, preview-controller ensure→install→start ok, **preview subdomain routes** (forward-auth 401 on `/` and on `/__oxy/preview/auth` via the v3 HostRegexp router), `unshare -Urn` userns-ok, bwrap present.

Docs corrected (`docker-compose.md`, `tunnel.md`): the shim is needed on Docker 28/29+ (any OS); only old Linux Docker (≤27) can skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)