### PR TITLE
fix(ui): show the deliverable card only after the turn completes

### DIFF
--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -1967,9 +1967,12 @@ const HistoricalMessageImpl: FC<{
                   />
                 )}
 
-                {/* Artifact Button — one deliverable card per turn, with the
-                    real file name / title (not a generic "{TYPE} 成果物"). */}
-                {artifact && artifact.type !== 'image' && (
+                {/* Artifact Button — one deliverable card per turn, with the real file
+                    name / title. Gated on !isRunning so the "打开成果物 / 运行预览" card only
+                    appears once the WHOLE turn is done — not mid-build (a half-written
+                    multi-file app would preview broken + waste a build). Live writes still
+                    show in the turn-card's activity stream during the turn. */}
+                {artifact && artifact.type !== 'image' && !isRunning && (
                   <div className="mt-3">
                     <ArtifactButton
                       type={artifact.type}


### PR DESCRIPTION
The `打开成果物 / 运行预览` card appeared the moment any single Write finished, so for a multi-file app it showed **mid-build** (the screenshot: index.html written but Snake/Tetris still pending). Opening it then = a half-built app; 运行预览 would install+build incomplete code (broken + wasted build).

Fix: gate the inline `ArtifactButton` on the message's turn being done (`!isRunning` / `message.status?.type !== 'running'`). Live writes still stream in the turn-card's activity list; the **deliverable** card appears only when the whole turn completes. Artifact still lands in the store (Files/panel) during the turn; inline images unaffected. Matches Cowork's 'deliverable when done'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)