### PR TITLE
ci(changedoc): use generic OPENAI_API_KEY secret name

### DIFF
--- a/.github/workflows/ai-pr-docs.yml
+++ b/.github/workflows/ai-pr-docs.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Configure Qwen Code provider & model
         env:
           # Volcengine ARK coding gateway, OpenAI-compatible path (/api/coding/v3).
-          # Reuses the existing ARK_API_KEY secret (ARK Bearer token); ensure it's
-          # available to the 'ai-review' environment (repo- or env-level secret).
-          OPENAI_API_KEY: ${{ secrets.ARK_API_KEY }}
+          # OPENAI_API_KEY secret = the ARK Bearer token (one key, generic name to
+          # match the CLI's env var). Set on the 'ai-review' environment.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           echo "::add-mask::${OPENAI_API_KEY}"
           {


### PR DESCRIPTION
## What

Renames the changedoc secret reference `secrets.ARK_API_KEY` → `secrets.OPENAI_API_KEY` (matches the CLI's env var; one generic key name). Endpoint/model unchanged (ARK `/api/coding/v3` + `doubao-seed-2.0-code`).

## Secret already set

`OPENAI_API_KEY` is set on the **`ai-review`** environment (= the ARK Bearer token). So once this merges, the **next** PR's `changedoc` run (which uses base-`main`'s workflow per `pull_request_target`) will authenticate against ARK and should go green.

Docs/CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)