### PR TITLE
docs: session wrap-up + multi-model research & next-focus

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -33,6 +33,14 @@ plan for what's left. Owner-set: **Now = Slimming only.**
 one-time package→repo link); zero Mastra references ✅.
 
 ### 🔵 NEXT — Deployment completeness + capability lists
+- [ ] **🎯 Multi-model selection (owner-set focus, 2026-06-07)** — let users pick the model per run
+      instead of the single startup `ANTHROPIC_MODEL`. **MVP = same-gateway (ARK) model switch**:
+      a curated model registry + `model` plumbing that mirrors the proven `skillSlug`/`permissionTier`
+      path (store → ws-adapter `chat` msg → ws-server validate → worker) + a real composer picker
+      (replacing the cosmetic "GLM 5.0" badge) + `query({ model })`. Cross-provider env-routing,
+      DB-backed admin registry, and failover are later phases. Stays within **SDK 0.2.112 / ARK**
+      (Anthropic-compatible gateways only). Research + phased plan:
+      `research/2026-06-multi-model-support-research.md`.
 - [x] **Agent code sandbox** — fixed the registration sequencing bug (eager `ensureSandbox()`
       before the check; `state=null` → bash never registered). Verified live (srt active). *(PR #112)*
 - [x] **Path A completeness** — **`docker-compose.prod.yml`**: bundled Traefik + websecure/TLS + the
@@ -48,9 +56,10 @@ one-time package→repo link); zero Mastra references ✅.
 - **Skills / MCP curation ("lists")** — content refresh (skills-api `scrapedAt`/ETag), admin
   curation UI for the official catalog, an **MCP catalog/picker**, and fix the stale "coming soon" copy.
 
-### 🟣 LATER — Multi-model, gates, accounting, polish
-- **Multi-model** (Phase 4) — model registry + routing/failover + per-capability key split, within
-  the **SDK 0.2.112 / ARK** constraint (no 0.3.x-only features). The current picker is cosmetic.
+### 🟣 LATER — gates, accounting, polish
+- **Multi-model** — **promoted to NEXT (2026-06-07)** — see the NEXT item +
+  `research/2026-06-multi-model-support-research.md`. Phase 4 *stretch* remains: cross-provider
+  routing/**failover** + per-capability key split + capability gating (e.g. vision-only models).
 - **CI hard gates** (Phase 0 remainder) — typecheck, validate-routes (29 REST routes), test
   (Postgres service container); TS-ify `ws-server.mjs`/`ws-query-worker.mjs` + typed WS protocol.
 - **Accounting** (Phase 2 wiring) — call `spendOneCredit`, persist per-run cost/tokens, enable the

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -1,7 +1,7 @@
 # OxyGenie — Status (Living Memory)
 
 > **This is the living memory of the project. Update it whenever state changes.**
-> Last updated: **2026-06-06**
+> Last updated: **2026-06-07**
 
 ## Current position (one-paragraph snapshot)
 
@@ -236,7 +236,7 @@ file → done). The earlier GLM-plan blocker is resolved.
 | Make tests CI-runnable (unit/e2e split + services) | M | Then make `test` a hard gate |
 | Fix TS errors | S–M | Good starter task; then make `typecheck` a hard gate |
 | Sandbox Python/Bash exec — adopt `srt` + env allowlist | M | **Critical** (Risk #1); via Phase 0.5 `ExecutionRuntime` + Anthropic `srt` |
-| `changedoc` (ai-pr-docs) — provider = ARK | S (chore) | Repointed OpenRouter→**ARK** `/api/coding/v3` + `doubao-seed-2.0-code` + `ARK_API_KEY` (#118). To go green: ensure `ARK_API_KEY` is visible to the `ai-review` Environment (`pull_request_target` → new config effective next PR). Not a quality gate. Optional: gate behind an `ai-review` label to stop red on every PR. |
+| `changedoc` (ai-pr-docs) — wired to ARK ✅ | S (chore) | OpenRouter→**ARK** `/api/coding/v3` + `doubao-seed-2.0-code` (#118); secret = generic **`OPENAI_API_KEY`** (#120) set on `ai-review` env (= the ARK `ANTHROPIC_AUTH_TOKEN`). curl-validated (HTTP 200). `pull_request_target` → **next PR** confirms green. Not a quality gate. Optional: `ai-review` label gate to silence red. |
 | Archive old public repo `constructa-starter` | S (chore) | Avoid two-public-repo confusion |
 | Bump gitleaks/checkout actions off Node 20 | S (chore) | Deprecation forced ~2026-06-16 |
 | **Workspace (项目) as a first-class concept** | L | Decouple Workspace from Conversation; let new-chat pick "existing workspace vs new"; conversations belong to a workspace (stable absolute path). Today每对话=独立 workspace（`getSessionWorkspace`, 1:1）。L2 in `research/2026-06-conversation-persistence-resume-comparison.md`; subsumes the persistence 治本. Owner-deferred 2026-06 (do 治标 first). |
@@ -252,7 +252,8 @@ file → done). The earlier GLM-plan blocker is resolved.
 | ✅ ~~NEXT · Path A: bundle Traefik + preview-auth~~ | M | **Done — `docker-compose.prod.yml` (#113/#114).** Bundled Traefik + preview-auth (v3 `HostRegexp`) + wildcard cert + `dockerproxy` shim (Docker 28/29 API min); LE DNS-01 + CF Origin CA. **VM-verified** on Ubuntu 22.04/Docker 29. Residual: LE issuance vs real public DNS untested. |
 | ✅ ~~NEXT · Agent code sandbox: fix srt registration sequencing~~ | M | **Done — PR #112.** Eager `ensureSandbox()` before the `sandboxStatus()` check (was `state=null` → bash never registered); bubblewrap in image. Verified live (srt active). |
 | **🔵 NEXT · MCP catalog/picker + fix stale "coming soon" copy** | M | No curated MCP picker yet; `skills.content.ts` "enabling … coming soon" copy is outdated (Skills shipped). Pairs with the Skills curation rows above. |
-| **🟣 LATER · Multi-model: registry + routing/failover** | L | Phase 4. Picker is cosmetic today (hardcoded GLM/ARK). Within the **SDK 0.2.112 / ARK** constraint; per-capability key split. |
+| **🎯 NEXT · Multi-model selection (owner focus 2026-06-07)** | S–M (MVP) | Pick model per run vs the startup `ANTHROPIC_MODEL`. MVP = same-gateway (ARK) switch: curated registry + `model` plumbing (mirror `skillSlug`/`permissionTier`) + real composer picker + `query({model})`. Plan: `research/2026-06-multi-model-support-research.md`. |
+| **🟣 LATER · Multi-model: cross-provider routing + failover** | L | Phase 4 stretch (after the NEXT MVP): per-request env routing to other Anthropic-compatible gateways, DB-backed admin registry, failover, per-capability key split, capability gating. Within **SDK 0.2.112 / ARK** (Anthropic-protocol only). |
 | **🟣 LATER · Revisit `ENABLE_STRUCTURED_OUTPUTS` (off)** | M | Coupled to the artifact/structured-output strategy; Phase C now done → resolve the StructuredOutput-leak root cause instead of keeping the flag forced-off. |
 | **🟣 LATER · Wire accounting (Phase 2)** | M | `spendOneCredit` never called; persist per-run cost/tokens; enable audit log; stop logging raw message content (PII). |
 | **🟣 LATER · Email-verify self-host UX + P16 version recording + deprecated-fn cleanup** | S | The "verify your email" banner on a self-host is friction; P16 artifact version recording paused (`ENABLE_VERSION_RECORDING=false`); `syncOldUserSkills`/`getSkillStatus` are `@deprecated`. |
@@ -265,6 +266,18 @@ file → done). The earlier GLM-plan blocker is resolved.
 
 ## Decision log
 
+- **2026-06-07** — **本轮收工 + 下一焦点 = 多模型选择(owner 定)**。今天(06-06 会话)全部收口:Phase C 全部完成、
+  分享功能上线、文档对齐、changedoc 接通 ARK(见下条)。**下一步 = 让系统支持多模型选择**,已先产出调研 +
+  分阶段实施计划 `research/2026-06-multi-model-support-research.md`。要点:① 现状 = model 是启动期单一
+  `ANTHROPIC_MODEL`,UI「GLM 5.0」是死徽章,前端→worker 无任何传递;② 关键约束 = 我们驱动的是 **Claude Agent
+  SDK(钉死 0.2.112)**,只说 Anthropic 协议,故"多模型"= 跨 **Anthropic 兼容网关**的多模型(OpenAI-only 厂商需加
+  转译代理,暂不做);③ 关键使能点 = worker 是**每请求新子进程**,`ws-server` 可**按请求覆写** 其
+  `ANTHROPIC_MODEL`/`BASE_URL`/`AUTH_TOKEN` → 无需 0.3.x 即可路由到任意 provider;④ **MVP(明天)= 同网关(ARK)
+  切模型**:精选 registry + `model` 走通(照搬 `skillSlug`/`permissionTier` 链路)+ 真 composer picker +
+  `query({model})`,**不**改 baseURL/key、**不**动 DB;⑤ v2 = 会话/消息持久化 + DB registry + admin 策展
+  (照搬 Skills 目录);Phase 4 stretch = 跨 provider 路由/failover + per-capability key 拆分。参考:LibreChat
+  (spec→preset + 每消息记录 model)/ Lobe(provider card + 运行时 resolve)——借思路不抄码。
+
 - **2026-06-06 (later)** — **Phase C 收口:Path A 完成 + 预览分享上线 + changedoc 切 ARK。结论:Phase C 全部完成。**
   ① **Path A**(`docker-compose.prod.yml`)在**真 Linux VM**(Ubuntu 22.04 / Docker 29,Multipass)验证通过
   (migrate/health/WS/重定向/预览 forward-auth 全绿);此 VM run **逮到并修了 Docker 28/29 守护进程最低 API**
@@ -273,9 +286,11 @@ file → done). The earlier GLM-plan blocker is resolved.
   ② **预览体验收尾**:成果物卡**收到整轮结束**才显示(#115);**分享=公开链接切换**(#116——`/__oxy/preview/
   authorize` 对 public host 放行 + 分享期间钉住常驻 → 无 token 的 `<id>.<域名>/` 链接,任何人可开)。Mac 本机
   用 mkcert + dnsmasq 受信泛域名证书完成浏览器验证。生命周期+分享写入 README(_CN) + v1 计划 §8(#117)。
-  ③ **changedoc**:`ai-pr-docs`(ChangeDoc/AI-review)从 OpenRouter 切到 **ARK**(`/api/coding/v3`、
-  `doubao-seed-2.0-code`、`ARK_API_KEY`,#118)。注:`pull_request_target` 跑基分支版本,新配置**下个 PR 起**
-  生效;变绿还需 `ARK_API_KEY` 对 `ai-review` Environment 可见。
+  ③ **changedoc 接通**:`ai-pr-docs`(ChangeDoc/AI-review)从 OpenRouter 切到 **ARK**
+  (`/api/coding/v3`、`doubao-seed-2.0-code`,#118),secret 名按 owner 要求用通用 **`OPENAI_API_KEY`**
+  (#120)。key = 本地 `~/oxygenie-deploy/secrets.env` 的 `ANTHROPIC_AUTH_TOKEN`,已写入 `ai-review`
+  Environment(值未回显)。**已 curl 实测三件套**:`/api/coding/v3` + `doubao-seed-2.0-code` + 该 key →
+  HTTP 200。注:`pull_request_target` 跑基分支版本,故**下个 PR** 的 changedoc 才会用上新配置并变绿。
 
 - **2026-06-06** — **Phase C 真预览全链路打通 + Mac/Tunnel 部署上线 + 路线图重置**。
   ① **真预览 E2E 修复**(实测驱动):Traefik **v3 `HostRegexp`** 修预览 404 —— v2 命名组

--- a/docs/project/research/2026-06-multi-model-support-research.md
+++ b/docs/project/research/2026-06-multi-model-support-research.md
@@ -1,0 +1,202 @@
+# Multi-model selection — research & implementation plan (2026-06)
+
+**Status:** research / owner-set next focus (2026-06-07). Implementation pending.
+**Goal:** let the user pick which model an agent run uses, instead of the single
+deployment-wide `ANTHROPIC_MODEL`. Stay inside the **SDK 0.2.112 / ARK** constraint
+(no 0.3.x-only features); fit the **self-hosted, single-org, curated-capabilities**
+product shape (a team-curated model list, not a public marketplace).
+
+---
+
+## 1. Current state (code audit, 2026-06-07)
+
+| Aspect | Today |
+|---|---|
+| Where the model comes from | `process.env.ANTHROPIC_MODEL`, read **once at server startup** (`ws-server.mjs` config ~L107; mirrored in `ws-query-worker.mjs` ~L24). |
+| How it reaches the SDK | Worker passes it explicitly: `query({ options: { model: config.model, … } })` (`ws-query-worker.mjs` ~L693). |
+| Auth / endpoint | Worker child inherits `process.env` wholesale; `ws-server` sets `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_URL` and (for ARK) inherits `ANTHROPIC_AUTH_TOKEN` (Bearer). One gateway, one key. |
+| Per-request / per-session model | **None.** No `model` field on the inbound `chat` message; no `model` column on `agent_session`. |
+| UI | The "GLM 5.0" text in `chat-composer.tsx` (~L468) is a **hardcoded, non-interactive badge**. Nothing is sent to the backend. |
+| Usage tracking | `recordUsage()` already captures `modelUsage` from the SDK `result` event (post-run) → `/api/usage`. Telemetry only, not selection. |
+| **Proven plumbing pattern to mirror** | `skillSlug` and `permissionTier` already flow **frontend store → ws-adapter `chat` message → ws-server `handleChat` → worker request**. A `model` field follows the exact same path. |
+
+**Net:** model selection has **zero** effect today. The hard parts (a registry,
+the picker, per-request routing) are greenfield, but the plumbing template and a
+fresh-child-process-per-request architecture make it tractable.
+
+---
+
+## 2. The constraint that shapes everything: we drive the **Claude Agent SDK**, not a raw chat client
+
+LibreChat/Lobe build per-provider HTTP clients (OpenAI/Anthropic/Google factories).
+**We can't** — our "client" is the Agent SDK, which spawns a CLI subprocess that
+talks **only the Anthropic-compatible protocol** and reads its target from env:
+
+- `ANTHROPIC_BASE_URL` (+ `ANTHROPIC_API_URL`) — the gateway
+- `ANTHROPIC_AUTH_TOKEN` (Bearer, ARK) **or** `ANTHROPIC_API_KEY` (x-api-key, native)
+- `ANTHROPIC_MODEL` (+ the `model` option on `query()`)
+- alias models: `ANTHROPIC_DEFAULT_SONNET_MODEL` / `…_OPUS_MODEL` / `…_HAIKU_MODEL`,
+  `CLAUDE_CODE_SUBAGENT_MODEL` (used by the SDK for sub-agents + the cheap background tier)
+
+**Consequence — two tiers of "multi-model":**
+
+- **A. Same-gateway, many models (EASY, the MVP).** ARK `/api/coding` already serves
+  several models behind **one base URL + one key** (today: `glm-5.1` main,
+  `doubao-seed-2.0-lite` haiku; `doubao-seed-2.0-code` validated on `/api/coding/v3`).
+  Switching model = pass a different `model` string. **No key/baseURL change.**
+- **B. Cross-gateway / cross-provider (LATER).** e.g. ARK **+** Zhipu native
+  (`open.bigmodel.cn/api/anthropic`) **+** native Anthropic. Each has its own
+  base URL + token + model namespace. Requires **per-request env routing** (below).
+  Still no 0.3.x needed — because the worker is a fresh child process, `ws-server`
+  can set that child's `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_MODEL`
+  per request based on the chosen model's provider.
+
+> **Hard limit to call out:** the SDK speaks Anthropic-protocol only. **OpenAI-only**
+> providers cannot be used directly — they'd need an Anthropic-compatible gateway/shim
+> in front. So "multi-model" here = "multi-model across Anthropic-compatible gateways."
+> (Our `/api/coding/v3` OpenAI path is for the changedoc CLI, **not** the agent SDK.)
+
+---
+
+## 3. The key enabler: per-request worker env override
+
+The single most important design point. `handleChat` spawns the worker with
+`workerEnv = { ...process.env }` and then overrides specific keys. Today it overrides
+`ANTHROPIC_MODEL` from a startup constant. We change it to override
+`ANTHROPIC_MODEL` (always) and — for mode B — `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_URL`
+/ `ANTHROPIC_AUTH_TOKEN` (or `ANTHROPIC_API_KEY`) **from the selected model's registry
+entry**. This gives full provider routing with the pinned SDK and no protocol work.
+
+---
+
+## 4. Proposed architecture
+
+### 4.1 Model registry (the curated list)
+A small, curated set the team configures — **not** a fetched marketplace (matches the
+product's "curated capabilities" principle, like Skills).
+
+Per-entry fields (borrowed from LibreChat's spec + Lobe's provider card, trimmed):
+
+```
+id            // stable key sent over the wire, e.g. "glm-5.1", "doubao-seed-2.0-code"
+label         // display name, e.g. "GLM 5.1", "Doubao Code 2.0"
+model         // the string the gateway expects (often == id)
+provider      // "ark" | "zhipu" | "anthropic" | "<custom>"
+default?      // the one selected when none chosen
+enabled?      // hide without deleting
+tags?         // ["coding","fast","cheap","vision"] for UI hints
+// provider routing (mode B only; omit for same-gateway mode A):
+baseUrlEnv?   // name of the env var holding the gateway base URL
+tokenEnv?     // name of the env var holding the Bearer token (ARK) ...
+apiKeyEnv?    // ... or x-api-key (native Anthropic)
+// optional alias remap when this model implies different sub-agent/background models:
+aliases?      // { sonnet, opus, haiku, subagent }
+```
+
+**Where it lives — phased:**
+- **MVP:** a server-side config (env-derived or a checked-in `model-registry` TS/JSON
+  of curated entries, all `provider: "ark"`). No DB migration. Secrets stay as env var
+  *names* in the registry; values stay outside the repo.
+- **v2:** a DB table + admin UI, mirroring the **Skills catalog** model (DB = truth,
+  curated seed via `migrate`, admin add/remove). Reuse that proven pattern.
+
+### 4.2 Selection plumbing (mirror `skillSlug` / `permissionTier` exactly)
+1. `src/lib/chat-session-store.ts`: add `selectedModelId` + setter (default = registry default).
+2. `src/claude/adapters/ws-adapter.ts`: add `model?: string` to the `chat` `InboundMessage`;
+   include `model: store.selectedModelId` in the `send({ type:'chat', … })`.
+3. `ws-server.mjs` `handleChat`: accept `model`, **validate against the registry**
+   (reject/clamp unknown → default), thread into the worker spawn.
+4. `ws-query-worker.mjs`: already passes `config.model` to `query()` — just ensure the
+   resolved model flows in (via request payload or env, matching the skillSlug path).
+
+### 4.3 Worker env routing (mode B)
+In `handleChat`, after resolving the registry entry: build `workerEnv` overriding
+`ANTHROPIC_MODEL` and (if the entry carries provider routing) `ANTHROPIC_BASE_URL` /
+`ANTHROPIC_API_URL` / the token var, reading values from the named env vars. For mode A
+(all-ARK) this collapses to just `ANTHROPIC_MODEL`.
+
+### 4.4 Sub-agent / alias models
+The SDK uses `ANTHROPIC_DEFAULT_*` + `CLAUDE_CODE_SUBAGENT_MODEL` internally.
+- **MVP:** leave the alias env as deployed (the gateway default). Switching the *main*
+  model only changes the top-level `query({model})`.
+- **v2:** let a registry entry's `aliases` remap these per-request (needed if the chosen
+  model lives on a *different* provider than the deployed aliases).
+
+### 4.5 Session persistence
+Add a `model` column to `agent_session` so resume reuses the last model and the picker
+reflects it. Optional for MVP (store-only is fine first); do it with the v2 DB work.
+LibreChat stores model **per message** — worth adopting later for cost attribution
+(we already have `modelUsage` telemetry to pair with it).
+
+### 4.6 UI picker
+Replace the cosmetic badge in `chat-composer.tsx` with a real dropdown:
+- options from the registry (a `GET` server fn, or a small static import for MVP);
+- writes `selectedModelId` to the store; disabled while a run is active;
+- mirror the existing **permission-tier selector** UX in the composer.
+
+### 4.7 Credentials / keys
+Per-provider tokens are env vars **outside the repo** (e.g. `~/oxygenie-deploy/secrets.env`);
+the registry references their *names*, `ws-server` reads values at spawn. This is the
+"per-capability key split" the roadmap calls for — no single-key blast radius once
+mode B lands.
+
+---
+
+## 5. Phased scope
+
+| Phase | Scope | Effort |
+|---|---|---|
+| **MVP (tomorrow)** | Same-gateway (ARK) model switch: registry config (curated ARK models) + `model` plumbing (store→adapter→ws-server→worker, validated) + real composer picker + `query({model})`. **No** baseURL/token switching, **no** DB. | S–M |
+| **v2** | Session/message persistence (`model` column), DB-backed registry + admin curation UI (mirror Skills), alias remap. | M |
+| **Phase 4 stretch** | Cross-provider routing (mode B per-request env), provider failover/fallback, per-capability key split, model capability gating (e.g. only vision models for image tasks). | M–L |
+
+---
+
+## 6. Concrete change list (MVP)
+
+- `src/config/model-registry.ts` (**new**) — curated entries + `getModels()` / `resolveModel(id)` + default.
+- `src/lib/chat-session-store.ts` — `selectedModelId` state + setter.
+- `src/claude/adapters/ws-adapter.ts` — `model?` on `chat` `InboundMessage`; send it.
+- `ws-server.mjs` — `handleChat` accepts + validates `model`; set `workerEnv.ANTHROPIC_MODEL` from it (replacing the startup constant).
+- `ws-query-worker.mjs` — ensure resolved model reaches `query({ options:{ model } })` (largely already there).
+- `src/components/claude-chat/chat-composer.tsx` — swap the static badge for a registry-driven `<select>`; wire to the store.
+- (optional) a `listModels` server fn if the registry should be server-owned.
+
+---
+
+## 7. Risks & open questions
+
+1. **Does ARK `/api/coding` (Anthropic proto) serve every model we want behind one key?**
+   Confirmed for `glm-5.1` + `doubao-seed-2.0-lite` (deployed) and `doubao-seed-2.0-code`
+   (validated on `/api/coding/v3`). **Verify each MVP model on `/api/coding` (the SDK path)**
+   before listing it — the OpenAI `/v3` validation doesn't prove the Anthropic path.
+2. **Alias/sub-agent coupling.** If a chosen model's provider differs from the deployed
+   `ANTHROPIC_DEFAULT_*`, sub-agents/background calls may still hit the old provider until
+   v2 alias remap. Keep MVP same-gateway to avoid this.
+3. **Resume + model change mid-session.** Decide whether changing model mid-conversation
+   is allowed (likely yes; record per-message later). The SDK resume carries its own session;
+   a different model on resume is generally fine over the same gateway.
+4. **No OpenAI-only providers** without an Anthropic-compatible shim (§2). Set expectations.
+5. **Structured outputs flag.** `ENABLE_STRUCTURED_OUTPUTS` stays off; ensure model switch
+   doesn't re-trigger the Stop-hook path.
+
+---
+
+## 8. Prior art (consulted; borrow, don't copy)
+
+- **LibreChat** (`packages/data-provider/src/models.ts`, `librechat.example.yaml`):
+  two-tier spec→preset; YAML/env custom endpoints with `${ENV}` injection; **per-message
+  model+endpoint logging**; endpoint-type sniffing. *Borrow:* env-named credentials in a
+  declarative registry, per-message model tracking.
+- **Lobe Chat** (`packages/model-bank/.../modelProvider.ts`, `src/store/aiInfra`,
+  `openaiCompatibleFactory`): provider cards; runtime `resolveRuntimeProvider` routing custom
+  → compat runtime; Zustand per-session selection. *Borrow:* clean registry + a request-time
+  "resolve provider → routing config" helper; store-held selection.
+- **Skip:** their 50–70 provider enums and per-provider HTTP client factories — we have one
+  SDK and (for now) one Anthropic-compatible gateway. Our "factory" is just choosing the
+  worker child's env.
+
+**Verdict for OxyGenie:** a tiny curated registry + the proven per-request plumbing +
+per-request worker-env routing gives full multi-model (and later multi-provider) on the
+pinned SDK with no protocol work. Ship mode A (same-gateway) first; the env-routing seam
+makes mode B a later, additive change.


### PR DESCRIPTION
## What

Closes out today's session and tees up tomorrow's owner-set focus — **multi-model selection** — with a grounded research + phased implementation plan.

## Added

**`docs/project/research/2026-06-multi-model-support-research.md`** — based on a fresh code audit + reference study (LibreChat / Lobe Chat):
- **Current state**: model = single startup `ANTHROPIC_MODEL`; the "GLM 5.0" badge is cosmetic; nothing flows frontend→worker. But `skillSlug`/`permissionTier` is a proven per-request plumbing template, and the worker is a fresh child process per request.
- **The constraint that shapes it**: we drive the **Claude Agent SDK (pinned 0.2.112)**, which speaks **Anthropic-protocol only** → "multi-model" = multi-model across **Anthropic-compatible gateways** (OpenAI-only providers would need a shim).
- **Key enabler**: per-request **worker-env override** (`ANTHROPIC_MODEL`/`BASE_URL`/`AUTH_TOKEN`) gives full provider routing with no 0.3.x features.
- **Architecture**: curated model registry → selection plumbing (mirror skillSlug) → worker-env routing → sub-agent/alias handling → session persistence → real composer picker → per-provider keys.
- **Phased scope**: **MVP (tomorrow) = same-gateway (ARK) model switch** (no baseURL/key change, no DB); v2 = DB registry + admin + persistence; Phase 4 = cross-provider routing/failover.
- File-level change list, risks/open questions, and a borrow-vs-skip verdict vs LibreChat/Lobe.

## Updated

- **ROADMAP**: Multi-model **LATER → NEXT** (owner focus 2026-06-07) + research pointer; LATER trimmed to the Phase-4 stretch.
- **STATUS**: new 2026-06-07 decision-log entry (session close + plan); changedoc row → "wired to ARK" (generic `OPENAI_API_KEY` secret set + curl-validated, #118/#120); new NEXT multi-model backlog row.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)