### PR TITLE
ci(changedoc): point Qwen ChangeDoc/review at ARK coding gateway

### DIFF
--- a/.github/workflows/ai-pr-docs.yml
+++ b/.github/workflows/ai-pr-docs.yml
@@ -51,16 +51,19 @@ jobs:
 
       - name: Configure Qwen Code provider & model
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENROUTER_API_KEY }} # add this as an Environment secret on 'ai-review'
+          # Volcengine ARK coding gateway, OpenAI-compatible path (/api/coding/v3).
+          # Reuses the existing ARK_API_KEY secret (ARK Bearer token); ensure it's
+          # available to the 'ai-review' environment (repo- or env-level secret).
+          OPENAI_API_KEY: ${{ secrets.ARK_API_KEY }}
         run: |
           echo "::add-mask::${OPENAI_API_KEY}"
           {
             echo "OPENAI_API_KEY=${OPENAI_API_KEY}"
-            echo "OPENAI_BASE_URL=https://openrouter.ai/api/v1"
-            echo "OPENAI_MODEL=qwen/qwen3-coder"
-            # To use Alibaba DashScope instead, replace the two lines above with:
-            # echo "OPENAI_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
-            # echo "OPENAI_MODEL=qwen3-coder-plus"
+            echo "OPENAI_BASE_URL=https://ark.cn-beijing.volces.com/api/coding/v3"
+            echo "OPENAI_MODEL=doubao-seed-2.0-code"
+            # Other providers (swap base_url + model + the secret above):
+            #   OpenRouter: https://openrouter.ai/api/v1                          | qwen/qwen3-coder
+            #   DashScope:  https://dashscope-intl.aliyuncs.com/compatible-mode/v1 | qwen3-coder-plus
           } >> $GITHUB_ENV
 
       - name: Build prompts


### PR DESCRIPTION
## What

Switches the **AI ChangeDoc & Code Review** workflow (`.github/workflows/ai-pr-docs.yml`) from OpenRouter to the **Volcengine ARK coding gateway** (OpenAI-compatible), reusing infra the project already runs on.

| knob | before | after |
|---|---|---|
| `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` | `https://ark.cn-beijing.volces.com/api/coding/v3` |
| `OPENAI_MODEL` | `qwen/qwen3-coder` | `doubao-seed-2.0-code` |
| secret | `OPENROUTER_API_KEY` | `ARK_API_KEY` (reuse existing ARK Bearer token) |

## Action still required to make it green

The `ARK_API_KEY` secret must be available to the **`ai-review`** GitHub Environment (the job runs with `environment: ai-review`). If `ARK_API_KEY` is only a repo-level secret, it's already visible to the environment job; otherwise add it to that environment. Until then this workflow still fails on auth — but it's **not a quality gate** (Quality Checks + gitleaks are the real gates).

## Note

`/api/coding/v3` is the ARK coding gateway's **OpenAI-protocol** path (Bearer auth) — distinct from the `/api/coding` (Anthropic-compatible) path the Agent SDK uses. Same ARK key, different model namespace (Doubao model ids here, not the sonnet/opus aliases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)