### PR TITLE
feat(preview): public-link share toggle for sandbox previews

### DIFF
--- a/src/claude/adapters/index.ts
+++ b/src/claude/adapters/index.ts
@@ -9,6 +9,7 @@ export {
   cancelActiveRun,
   startPreview,
   stopPreview,
+  sharePreview,
   respondApproval,
   abort,
   resumeSession,

--- a/src/claude/adapters/ws-adapter.ts
+++ b/src/claude/adapters/ws-adapter.ts
@@ -114,6 +114,7 @@ type InboundMessage =
   | { type: 'abort' }
   | { type: 'start_preview'; sessionId?: string; mode?: 'static' | 'live' }
   | { type: 'stop_preview'; sessionId?: string }
+  | { type: 'share_preview'; previewId: string; sessionId?: string }
   | { type: 'approval_response'; toolUseID: string; decision: 'allow' | 'deny' }
   | { type: 'ping' };
 
@@ -617,6 +618,16 @@ export async function startPreview(
 
 export async function stopPreview(sessionId?: string): Promise<void> {
   await send({ type: 'stop_preview', sessionId: sessionId ?? currentSessionId });
+}
+
+/**
+ * Mark a running preview as public (Option A share toggle). The backend drops
+ * the forward-auth gate for this preview and pins it alive, then replies with an
+ * updated `preview_state` (public:true, shareUrl). The bare share link then
+ * works for anyone who opens it (on a publicly-resolvable domain).
+ */
+export async function sharePreview(previewId: string, sessionId?: string): Promise<void> {
+  await send({ type: 'share_preview', previewId, sessionId: sessionId ?? currentSessionId });
 }
 
 /**

--- a/src/components/claude-chat/artifact-html.tsx
+++ b/src/components/claude-chat/artifact-html.tsx
@@ -12,8 +12,8 @@
  */
 
 import { useEffect, useMemo, useState, type FC, type Ref } from 'react'
-import { AlertTriangle, Info, Loader2, Play } from 'lucide-react'
-import { startPreview } from '~/claude/adapters'
+import { AlertTriangle, Check, Info, Loader2, Play, Share2 } from 'lucide-react'
+import { sharePreview, startPreview } from '~/claude/adapters'
 import { useSessionPreview } from '~/lib/hooks/use-session-workbench'
 
 export interface HTMLArtifactProps {
@@ -67,6 +67,7 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
 
   const preview = useSessionPreview()
   const [starting, setStarting] = useState(false)
+  const [copied, setCopied] = useState(false)
 
   // Cleanup blob URL on unmount
   useEffect(() => {
@@ -88,6 +89,35 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
   const runPreview = () => {
     setStarting(true)
     void startPreview().catch(() => setStarting(false))
+  }
+
+  // Bare, token-free origin of the running preview — the link safe to share.
+  // Prefer the backend-confirmed shareUrl; otherwise derive it from the live URL.
+  const shareUrl =
+    preview?.shareUrl ||
+    (preview?.url
+      ? (() => {
+          try {
+            return new URL(preview.url as string).origin + '/'
+          } catch {
+            return ''
+          }
+        })()
+      : '')
+
+  // Copy the link immediately (inside the click gesture so the clipboard write
+  // is allowed), then tell the backend to make this preview public so the link
+  // works for anyone who opens it.
+  const onShare = async () => {
+    if (!shareUrl) return
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be blocked (insecure context); the URL is shown below to copy manually.
+    }
+    if (preview?.previewId) void sharePreview(preview.previewId).catch(() => {})
   }
 
   return (
@@ -116,7 +146,26 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
               {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
               {busy ? '运行中…' : liveUrl ? '重新运行' : '运行预览'}
             </button>
+            {liveUrl && (
+              <button
+                type="button"
+                onClick={() => void onShare()}
+                title="复制公开链接，分享给他人在浏览器打开"
+                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-300 bg-amber-100 px-2 py-1 font-medium text-amber-900 transition hover:bg-amber-200 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60"
+              >
+                {copied ? <Check className="h-3.5 w-3.5" /> : <Share2 className="h-3.5 w-3.5" />}
+                {copied ? '已复制' : '分享'}
+              </button>
+            )}
           </div>
+          {liveUrl && shareUrl && (preview?.public || copied) && (
+            <div className="flex items-center gap-1.5 pl-5 text-[11px] text-amber-800 dark:text-amber-300">
+              <Share2 className="h-3 w-3 shrink-0" />
+              <span className="truncate">
+                公开链接：<span className="font-mono">{shareUrl}</span>
+              </span>
+            </div>
+          )}
           {(busy || failed) && (
             <div className="flex items-center gap-1.5 pl-5 text-[11px] text-amber-800 dark:text-amber-300">
               {failed ? (

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -118,6 +118,11 @@ export type PreviewState = {
   status: 'detecting' | 'installing' | 'building' | 'ready' | 'error' | 'stopped';
   url?: string;
   error?: string;
+  // Set once the user shares the preview (Option A public-link toggle): the
+  // preview bypasses the forward-auth gate and is pinned alive. `shareUrl` is
+  // the bare, token-free link anyone can open.
+  public?: boolean;
+  shareUrl?: string;
 };
 
 // Ask-mode HITL: a pending tool-approval request, pushed by the worker over WS

--- a/src/preview/runtime.js
+++ b/src/preview/runtime.js
@@ -110,11 +110,52 @@ export class PreviewRuntime {
     return this.active.get(previewId) || null;
   }
 
+  getStateByHost(host) {
+    if (!host) return null;
+    const wanted = String(host).toLowerCase();
+    for (const state of this.active.values()) {
+      if (state.host && state.host.toLowerCase() === wanted) return state;
+    }
+    return null;
+  }
+
+  // A preview is "public" once the user has explicitly shared it (Option A:
+  // public-link toggle). Public previews skip the forward-auth cookie gate
+  // (see ws-server `/__oxy/preview/authorize`) and are pinned alive (no
+  // idle-reap), so a shared link keeps working for anyone who opens it.
+  isPublicHost(host) {
+    const state = this.getStateByHost(host);
+    return !!(state && state.public);
+  }
+
   touchPreview(previewId) {
     const state = this.active.get(previewId);
     if (!state) return null;
     state.lastAccessAt = Date.now();
     return state;
+  }
+
+  // Flip a running preview to public and return a state-shaped payload (so the
+  // caller can broadcast it over `preview_state`). `shareUrl` is the bare,
+  // token-free origin URL — it works for anyone because authorize bypasses the
+  // cookie for public hosts. Returns null if the preview isn't running.
+  sharePreview(previewId) {
+    const state = this.active.get(previewId);
+    if (!state || state.status !== 'ready') return null;
+    state.public = true;
+    state.lastAccessAt = Date.now();
+    const shareUrl = `${this.protocol}://${state.host}/`;
+    state.shareUrl = shareUrl;
+    return {
+      sessionId: state.sessionId,
+      previewId,
+      mode: state.mode,
+      status: state.status,
+      url: state.url,
+      manifest: state.manifest,
+      public: true,
+      shareUrl,
+    };
   }
 
   async stopPreview(previewId, reason = 'stopped') {
@@ -138,6 +179,7 @@ export class PreviewRuntime {
     const stopped = [];
     for (const [previewId, state] of this.active.entries()) {
       if (state.status !== 'ready') continue;
+      if (state.public) continue; // shared previews are pinned alive
       if (now - state.lastAccessAt <= this.idleTimeoutMs) continue;
       try {
         const next = await this.stopPreview(previewId, 'idle timeout');

--- a/tests/unit/preview-runtime.test.ts
+++ b/tests/unit/preview-runtime.test.ts
@@ -46,3 +46,79 @@ describe('PreviewRuntime', () => {
     expect(state.error).toMatch(/frontend SPA\/static apps only/);
   });
 });
+
+describe('PreviewRuntime sharing (Option A public-link toggle)', () => {
+  function readyRuntime() {
+    const stopped: string[] = [];
+    const provider = {
+      ensureSessionSandbox: async () => undefined,
+      installDeps: async () => undefined,
+      startPreview: async () => undefined,
+      stopPreview: async ({ previewId }: { previewId: string }) => {
+        stopped.push(previewId);
+        return undefined;
+      },
+    };
+    const runtime = new PreviewRuntime({ provider });
+    runtime.active.set('p-1', {
+      sessionId: 's-1',
+      previewId: 'p-1',
+      mode: 'static',
+      host: 'p-1.example.com',
+      status: 'ready',
+      url: 'http://p-1.example.com/__oxy/preview/auth?t=tok',
+      lastAccessAt: Date.now(),
+    });
+    return { runtime, stopped };
+  }
+
+  it('sharePreview flips a ready preview to public and returns a bare share URL', () => {
+    const { runtime } = readyRuntime();
+    const state = runtime.sharePreview('p-1');
+    expect(state).not.toBeNull();
+    expect(state?.public).toBe(true);
+    expect(state?.shareUrl).toBe('http://p-1.example.com/');
+    expect(runtime.getState('p-1')?.public).toBe(true);
+  });
+
+  it('sharePreview returns null for unknown or not-ready previews', () => {
+    const { runtime } = readyRuntime();
+    expect(runtime.sharePreview('nope')).toBeNull();
+    runtime.active.get('p-1')!.status = 'building';
+    expect(runtime.sharePreview('p-1')).toBeNull();
+  });
+
+  it('isPublicHost / getStateByHost resolve by host (case-insensitive)', () => {
+    const { runtime } = readyRuntime();
+    expect(runtime.isPublicHost('p-1.example.com')).toBe(false);
+    runtime.sharePreview('p-1');
+    expect(runtime.isPublicHost('P-1.EXAMPLE.COM')).toBe(true);
+    expect(runtime.getStateByHost('p-1.example.com')?.previewId).toBe('p-1');
+    expect(runtime.isPublicHost('other.example.com')).toBe(false);
+  });
+
+  it('reapIdlePreviews keeps shared (public) previews pinned alive', async () => {
+    const { runtime, stopped } = readyRuntime();
+    // Force the preview well past the idle window.
+    runtime.active.get('p-1')!.lastAccessAt = Date.now() - runtime.idleTimeoutMs - 60_000;
+
+    // Not shared yet → reaped.
+    const reapedBefore = await runtime.reapIdlePreviews();
+    expect(reapedBefore.map((s) => s.previewId)).toContain('p-1');
+    expect(stopped).toContain('p-1');
+
+    // Re-add as a shared/public preview → must survive the reaper.
+    runtime.active.set('p-1', {
+      sessionId: 's-1',
+      previewId: 'p-1',
+      mode: 'static',
+      host: 'p-1.example.com',
+      status: 'ready',
+      lastAccessAt: Date.now() - runtime.idleTimeoutMs - 60_000,
+      public: true,
+    });
+    const reapedAfter = await runtime.reapIdlePreviews();
+    expect(reapedAfter.map((s) => s.previewId)).not.toContain('p-1');
+    expect(runtime.getState('p-1')).not.toBeNull();
+  });
+});

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -292,6 +292,7 @@ const BUSINESS_MESSAGE_TYPES = new Set([
   'abort',
   'start_preview',
   'stop_preview',
+  'share_preview',
   'approval_response',
 ]);
 
@@ -808,6 +809,20 @@ async function handlePreviewHttp(req, res) {
   }
 
   if (req.method === 'GET' && url.pathname === '/__oxy/preview/authorize') {
+    // Public (user-shared) previews bypass the cookie gate entirely so anyone
+    // with the link can open them. The forward-auth middleware still runs; we
+    // just always answer "ok" for hosts the user explicitly marked public.
+    const publicState = previewRuntime.getStateByHost(host);
+    if (publicState?.public) {
+      previewRuntime.touchPreview(publicState.previewId);
+      res.writeHead(200, {
+        'content-type': 'text/plain; charset=utf-8',
+        'x-oxygenie-preview-id': publicState.previewId,
+        'x-oxygenie-preview-public': '1',
+      });
+      res.end('ok');
+      return true;
+    }
     const verified = previewAuth.verifyCookie(req.headers.cookie || '', { host });
     if (!verified) {
       res.writeHead(401, { 'content-type': 'text/plain; charset=utf-8' });
@@ -944,6 +959,39 @@ async function handleStartPreview(ws, message) {
       mode,
       status: 'error',
       error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleSharePreview(ws, message) {
+  try {
+    const previewId = message.previewId;
+    if (!previewId) {
+      sendMessage(ws, {
+        type: 'error',
+        code: 'invalid_message',
+        message: 'Missing previewId for share_preview',
+        retriable: false,
+      });
+      return;
+    }
+    const state = previewRuntime.sharePreview(previewId);
+    if (!state) {
+      sendMessage(ws, {
+        type: 'error',
+        code: 'preview_share_failed',
+        message: 'Preview is not running. Start the preview before sharing.',
+        retriable: true,
+      });
+      return;
+    }
+    sendPreviewState(ws, state);
+  } catch (error) {
+    sendMessage(ws, {
+      type: 'error',
+      code: 'preview_share_failed',
+      message: error instanceof Error ? error.message : String(error),
+      retriable: true,
     });
   }
 }
@@ -1600,6 +1648,10 @@ async function handleMessage(ws, msg) {
 
     case 'stop_preview':
       await handleStopPreview(ws, message);
+      break;
+
+    case 'share_preview':
+      await handleSharePreview(ws, message);
       break;
 
     case 'approval_response': {


### PR DESCRIPTION
## What

Adds a 「分享」 button on a running multi-file preview that **copies a bare, token-free link anyone can open in the browser** — Option A (public-link toggle), as confirmed by the owner ("走 A").

## Why

Naively copying the preview URL doesn't work for others: the live URL carries a one-time `?t=` bootstrap token that becomes a per-browser httpOnly cookie, and previews are idle-reaped after 5 min. So a shared link needs (a) auth bypass and (b) keep-alive.

## How (no container/label churn)

- The preview's Traefik **forward-auth middleware stays attached**. Instead, `/__oxy/preview/authorize` answers `ok` for hosts the user explicitly marked **public**, so the cookie gate is bypassed *only* for shared previews. No need to recreate the container or rewrite Traefik labels.
- Shared previews are **pinned alive** — `reapIdlePreviews` skips `public` ones — so the link survives past the idle window.
- The share link is the **bare origin** `https://<id>.<domain>/` (no token).

## Changes

**Backend**
- `src/preview/runtime.js`: `getStateByHost` / `isPublicHost` / `sharePreview` (returns a state-shaped payload with `public:true` + bare `shareUrl`); reaper skips public previews.
- `ws-server.mjs`: public-bypass in `/__oxy/preview/authorize`; `share_preview` message type + `handleSharePreview`.

**Frontend**
- `src/claude/adapters/ws-adapter.ts` (+ barrel): `sharePreview()` sender + `share_preview` inbound type.
- `src/lib/chat-session-store.ts`: `PreviewState` gains `public?` / `shareUrl?`.
- `src/components/claude-chat/artifact-html.tsx`: 分享 button — copies the link **inside the click gesture** (so clipboard write is allowed), then flips the preview public on the backend; plus a public-link hint line.

## UX

分享 appears once a preview is **ready**. Clicking copies the link immediately (button shows ✓ 已复制) and marks the preview public in the background; a `公开链接：<url>` line is shown so it can be copied manually if the clipboard is blocked.

## Limitation

External access requires a **publicly-resolvable** preview domain (e.g. `*.oxygenie.cc`). On the local Multipass VM (`*.oxygenie.local`) the link only resolves on the local network / configured resolver.

## Capacity note

Public previews hold a `MAX_ACTIVE_PREVIEWS` slot until manually stopped (or container restart). For a self-hosted trusted-team deployment this is acceptable; `stop_preview` releases it.

## Tests

`tests/unit/preview-runtime.test.ts`: share flips + bare URL, null guards (unknown / not-ready), case-insensitive host lookup, and reaper pins public previews. Verified the runtime logic directly via Node (deps not installed in this worktree); `node --check` passes on both `.mjs`/`.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)