### PR TITLE
docs: multi-model full spec (PRD rev.3) + implementation context pack

### DIFF
--- a/docs/project/prd/2026-06-multi-model-switching-prd.md
+++ b/docs/project/prd/2026-06-multi-model-switching-prd.md
@@ -1,231 +1,244 @@
 # PRD：多模型切换（Anthropic 协议 · 跨账号 · 配置→探活→可切 · 管理看板）
 
-> 日期：2026-06-07（rev.2，owner 决策已并入） ｜ 状态：草案待评审
-> 关联：`research/2026-06-multi-model-support-research.md`（调研 + 现状代码审计）、`ROADMAP.md`（NEXT · 多模型）、`prd/2026-06-skills-integration-prd.md`（同构能力中心 + DB enablement 模式）、`VISION.md`、`CLAUDE.md`（SDK 钉死 0.2.112 / ARK）。
-> 参考实现（借思路不抄码）：**CraftAgent**（`references/famous_ai-chat_projects/craft-agents-oss`，`LlmConnection` + 配置/凭据分离 + 懒探活 + 每会话锁定）、**Lobe Chat**（admin 配置面板 + provider/model 表 + 手动 health check + env 默认与 DB 覆盖合并）。
+> 日期：2026-06-07（**rev.3 · 完整版 · 调研完成,据此实施**） ｜ 状态：定稿待实施
+> 关联：**`research/2026-06-multi-model-context-pack.md`（实施资料包 = 代码锚点 + SDK 契约 + 参考digest + env 清单,实施直接照它）**、`research/2026-06-multi-model-support-research.md`（初版调研）、`prd/2026-06-skills-integration-prd.md`（同构:DB catalog + enablement + admin + BullMQ + seed-on-migrate）、`ROADMAP.md`、`VISION.md`、`CLAUDE.md`。
+> 参考实现（借思路不抄码,详见资料包）：**CraftAgent**（`LlmConnection` + 配置/凭据分离 + 懒探活 + 每会话锁定）、**LobeChat**（admin 配置面板 + provider/model 表 + env↔DB 合并 + 手动 check + `${ENV}` 注入）、**LibreChat**（custom-endpoint Zod 校验 + `${ENV}` + 三档 model-list + 每消息记 model/endpoint）、**claude-agent-kit**（`query({options:{env}})` 按请求合并 env 的路由法）。
 
-## 0. Owner 决策（2026-06-07，已拍板 → 本 rev 据此定稿）
+## 0. Owner 决策（2026-06-07 已拍板）
 
-1. **探活是后端功能,默认 6 小时一次(可配),不需要高频。**
-2. **发送时选了不健康的模型 → 直接报错**(不静默回退)。
-3. **配置落入 `.env`**(沿用密钥纪律);但 **admin 需要一个看板看到模型健康度**。
-4. **选择粒度 = 每个会话**。
-5. **探活方式 = 直连 `/v1/messages`**。
-6. **多模型不只是"被选择",还要能"被配置(后台)"**:配置多个**模型来源**、配置**模型 model ids**、**检测可用** —— 这三件是"可选择"的前提。
+1. 探活 = **后端,默认 6h 一次(可配)**,不高频。
+2. 发送时选了不健康模型 → **直接报错**(不静默回退)。
+3. 配置:**密钥落 `.env`**;**admin 在看板看健康度**;且**多模型可在后台配置**(来源 + model ids + 检测可用)。
+4. 选择粒度 = **每会话**。
+5. 探活 = **直连 `/v1/messages`**。
+6. **完整版实施**(非 MVP 裁剪):多模型可**被配置(后台)**,配置即"可选择"的前提。
 
-> 一句话模型:**配置(来源 + model ids)→ 探活(检测可用)→ 看板(健康可见)→ 用户每会话选一个 healthy 的 → 按请求路由到对应连接运行。**
+> 据 #6 + #3,**完整版定调(本 rev 锁定,原 §13-D1 已决为"全")**:
+> **定义(连接 + model ids)= DB 真相,admin 后台 CRUD**;**首次从 `.env` 种子引导**(seed-on-migrate,照搬 Skills);**密钥永远只在 `.env`,DB/前端/日志只存/只见 `tokenEnv` 名**。一句话流程:**配置(后台/.env 种子)→ 探活(6h 检测)→ 看板(健康可见)→ 用户每会话选 healthy → 按请求路由到对应连接运行。**
 
 ---
 
-## 1. 背景与现状（代码审计已确认）
+## 1. 背景与现状（代码审计已确认,锚点见资料包 §B）
 
-- **模型今天是部署期单值**：`ws-server.mjs` 启动读 `ANTHROPIC_MODEL`,spawn worker 时塞进子进程 env;worker `query({ options:{ model } })`。所有会话共用一个模型。
-- **UI 是死徽章**：`chat-composer.tsx` 的「GLM 5.0」纯展示,无任何后端效果。
-- **已有可复用链路**:`skillSlug` / `permissionTier` 已走通 **store → ws-adapter `chat` 消息 → ws-server `handleChat` → worker**。model 照抄。
-- **关键使能点**:worker 是**每请求新子进程**,`ws-server` 可**按请求覆写** `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_URL` / `ANTHROPIC_AUTH_TOKEN`(或 `ANTHROPIC_API_KEY`)/ `ANTHROPIC_MODEL`。**这就是跨账号切换的全部底层机制**,无需 SDK 0.3.x。
-- **协议约束**:驱动的是 **Claude Agent SDK(钉死 0.2.112)**,只说 **Anthropic Messages 协议** → "多模型"= **跨 Anthropic 兼容网关的多模型**;纯 OpenAI 厂商需自备 Anthropic 兼容代理(本期不做)。
+- **模型今天是部署期单值**：`ws-server.mjs` 启动读 `ANTHROPIC_MODEL`(L107),spawn worker 时塞 `workerEnv.ANTHROPIC_MODEL`(L1106-1117);worker `query({ options:{ model } })`(`ws-query-worker.mjs` L689-732)。所有会话共用一个。
+- **UI 死徽章**：`chat-composer.tsx` 的「GLM 5.0」纯展示。
+- **已有可复用链路**:`skillSlug`/`permissionTier` 走通 **store(selectedTier)→ ws-adapter `chat`(L845-852)→ ws-server `handleChat`(L1027,case L1469-1484)→ worker**。model 照抄。
+- **关键使能点**:worker 是**每请求新子进程**;ws-server 可**按请求设其 env**(或经 SDK `query({options:{env}})`,claude-agent-kit 同款)。这是跨账号路由的全部底层机制,**无需 0.3.x**。
+- **协议约束**:驱动 **Claude Agent SDK(钉死 0.2.112,最后一个 bundled-JS 版)**,只说 **Anthropic Messages 协议** → 多模型 = **跨 Anthropic 兼容网关的多模型**;纯 OpenAI 厂商需自备 Anthropic 兼容代理(本期不做)。
 
 ---
 
 ## 2. 目标 / 非目标
 
 **目标**
-- G1 用户能在 composer **按会话选择本次运行的模型**,替代单一 `ANTHROPIC_MODEL`。
-- G2 候选模型可来自**多个连接(不同 baseURL + 不同 token/账号)**,只要是 Anthropic 协议。
-- G3 **配置(后台)**:可配置多个**模型来源**与每个来源下的 **model ids**(v1 经 `.env`,v2 经 DB admin)。
-- G4 **检测可用**:后端 **6h 周期探活**(可配 + 可手动),判定每个模型"是否能用"。
-- G5 **管理看板**:admin 能在看板看到所有连接/模型的**健康度 + 上次探活时间 + 失败原因**,并能 **enable/disable** 单个模型。
-- G6 **菜单只列当前能用的(enabled && healthy)**;选了不健康的发送时报错。
-- G7 切换对**主模型 + 子代理/后台档**一致生效(同连接 alias),不串账号。
-- G8 **密钥不出仓库、不进前端、不进 DB**(只在 `.env`/`secrets.env`,按名引用)。
+- G1 用户 composer **按会话选模型**,替代单一 `ANTHROPIC_MODEL`。
+- G2 候选模型来自**多个连接(不同 baseUrl + token/账号)**,只要 Anthropic 协议。
+- G3 **后台配置**:admin 在 `/admin/models` **CRUD 连接 + model ids**(DB),`.env` 提供种子 + 密钥。
+- G4 **检测可用**:后端 **6h 周期探活**(可配 + 手动),判定每模型"能用"。
+- G5 **看板**:admin 看每连接/模型的**健康 + 上次探活 + 失败原因 + 延迟**,可 enable/disable + 立即重测。
+- G6 **菜单只列 enabled && healthy**;选不健康发送时报错。
+- G7 切换对**主模型 + 子代理/后台档一致**(同连接 alias),不串账号。
+- G8 **密钥不出 `.env`**(不入 DB/前端/日志/配置 JSON,只按 `tokenEnv` 名引用)。
 
 **非目标(本期不做)**
-- N1 失败自动 failover / 负载均衡(Phase 4)。
-- N2 OpenAI-only 厂商协议转译(Phase 4 评估)。
-- N3 v1 不做"admin 在网页新增/删除**来源**"(来源仍走 `.env`);admin 只**看健康 + 改 enable**。**v2** 再上 DB 全量 CRUD(照搬 Skills 目录)。详见 §13-D1。
-- N4 按能力门控(只让视觉模型接图片)(Phase 4)。
-- N5 计费按模型精细归集(已有 `modelUsage` 遥测,后续配 per-message 记录)。
+- N1 失败自动 failover(SDK 有 `fallbackModel` 选项,Phase 4 接)。
+- N2 OpenAI-only 协议转译(Phase 4 评估)。
+- N3 从 provider `/models` 动态拉取模型列表(LibreChat `fetch:true`)——本期**手动列 model ids**(ARK 等网关 `/models` 不一定可靠,且要精选);留 Phase 4。
+- N4 按能力门控(视觉模型才接图片)(Phase 4)。
+- N5 per-message 模型记录(成本归集)——有 `modelUsage` 遥测垫底,v-next 接。
 
 ---
 
-## 3. 数据模型（连接 / 模型 / 运行期健康）
+## 3. 数据模型
 
-借 CraftAgent 的 `LlmConnection`(连接) + LibreChat 的 spec→preset 两层。
+借 CraftAgent `LlmConnection`(连接) + 凭据分离。**定义在 DB(admin CRUD),密钥在 `.env`**。
 
-### 3.1 Connection（连接 = 一个 Anthropic 兼容端点 + 一份凭据 = 一个账号/网关）
+### 3.1 `model_connection`（连接 = 端点 + 一份凭据 = 一个账号/网关；DB,无密钥）
 ```
-id            # 稳定键,如 "ark-coding"
-label         # 展示名
-baseUrl       # 如 https://ark.cn-beijing.volces.com/api/coding
-authStyle     # "bearer"(ARK) | "x-api-key"(原生 Anthropic)
-tokenEnv      # 持密钥的【环境变量名】,如 ARK_AUTH_TOKEN(值在 .env,不入配置 JSON/DB/前端)
-anthropicVersion?  # 默认 "2023-06-01"
-aliases?      # 子代理/后台档默认模型 { sonnet, opus, haiku, subagent }
+id            text pk   # 稳定键,如 "ark-coding"
+label         text      # 展示名
+baseUrl       text      # 如 https://ark.cn-beijing.volces.com/api/coding(不带 /v1)
+authStyle     text      # "bearer" | "x-api-key"
+tokenEnv      text      # 持密钥的【环境变量名】,如 ARK_AUTH_TOKEN(值在 .env)
+anthropicVersion text   # 默认 "2023-06-01"
+customHeaders jsonb?    # 可选,网关路由头 → 设 ANTHROPIC_CUSTOM_HEADERS
+aliasOpus/aliasSonnet/aliasHaiku/aliasSubagent text?  # 子代理/后台档模型(同账号)
+sort int, createdAt, updatedAt
 ```
-> 跨账号 = 多个 Connection,各自 `baseUrl` + `tokenEnv`。**凭据与配置分离**(CraftAgent 实践):配置可读/可日志,密钥单独按名取。
 
-### 3.2 Model（模型 = 归属某连接）
+### 3.2 `model_definition`（模型 = 归属连接；DB,admin CRUD）
 ```
-id            # 全局唯一,前端/线上传输用,如 "ark/glm-5.1"
-label         # 展示名
-connection    # 引用 Connection.id
-model         # 网关认的模型串,如 "glm-5.1"
-tags?         # ["coding","fast","cheap","vision"] 仅 UI 提示
-aliases?      # 覆盖连接级 alias(可选)
+id            text pk   # 全局唯一,线上传输用,如 "ark/glm-5.1"
+label         text
+connectionId  text fk → model_connection.id
+model         text      # 网关认的模型串,如 "glm-5.1"
+tags          jsonb?    # ["coding","fast"] 仅 UI 提示
+enabled       boolean default true
+isDefault     boolean default false  # 全局默认(须 healthy,否则回退首个 healthy)
+sort int, createdAt, updatedAt
 ```
-> `enabled` 不放静态配置,而在 **DB `model_enablement`**(admin 可在看板即时改,无需改 `.env`/重启)。默认启用。
 
-### 3.3 运行期健康（由探活产生,落 DB `model_health`,看板 + 菜单共读）
+### 3.3 `model_health`（探活产生；看板 + 菜单共读）
 ```
-modelId, health("healthy"|"unhealthy"|"unknown"), lastProbeAt, probeError?(network|auth|model|timeout|http_xxx), latencyMs?
+modelId text pk fk → model_definition.id
+health  text       # "healthy" | "unhealthy" | "unknown"
+lastProbeAt timestamp
+probeError text?   # network|auth|model|timeout|http_4xx|http_5xx
+latencyMs int?
 ```
+
+> **种子(seed-on-migrate,照搬 Skills)**:`.env` 的 `OXY_MODELS_SEED`(JSON)首次写入 `model_connection`+`model_definition`(幂等,存在则跳过)。之后以 DB 为准,admin 改 DB。`.env` 仍是密钥与"开箱即用"来源。
 
 ---
 
-## 4. 在哪配置 / 如何配置（owner 决策 #3、#6）
+## 4. 配置：在哪 / 怎么配（owner #3、#6）
 
-### 4.1 来源 + model ids → `.env`（仓库内只更新 `.env.example`）
-配置即 `.env` 的几个变量(非密钥部分是 JSON,密钥是独立变量,按 `tokenEnv` 引用):
-
+### 4.1 `.env`（仓库内只改 `.env.example`）= 密钥 + 种子
 ```bash
-# —— 多模型配置(非密钥;可被看板读取/展示) ——
-OXY_MODEL_DEFAULT="ark/glm-5.1"      # 默认模型 id(须最终解析为 healthy,否则回退首个 healthy)
-OXY_MODEL_CONNECTIONS='[
-  {"id":"ark-coding","label":"火山 ARK","baseUrl":"https://ark.cn-beijing.volces.com/api/coding","authStyle":"bearer","tokenEnv":"ARK_AUTH_TOKEN","aliases":{"haiku":"doubao-seed-2.0-lite"}},
-  {"id":"zhipu","label":"智谱 GLM","baseUrl":"https://open.bigmodel.cn/api/anthropic","authStyle":"bearer","tokenEnv":"ZHIPU_AUTH_TOKEN"}
-]'
-OXY_MODELS='[
-  {"id":"ark/glm-5.1","label":"GLM 5.1","connection":"ark-coding","model":"glm-5.1","tags":["general"]},
-  {"id":"ark/doubao-code","label":"Doubao Code 2.0","connection":"ark-coding","model":"doubao-seed-2.0-code","tags":["coding"]},
-  {"id":"zhipu/glm-5.1","label":"GLM 5.1(智谱直连)","connection":"zhipu","model":"glm-5.1","tags":["general"]}
-]'
-MODEL_PROBE_INTERVAL_MS=21600000     # 探活周期,默认 6h(owner #1)
-
-# —— 密钥(按 tokenEnv 名;值仅此处,绝不入 JSON/DB/前端) ——
+# 密钥(按 tokenEnv 名;值仅此;绝不入 DB/前端/日志/JSON)
 ARK_AUTH_TOKEN=...
 ZHIPU_AUTH_TOKEN=...
+
+# 可选 bootstrap 种子(首启写入 DB;之后 admin 在看板维护)
+OXY_MODELS_SEED='{
+  "default":"ark/glm-5.1",
+  "connections":[
+    {"id":"ark-coding","label":"火山 ARK","baseUrl":"https://ark.cn-beijing.volces.com/api/coding","authStyle":"bearer","tokenEnv":"ARK_AUTH_TOKEN","aliasHaiku":"doubao-seed-2.0-lite"},
+    {"id":"zhipu","label":"智谱 GLM","baseUrl":"https://open.bigmodel.cn/api/anthropic","authStyle":"bearer","tokenEnv":"ZHIPU_AUTH_TOKEN"}
+  ],
+  "models":[
+    {"id":"ark/glm-5.1","label":"GLM 5.1","connection":"ark-coding","model":"glm-5.1","isDefault":true,"tags":["general"]},
+    {"id":"ark/doubao-code","label":"Doubao Code 2.0","connection":"ark-coding","model":"doubao-seed-2.0-code","tags":["coding"]},
+    {"id":"zhipu/glm-5.1","label":"GLM 5.1(智谱)","connection":"zhipu","model":"glm-5.1","tags":["general"]}
+  ]
+}'
+MODEL_PROBE_CRON="0 */6 * * *"     # 6h 探活(owner #1),BullMQ repeat,可配
 ```
-> 说明:连接/模型定义放 **非密钥 JSON 变量**(可安全送看板);token 只在独立变量,服务端按 `tokenEnv` 取。`.env` 是单一配置入口(owner #3)。**仓库内只改 `.env.example`,不改真实 `.env`。**
+- **`${ENV}` 原则(LibreChat)**:配置只存 `tokenEnv` 名;密钥按名在**后端**解析,**永不下发前端**。
+- **Zod 严校验(LibreChat)**:种子/admin 写入都过 Zod;坏引用(未知 connection)、重复 id、缺字段 → 拒绝并报清晰错误。
 
-### 4.2 admin 可改的部分 → DB（看板,无需重启）
-- **`model_enablement`**(admin 改):某 model 的 `enabled`。
-- **`model_health`**(探活写):健康度 + 时间 + 原因。
-- 这两张表让"配置 model ids 的**开关**"和"健康可见"在看板即时生效,而**来源/凭据仍在 `.env`**(v1 不在网页改来源,见 §13-D1)。
-
-### 4.3 加载与合并
-`ws-server` + web app 启动:读 `.env` 的 JSON → 解析连接/模型 → 与 DB `model_enablement` 合并(env 定义 + DB 开关)→ 与 DB `model_health` 合并(展示/门控)。**env 决定"有什么",DB 决定"开没开 + 健不健康"**(对齐 Lobe 的 env-默认 + DB-覆盖思路,但密钥永不入 DB)。
+### 4.2 DB = 运行期真相,admin 后台 CRUD
+- `/admin/models` 可**增删改**连接与 model id、改 `enabled`/`isDefault`、设 `tokenEnv`/baseUrl/authStyle/alias。
+- **新增连接的密钥**:UI 只填 `tokenEnv` 名;**值要由有服务器权限者写进 `.env`**(单组织可信团队可接受;符合"密钥出仓库/不入 DB")。UI 即时提示"该 tokenEnv 当前是否已解析到值"。
+- env(种子)+ DB 合并:**DB 决定有什么/开没开;env 提供密钥 + 首启种子**(对齐 Lobe env-默认↔DB-覆盖,但密钥永在 env)。
 
 ---
 
-## 5. 如何测试（探活 —— owner #1、#5）
+## 5. 探活（owner #1、#5；6h 后端）
 
-**探活 = 用与 SDK 一致的 Anthropic 协议,向该模型的连接发最小请求。**
-
-- 请求:`POST {connection.baseUrl}/v1/messages`,headers `anthropic-version` + 按 `authStyle` 的 `Authorization: Bearer`/`x-api-key`,body `{model, max_tokens:1, messages:[{role:"user",content:"ping"}]}`。
-- 判定:**200 + 合法 message → healthy**(端点可达 + 凭据有效 + 模型名被接受 = 真"能用");401/403→`unhealthy(auth)`;400/404→`unhealthy(model)`;DNS/连接→`network`;超时→`timeout`;**429→视为 healthy**(限流但可用)。
-- **周期 = 6h,可配**(`MODEL_PROBE_INTERVAL_MS`,owner #1);**后端**跑(ws-server 定时器,或 BullMQ 可重复任务——已具 Redis/BullMQ),结果写 `model_health`。另提供 **admin 手动"立即重测"**(单个/全部)。
-- 与 changedoc 区分:changedoc 用 ARK 的 **OpenAI 协议 `/api/coding/v3`**;**探活走 Anthropic `/v1/messages`**(SDK 真实路径)。
-- 密钥只在后端用,**看板/前端只见 health/label/id**,绝不下发 token。
+**探活 = 与 SDK 一致的 Anthropic 协议最小请求。**
+- `POST {connection.baseUrl}/v1/messages`,headers:`content-type: application/json` + `anthropic-version: {anthropicVersion}` + 按 `authStyle` 的 **`Authorization: Bearer`** 或 **`x-api-key`**(二选一)+ 可选 `customHeaders`;body `{model, max_tokens:1, messages:[{role:"user",content:"ping"}]}`。
+- 判定:**200 → healthy**(可达 + 鉴权 + 模型被接受 = 真"能用");401/403 → `auth`;**404(原生 Anthropic)/400(部分网关)指向模型 → `model`**(⚠️ ARK 实测确认用哪个码);DNS/连接 → `network`;超时 → `timeout`;**429 → 视为 healthy**(限流可用)。
+- **周期 = `MODEL_PROBE_CRON`(默认 6h)**,跑在 **`src/worker` BullMQ repeat job**(同 `daily-credit-refill` 写法:`repeat:{pattern}`+稳定 `jobId`)→ 写 `model_health`。另 **admin 手动"立即重测"**(单/全)。
+- 走 **`/v1/messages`**(SDK 真实路径),区别于 changedoc 的 ARK **OpenAI `/api/coding/v3`**。
+- **仅后端**用密钥;看板/前端只见 health/label/id,**绝不下发 token**。
 
 ---
 
-## 6. 什么状态下显示在可切换菜单里（owner #2、#6）
+## 6. 菜单可见/可切（owner #2、#6）
 
-| enabled(DB) | health(最近一次探活) | 用户菜单 |
+| enabled(DB) | health(最近探活) | 用户菜单 |
 |---|---|---|
-| false | — | **不显示** |
+| false | — | 不显示 |
 | true | `healthy` | **显示 + 可选** ✅ |
-| true | `unknown`(从未探/探活中) | "检测中…",不可选 |
-| true | `unhealthy` | **置灰 + 原因**(默认);`hideUnhealthy=true` 时隐藏 |
+| true | `unknown`(未探/探活中) | "检测中…",不可选 |
+| true | `unhealthy` | **置灰 + 原因**(默认);`hideUnhealthy=true` 隐藏 |
 
-- **可选 = enabled && healthy**。
-- **默认模型**须 healthy,否则回退首个 healthy 并提示。
-- **发送时再校验一次**:若所选 model 已变 unhealthy/disabled → **直接报错**(owner #2),前端提示换一个(不静默改模型)。
+- **可选 = enabled && healthy**。默认模型须 healthy,否则回退首个 healthy 并提示。
+- **发送时再校验**:所选 model 已 unhealthy/disabled → **直接报错**(owner #2),前端提示换一个,**不静默改**。
 
 ---
 
 ## 7. 管理看板（admin · owner #3、#5、#6）
 
-- 入口:`/admin/models`(照搬 `/admin/skills` 的 admin 模式)。
-- 展示:按 Connection 分组列出模型 → 每行 **健康圆点 + 上次探活时间 + 失败原因 + 延迟**;连接级显示 baseUrl/authStyle(**不显示 token**)。
-- 操作:**enable/disable** 单模型(写 `model_enablement`);**立即重测**(单个/全部,触发 §5 探活)。
-- v1 只读"来源/凭据"(改来源去 `.env`);**v2** 加来源/model id 的网页 CRUD(DB,密钥仍 env 引用)。
-- 数据走 server fn(`listModelsAdmin` / `setModelEnabled` / `reprobeModel`),遵守项目"Server Functions 优先、禁 REST"。
+- 入口 `/admin/models`(照搬 `/admin/skills` + `requireAdmin`,`skills.server.ts` L76-101)。
+- 列表按连接分组:模型行显示**健康圆点 + 上次探活 + 失败原因 + 延迟**;连接显示 baseUrl/authStyle/`tokenEnv`(**不显示 token 值**,只显示"已解析/未解析")。
+- 操作:**CRUD 连接/模型**、改 `enabled`/`isDefault`、**立即重测**(单/全)。
+- server fn(禁 REST,项目铁律):`listModelsAdmin` / `upsertConnection` / `deleteConnection` / `upsertModel` / `deleteModel` / `setModelEnabled` / `setDefaultModel` / `reprobeModel(s)`,全部 `requireAdmin`。
 
 ---
 
-## 8. 选择 → 运行（端到端 · owner #4 每会话）
+## 8. 选择 → 运行（端到端 · owner #4 每会话；env 契约见资料包 §C）
 
-1. **前端**:`chat-session-store` 增 `selectedModelId`(默认=`OXY_MODEL_DEFAULT`,须 healthy);composer 下拉读"可选模型"(server fn/WS),写 store;运行中禁用。**每会话**保留选择(store + 持久到 `agent_session.model`,resume 回显)。
-2. **发送**:`ws-adapter` 的 `chat` `InboundMessage` 增 `model?: string`,带 `model: selectedModelId`(照抄 skillSlug/permissionTier)。
-3. **ws-server `handleChat`**:
-   - 解析 model → Connection;**校验 enabled && healthy**;不满足 → **报错回前端**(owner #2)。
-   - 构造 `workerEnv`:`ANTHROPIC_BASE_URL`+`ANTHROPIC_API_URL`=baseUrl;按 `authStyle` 写 `ANTHROPIC_AUTH_TOKEN` **或** `ANTHROPIC_API_KEY`(**互斥,清掉另一个**);`ANTHROPIC_MODEL`=model;`ANTHROPIC_DEFAULT_*`/`CLAUDE_CODE_SUBAGENT_MODEL`=alias。
-4. **worker**:`query({ options:{ model } })` 已就绪;日志 `[Worker] Model: <id>` 便于核验。
+1. **前端**:`chat-session-store` 增 `selectedModelId`(默认=`isDefault` 且 healthy);composer 下拉读"可选模型"(server fn),写 store,运行中禁用。**每会话**:store + 持久 `agent_session.model`(resume 回显)。
+2. **发送**:`ws-adapter` `chat` `InboundMessage` 增 `model?`,带 `model: selectedModelId`(照抄 skillSlug,L845-852)。
+3. **ws-server `handleChat`**(L1027；workerEnv 块 L1106-1117):
+   - 解析 model → connection;**校验 enabled && healthy**(过期即时补探一次);不满足 → **报错回前端**(owner #2)。
+   - 构造按请求 env:
+     - `ANTHROPIC_BASE_URL = connection.baseUrl`(**只用 BASE_URL**;`ANTHROPIC_API_URL` 未文档化,保留现状但不依赖)。
+     - 鉴权**互斥**:`bearer`→设 `ANTHROPIC_AUTH_TOKEN`、**删 `ANTHROPIC_API_KEY`**;`x-api-key`→设 `ANTHROPIC_API_KEY`、**删 `ANTHROPIC_AUTH_TOKEN`**(SDK:AUTH_TOKEN 优先,二者并存有歧义)。
+     - `ANTHROPIC_MODEL = model.model`。
+     - alias(网关下才生效):`ANTHROPIC_DEFAULT_OPUS/SONNET/HAIKU_MODEL` + `CLAUDE_CODE_SUBAGENT_MODEL` ← connection 的 alias(缺省回退该连接主模型,**避免子代理/后台档串到别的账号**)。
+     - 可选 `ANTHROPIC_CUSTOM_HEADERS = connection.customHeaders`。
+4. **worker**:`query({ options:{ model } })` 已就绪(L689);确保解析后的 model 入参。日志 `[Worker] Model: <id>` 核验。
 
-**子代理一致性(G7)**:跨账号必须按请求设 alias,否则子代理/后台档打到部署默认连接(别的账号)。
+> 实现可二选一:**(a)** 继续设 worker 子进程 env(现状 workerEnv 块,最小改动);**(b)** 经 SDK `query({options:{env}})`(claude-agent-kit 同款)。**选 (a)**——与现有 `ANTHROPIC_MODEL` 注入一致、改动最小。
 
 ---
 
 ## 9. 安全与约束
 
-- 威胁模型 = 可信团队;菜单对组织内用户可见可切——可接受。enable/重测等**看板操作限 admin**。
-- **token 永不入 JSON 配置 / DB / 前端 / 日志**;只在 `.env`,后端按 `tokenEnv` 取。
+- 威胁模型 = 可信团队;菜单组织内可见可切。**CRUD/enable/重测限 admin**。
+- **token 永不入 DB/前端/日志/配置 JSON**;只在 `.env`,后端按 `tokenEnv` 取;新增连接的密钥需服务器侧写 `.env`。
 - 维持 `ENABLE_STRUCTURED_OUTPUTS=false`;切换不得重触发 StructuredOutput Stop-hook。
-- 钉死 SDK 0.2.112;不引入 0.3.x-only 特性。
+- 钉死 SDK 0.2.112;不引入 0.3.x-only;`query()` 无 apiKey/baseUrl 选项 → 一律走 env。
 
 ---
 
 ## 10. 测试计划
 
-- **单元**:JSON 配置解析/校验(坏引用/未知 connection/重复 id)、env+DB 合并(enabled)、菜单状态机、selection 校验(disabled/unhealthy → 报错)、`workerEnv` 构造(bearer↔x-api-key 互斥 + alias)。
-- **集成**:真实 ARK 模型探活→healthy 写 DB;坏 token→unhealthy(auth);worker env 路由→`query()` 实跑;手动重测刷新看板。
+- **单元**:种子/admin 写入 Zod 校验(坏引用/重复 id/缺字段);env+DB 合并;菜单状态机;selection 校验(disabled/unhealthy→报错);**env 构造**(bearer↔x-api-key 互斥 + 删另一个 + alias + customHeaders);探活码分类(200/401/404/429/超时)。
+- **集成**:真实 ARK 模型探活→healthy 写 DB;坏 token→`auth`;worker env 路由→`query()` 实跑;手动重测刷看板;admin CRUD round-trip。
 - **手动/验收**:见 §11。
 
 ---
 
-## 11. 验收标准（v1）
+## 11. 验收标准（完整版）
 
-- AC1 `.env` 配 ≥2 连接、≥3 模型;启动 + 6h 探活后,**菜单只列 enabled && healthy**;看板显示全部 + 健康/时间/原因。
-- AC2 切换模型 → 该次运行**确实用所选模型/连接**(worker 日志可证),含**跨账号**。
-- AC3 把某模型 token 置坏 → 下一次探活后它在菜单**消失/置灰**、看板标 `unhealthy(auth)`;其他不受影响。
-- AC4 选了不健康模型发送 → **报错**(不静默换)。
-- AC5 admin 在看板 disable 某模型 → 用户菜单即时不可选(无需重启)。
-- AC6 默认模型不健康 → 回退首个 healthy 并提示。
-- AC7 token **不出现在看板/前端/日志**(脱敏校验)。
-- AC8 子代理/后台档跟随所选连接(不串账号)。
+- AC1 种子 ≥2 连接、≥3 模型;6h(或手动)探活后,**菜单只列 enabled && healthy**;看板显示全部 + 健康/时间/原因/延迟。
+- AC2 切换 → 该次运行**确实用所选模型/连接**(worker 日志),含**跨账号**。
+- AC3 某模型 token 置坏 → 下次探活后菜单消失/置灰、看板标 `auth`;其他不受影响。
+- AC4 选不健康模型发送 → **报错**(不静默换)。
+- AC5 admin 看板 disable/CRUD → 用户菜单即时反映(无需重启)。
+- AC6 默认模型不健康 → 回退首个 healthy + 提示。
+- AC7 token **不出现在看板/前端/日志/网络响应**(脱敏校验)。
+- AC8 子代理/后台档跟随所选连接(不串账号;alias 生效)。
+- AC9 admin 新增连接 + 在 `.env` 配好其 `tokenEnv` → 该连接模型探活 healthy → 可选。
 
 ---
 
-## 12. 分阶段
+## 12. 分阶段（本期 = 完整版）
 
 | 阶段 | 范围 | 估算 |
 |---|---|---|
-| **v1(本期)** | `.env` 配置(连接+model ids)+ 6h 后端探活 → `model_health` + `model_enablement` 两表 + **admin 看板**(健康/重测/enable)+ 选择链路(每会话)+ 按请求 workerEnv 路由(含 alias)+ composer 真 picker + 发送时报错。 | M–L |
-| **v2** | 看板**网页 CRUD 来源/model id**(DB 化定义,密钥仍 env 引用)+ per-message 模型记录(成本归集)。 | M |
-| **Phase 4** | failover/路由、按能力门控、OpenAI-only 转译代理评估、per-capability key 进一步拆分。 | M–L |
+| **本期(完整版)** | DB 三表(connection/definition/health)+ seed-on-migrate + `${ENV}`/Zod 校验 + 6h BullMQ 探活 + `/admin/models` CRUD+看板 + 选择链路(每会话 + `agent_session.model`)+ 按请求 env 路由(BASE_URL/互斥 auth/MODEL/alias/customHeaders)+ composer 真 picker + 发送时报错。 | L(分多 PR) |
+| **v-next** | per-message 模型记录(成本)+ provider `/models` 动态拉取(`fetch`)。 | M |
+| **Phase 4** | `fallbackModel` failover/路由、按能力门控、OpenAI-only 转译代理、per-capability key 拆分。 | M–L |
+
+**实施 PR 切分(建议序,详见资料包 §E)**:① DB 三表 + 迁移 + seed + registry(env 解析 + DB 合并 + Zod);② 探活模块 + 6h BullMQ job + 手动重测;③ ws 选择链路(adapter/store/handleChat env 路由/worker)+ 发送时报错;④ composer picker;⑤ `/admin/models` 看板 + CRUD server fns;⑥ `agent_session.model` 持久 + resume 回显。每步独立 PR、可单测、admin-merge。
 
 ---
 
-## 13. 待 Owner 确认（其余决策点)
+## 13. 待 Owner 确认（仅剩次要项）
 
-> §0 的 6 项已拍板并入正文。剩下 1 个需确认:
-
-- **D1（v1 admin 范围）**:v1 看板 = **只读来源 + 健康 + enable/重测**(来源/model-id 定义仍走 `.env`);"网页新增/删除来源与 model id"放 v2。**确认?** 还是希望 v1 就能在网页加来源(则需把定义也 DB 化、本期范围加大)?
-- (次要)`hideUnhealthy` 默认 = 置灰显示原因(false),确认沿用?
+- D1 ~~v1 admin 范围~~ → **已决:完整版 = admin DB CRUD(本 rev 锁定)**。
+- D2 `hideUnhealthy` 默认 = 置灰显示原因(false),确认沿用?
+- D3 新增连接密钥需服务器侧写 `.env`(不在 UI 存密钥)——确认接受?(替代:DB 加密存 key,与"密钥出仓库"冲突,**不推荐**。)
 
 ---
 
-## 14. 关联实现清单（v1）
+## 14. 实现清单（完整版,精确锚点见资料包 §B）
 
-- `.env.example`:`OXY_MODEL_DEFAULT` / `OXY_MODEL_CONNECTIONS` / `OXY_MODELS` / `MODEL_PROBE_INTERVAL_MS` + 各 `*_AUTH_TOKEN` 占位。
-- `src/config/model-registry.*`(新):解析 env JSON + 按 `tokenEnv` 取密钥 + `resolveModel(id)` + 与 DB 合并 + `getSelectableModels()`。
-- DB:迁移加 `model_health`、`model_enablement` 两表(照搬 Skills `skill_enablement` 写法)。
-- 探活模块(新,后端):`probeModel()`(直连 `/v1/messages`)+ 6h 定时器/BullMQ + 写 `model_health` + 手动重测。
-- `ws-server.mjs` `handleChat`:收 + 校验 `model`、构造按请求 `workerEnv`(baseURL/auth/model/alias);不健康→报错。
-- `ws-query-worker.mjs`:确认解析后的 model 入 `query()`。
-- `src/claude/adapters/ws-adapter.ts`:`chat` 增 `model?`;`listModels`/`probeStatus` 通道。
-- `src/lib/chat-session-store.ts`:`selectedModelId` + setter(每会话)。
-- `src/components/claude-chat/chat-composer.tsx`:死徽章 → 分组下拉(health 圆点、禁用态)。
-- `src/routes/agents`(或 admin 区)新增 `/admin/models` 看板 + server fns(`listModelsAdmin`/`setModelEnabled`/`reprobeModel`)。
-- `agent_session.model` 列 + 迁移(每会话持久,owner #4)。
+- `.env.example`:`OXY_MODELS_SEED` / `MODEL_PROBE_CRON` + 各 `*_AUTH_TOKEN` 占位。
+- `src/db/schema/model.schema.ts`(新):`model_connection` / `model_definition` / `model_health`(照 `skill-catalog.schema.ts`)。
+- `drizzle/`:新迁移;`migrate`/seed 接 `OXY_MODELS_SEED`(照 Skills seed-on-migrate)。
+- `src/config/model-registry.*`(新):解析 env 种子 + Zod + 与 DB 合并 + `resolveModel(id)`+`getSelectableModels()`+`buildWorkerEnv(model)`。
+- `src/.../model-probe.*`(新,后端):`probeModel()`(直连 `/v1/messages`)+ 码分类。
+- `src/jobs/queues.ts`+`src/worker/index.ts`:加 `probe-models` repeat job(`MODEL_PROBE_CRON`)+ 手动入队。
+- `ws-server.mjs`:`handleChat`(L1027)收 + 校验 `model`;**重写 workerEnv 块(L1106-1117)**为按请求 `buildWorkerEnv`(BASE_URL/互斥 auth/MODEL/alias/customHeaders);不健康→报错。
+- `ws-query-worker.mjs`(L23-26、L689):确认解析后 model 入 `query()`。
+- `src/claude/adapters/ws-adapter.ts`(L109-119、L845-852):`chat` 增 `model?`;`listModels`/`probeStatus` 通道。
+- `src/lib/chat-session-store.ts`(仿 selectedTier L180-183/422-424):`selectedModelId`+setter(每会话)。
+- `src/components/claude-chat/chat-composer.tsx`(死徽章 ~L468;仿 tier selector):分组下拉 + health 圆点 + 禁用态。
+- `src/routes/admin/models/`(新,照 `src/routes/admin/skills`)+ `src/server/function/models.server.ts`(照 `skills.server.ts` requireAdmin)。
+- `src/db/schema/agent-session.schema.ts`(L16-45):加 `model text` 列 + 迁移。

--- a/docs/project/research/2026-06-multi-model-context-pack.md
+++ b/docs/project/research/2026-06-multi-model-context-pack.md
@@ -1,0 +1,143 @@
+# 多模型切换 — 实施资料包（Context Pack）
+
+> 日期：2026-06-07 ｜ 配套 **`prd/2026-06-multi-model-switching-prd.md`（rev.3 完整版）**。
+> 目的：把"实施这一个功能所需的全部上下文"汇成一份——背景、术语、**精确代码锚点**、**SDK 0.2.112 env/model 契约**、参考项目 digest、env 清单、**分 PR 实施序**、风险与验证。实施时**照此直接动手,无需再调研**。
+
+---
+
+## §A 背景与术语
+
+- **产品定位**：自托管 / 单组织 / 多用户(可信团队);威胁模型 = 半可信同事,非匿名攻击者(见 `VISION.md`/`CLAUDE.md`)。→ 菜单对组织内可见可切 OK;CRUD/enable 限 admin;密钥卫生是重点。
+- **运行时**：只用 **Claude Agent SDK,钉死 `0.2.112`**(最后一个 bundled-JS 版;0.2.113+ 换原生二进制,与 ARK 不兼容)。
+- **协议边界**：SDK 只说 **Anthropic Messages 协议** → "多模型" = **跨 Anthropic 兼容网关**的多模型。OpenAI-only 厂商需自备 Anthropic 兼容代理(本期 N2 不做)。
+- **术语**：
+  - **Connection(连接)** = 一个 Anthropic 兼容端点 + 一份凭据 = 一个账号/网关(baseUrl + authStyle + tokenEnv)。
+  - **Model(模型)** = 归属某连接的可选项(model 串 + enabled + tags)。
+  - **探活(probe)** = 用 `/v1/messages` 最小请求判定"能用"。
+  - **可切 = enabled(DB) && healthy(探活)**。
+
+---
+
+## §B 代码锚点（精确 file:line,实施直接定位）
+
+> 仓库根：`/Users/peng/Dev/Projects/active/ClaudeAgentChat/oxygenie-phasec`
+
+### ws-server.mjs
+- `handleChat(ws, prompt, resumeSessionId, options={})` 签名 **L1027**;解构 `{ silentInit, skillSlug, permissionTier }` **L1028** ← 加 `model`。
+- **workerEnv 构造块 L1106-1117**(`const workerEnv = { ...process.env }` … `if (config.model) workerEnv.ANTHROPIC_MODEL = config.model`)← **重写为按请求 `buildWorkerEnv(model)`**。
+- 入站 `case 'chat'` **L1469-1484**(`handleChat(ws, message.content, message.sessionId, { skillSlug, permissionTier })`)← 加 `model: message.model`。
+- `recordUsage()` / `modelUsage` **L356-395**(per-message 成本归集的接入点,v-next)。
+- 心跳 `setInterval(..., HEARTBEAT_INTERVAL_MS)` **L1822-1868**(周期任务样板;但探活用 BullMQ,不用这里)。
+
+### ws-query-worker.mjs
+- `config = { model: process.env.ANTHROPIC_MODEL, cwd }` **L23-26**。
+- `query({ prompt, options:{ cwd, model: config.model, ... } })` **L689-732**。
+- `skillSlug` 解构 **L242-250**、消费 **L684-687**(per-request 选项样板)。
+
+### src/claude/adapters/ws-adapter.ts
+- `InboundMessage` 联合,`chat` 成员 **L109-119** ← 加 `model?: string`。
+- 发送 `send({ type:'chat', …, skillSlug, permissionTier })` **L845-852** ← 加 `model: selectedModelId`。
+- `let currentSessionId` **L364**。
+- 现有 sender 模式(`startPreview`/`sharePreview` 等)可仿照加 `listModels`/`probeStatus`(或用 server fn,见下)。
+
+### src/lib/chat-session-store.ts
+- `selectedTier?: InteractionMode` **L180-183**;`setSelectedTier` **L422-424**;默认 `selectedTier:'act'` **L420** ← **照此加 `selectedModelId` + `setSelectedModelId`**。
+- `PreviewState` 类型 **L114-126**(会话态类型样板)。
+
+### src/components/claude-chat/chat-composer.tsx
+- 死徽章「GLM 5.0」 **~L468** ← 换真下拉。
+- 权限档选择器:`useChatSessionStore(s=>s.selectedTier)` **~L196**、`PermissionTierSelector` import **~L47**、组件 `./permission-tier-selector`(UX 样板,照此做 model picker)。
+
+### DB / Drizzle
+- Schema 目录 `src/db/schema/`。
+- **`src/db/schema/skill-catalog.schema.ts`**:`skillCatalog` **L37-80**、`skillEnablement` **L110-118**(DB catalog + enablement 样板,照此建 model 三表)。
+- `src/db/schema/agent-session.schema.ts`:列 **L16-45**、类型导出 **L58-59** ← 加 `model: text('model')` 列。
+- 迁移目录 `drizzle/`(`0000_…` → `0019_…`);**seed-on-migrate** 看 Skills 的种子写法(curated seed 接 `migrate`,幂等)。
+
+### Server Functions（admin 模式）
+- `src/server/function/skills.server.ts`:`requireUser` **L61-70**、`requireAdmin` **L76-101**(查 `user.systemRole==='admin'`)← 照此建 `models.server.ts`。
+- 路由:`src/routes/admin/`(已有 `skills/ users/ organizations/ a2composer/ index.tsx route.tsx`)← 加 `models/`。
+
+### BullMQ / 定时任务（探活的家）
+- `src/jobs/queues.ts`:`systemQueue = new Queue(queueName, { connection(IORedis REDIS_URL), prefix })`。
+- `src/worker/index.ts`:`new Worker(queueName, async job => switch(job.name){…})` **L18-33**;**bootstrap 调度** `const opts={ repeat:{ pattern: cron }, jobId:'daily-credit-refill' }; await queue.add(...)` **~L46-55**(用 `getRepeatableJobs()` 去重)← **照此加 `probe-models`**:`repeat:{ pattern: MODEL_PROBE_CRON }`, `jobId:'probe-models'`;job handler 调探活模块。
+
+---
+
+## §C SDK 0.2.112 — env / model 契约（权威,来自官方文档 + 类型核对）
+
+**`query({ prompt, options })` 选项**:`model?`、`fallbackModel?`、**`env?: Record<string,string|undefined>`**(传给 CLI 子进程,默认 `process.env`)、`resume`、`permissionMode`、`maxTurns`、`outputFormat`… **没有 `apiKey`/`baseUrl`/`authToken`/`customHeaders` 选项**(仅只读输出 `apiKeySource`)。→ **鉴权/baseURL 必须走 env**。
+
+**provider 路由 env(子进程读取)**:
+- `ANTHROPIC_BASE_URL` —— 所有请求根地址(替代 api.anthropic.com)。**只用这个**;`ANTHROPIC_API_URL` **未文档化**,不依赖(现有代码顺带设了,保留无妨)。
+- `ANTHROPIC_AUTH_TOKEN` → `Authorization: Bearer`(网关/ARK)。
+- `ANTHROPIC_API_KEY` → `x-api-key`(原生)。
+- **精度优先级:`AUTH_TOKEN` 优先于 `API_KEY`**(设了 AUTH_TOKEN 就用 Bearer;只有未设 AUTH_TOKEN 时才用 x-api-key)。**→ 二者只设其一,另一个从子进程 env 显式删除**(并存有歧义、个别代理会同时发两个头)。
+- `ANTHROPIC_CUSTOM_HEADERS` —— 每请求附加头(网关路由,可选)。
+- `ANTHROPIC_MODEL` —— 会话级模型覆盖(= `--model`/`options.model`,作用于该进程)。
+
+**alias / 子代理 env(仅在 `ANTHROPIC_BASE_URL` 指向网关时生效;直连 api.anthropic.com 时惰性)**:
+- `ANTHROPIC_DEFAULT_OPUS_MODEL` / `ANTHROPIC_DEFAULT_SONNET_MODEL` / `ANTHROPIC_DEFAULT_HAIKU_MODEL`(haiku=后台/廉价档)。
+- `CLAUDE_CODE_SUBAGENT_MODEL`(覆盖所有子代理模型;`inherit`=用常规解析)。
+- `ANTHROPIC_SMALL_FAST_MODEL` 已弃用 → 用 `_HAIKU_MODEL`。
+- **跨账号必须按连接设这些**,否则子代理/后台档打到部署默认账号。缺省策略:未配 alias → 全部回退该连接主模型。
+
+**每进程覆盖 = 合法且受支持**:`options.env` 可传完整自定义 env map;CLI 启动读这些;不同终端用各自 `--model` 即官方做法。我们 spawn 每请求新子进程 → 给它独立 env(BASE_URL + 单个 auth + MODEL + alias)即可路由到任意网关/模型。**实施选 (a) 设子进程 env(现状 workerEnv 块)**,与现有 `ANTHROPIC_MODEL` 注入一致、最小改动。
+
+**健康探活请求**:`POST {BASE_URL}/v1/messages`,headers `content-type: application/json` + `anthropic-version: 2023-06-01` + 单一 auth 头;body `{model, max_tokens:1, messages:[{role:"user",content:"ping"}]}`。
+- 码:**200=healthy**;401/403=`auth`;**404(原生)/部分网关 400 指向模型=`model`**(⚠️ ARK 用哪个码,实测确认);connection/DNS=`network`;超时=`timeout`;**429=healthy(限流)**。
+
+> 来源:Agent SDK overview / model-config / llm-gateway / authentication / Messages API / errors(均 code.claude.com & platform.claude.com)。0.2.112 无本地 tarball,字段以 0.1.59 类型核对 + 官方文档佐证(同 bundled-JS 契约);若要字节级确认:`npm pack @anthropic-ai/claude-agent-sdk@0.2.112` 看 `sdk.d.ts`。
+
+---
+
+## §D 参考项目 digest（借思路,不抄码）
+
+| 项目 | 路径 | 借什么 | 跳过 |
+|---|---|---|---|
+| **CraftAgent** | `references/famous_ai-chat_projects/craft-agents-oss` | `LlmConnection`(slug/providerType/authType/baseUrl/models[]);**配置与凭据分离**(凭据另存,绝不并列);**懒探活**(on-add/on-run,返回 `{success,warning}`);**每会话锁定**模型(首条消息后锁);mini/summary 模型按 keyword 选(haiku) | 其多 providerType/OAuth/Bedrock 映射 |
+| **LobeChat** | `references/famous_ai-chat_projects/lobe-chat` | admin provider/model 表 + 面板;**`${ENV}` 注入**;**env-默认↔DB-覆盖合并**(DB 胜,但**密钥可留 env**);手动 "Check" 测试;per-model enable | 50+ SDK driver、DB 加密 keyVaults(我们密钥留 env)、运行时 `/models` 拉取 |
+| **LibreChat** | `references/famous_ai-chat_projects/LibreChat` | custom-endpoint **Zod 严校验**(坏配置启动即报);`${ENV_VAR}` 解析(load 时,不下发前端);**三档 model-list**(hardcoded/`fetch:true`/fallback);**每消息记 `model`+`endpoint`**(审计);Anthropic 端点 headers(anthropic-version/beta) | 全量 50 端点类型、`fetch:true` 自动拉(本期 N3) |
+| **claude-agent-kit** | `references/useful_frameworks/claude-agent-kit` | **`query({options:{env}})` 按请求合并 env** 的路由法(`{...baseEnv, ...customEnv}` 设 ANTHROPIC_API_KEY/BASE_URL/MODEL);session 不绑 auth → 换 env 即换账号 | 无多模型(单模型/实例);`models[]` 仅 UI 未接 |
+
+**净结论**:连接/凭据分离(CraftAgent)+ DB 定义 + admin 面板 + env↔DB 合并(Lobe)+ Zod/`${ENV}`(LibreChat)+ 按请求 env 路由(claude-agent-kit)+ **我们自加 6h 探活**(三者都只有手动 check,无周期探活)。
+
+---
+
+## §E 分 PR 实施序（每步独立 PR、可单测、admin-merge）
+
+1. **DB + registry**:`src/db/schema/model.schema.ts`(三表)+ 迁移 + seed-on-migrate(`OXY_MODELS_SEED`)+ `src/config/model-registry.*`(env 解析 + Zod + DB 合并 + `resolveModel`/`getSelectableModels`/`buildWorkerEnv`)。单测:解析/校验/合并/env 构造。
+2. **探活**:`model-probe.*`(直连 `/v1/messages` + 码分类)+ `src/worker` 加 `probe-models` repeat(`MODEL_PROBE_CRON`)写 `model_health` + 手动入队。单测:码分类(mock fetch)。
+3. **选择链路**:`ws-adapter`(`chat` 加 `model?` + 发送)+ `chat-session-store`(`selectedModelId`)+ `ws-server.handleChat`(收 + 校验 + `buildWorkerEnv` 路由 + 不健康报错)+ worker 确认入参。单测:selection 校验 + env 互斥/alias。
+4. **picker**:`chat-composer` 死徽章 → 分组下拉(health 圆点 + 禁用态),读 server fn `getSelectableModels`。
+5. **admin 看板**:`src/routes/admin/models/` + `models.server.ts`(requireAdmin CRUD + reprobe)。
+6. **每会话持久**:`agent_session.model` 列 + 迁移;resume 回显;handleChat resume 时取持久 model。
+
+> 顺序保证:1→2 先把"配置+健康"打底;3 让"能切并真路由";4 给 UI;5 给 admin 配置;6 收尾持久。1-3 即"能用",4-6 即"完整 + 好用"。
+
+---
+
+## §F env 清单（落 `.env.example`,真实值进部署 env;❌ 不改真实 .env）
+
+```bash
+# 密钥(按 tokenEnv 名;绝不入 DB/前端/日志)
+ARK_AUTH_TOKEN=
+ZHIPU_AUTH_TOKEN=
+# 种子(首启写 DB;之后 admin 维护)—— 见 PRD §4.1 的 OXY_MODELS_SEED JSON
+OXY_MODELS_SEED=
+# 探活周期(BullMQ repeat;默认 6h)
+MODEL_PROBE_CRON="0 */6 * * *"
+```
+> 兼容:现有单值 `ANTHROPIC_MODEL`/`ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` 仍作"无种子时的默认单连接"回退,保证未配多模型的部署不回归。
+
+---
+
+## §G 风险 / 验证
+
+- **R1 ARK 未知模型返回码**:原生 Anthropic=404,网关可能 400 → 探活码分类要把"指向模型的 400/404"都判 `model`;**实测 ARK 一次确认**。
+- **R2 alias 串账号**:跨连接不设 alias,子代理/后台档打到部署默认账号 → 必须按连接设 `_DEFAULT_*`/`SUBAGENT`(§C)。
+- **R3 双 auth 头**:AUTH_TOKEN+API_KEY 并存歧义 → 构造 env 时**显式删另一个**。
+- **R4 密钥泄露面**:看板/前端/日志/server fn 返回**只含 health/label/id/tokenEnv 名**,绝不含 token 值;加脱敏单测(AC7)。
+- **R5 默认模型不健康**:回退首个 healthy + 提示(AC6),避免开局无可用模型。
+- **R6 SDK 字段未对 0.2.112 字节核对**:风险低(0.1.59 同契约 + 官方文档),需要时 `npm pack` 验证。
+- **验证主线**:配 2 连接(ARK + 智谱)→ 探活两者 healthy → 跨账号切换各自跑通(worker 日志 `Model:`)→ 置坏一个 token,下次探活该连接置灰(AC1-AC3,AC8-AC9)。


### PR DESCRIPTION
## What

Completes the prep before implementing the **full version** of multi-model switching: finished references research, locked best practices + the SDK contract, and produced a self-contained context pack so implementation proceeds without re-research.

## PRD rev.3 (full version, locked)

`prd/2026-06-multi-model-switching-prd.md`
- **Definitions in DB** (`model_connection` / `model_definition` / `model_health`), **admin CRUD** at `/admin/models`, **seeded from `.env`** (`OXY_MODELS_SEED`) on migrate (mirrors Skills catalog). **Secrets only in `.env`** by `tokenEnv` name — never in DB/UI/logs.
- **6h backend probe** (`MODEL_PROBE_CRON`) via a BullMQ repeat job → `model_health`; manual re-probe.
- Per-conversation selection (`agent_session.model`); **reject-on-unhealthy** at send; **per-request worker-env routing** (BASE_URL / mutually-exclusive auth / MODEL / per-connection aliases / custom headers).

## Context pack

`research/2026-06-multi-model-context-pack.md` — the implementation bundle:
- **Precise code anchors** (file:line) for every touchpoint (ws-server handleChat + workerEnv block, ws-query-worker query(), ws-adapter chat, store selectedTier pattern, composer badge, skill-catalog schema, agent-session schema, skills.server requireAdmin, BullMQ repeat in src/worker).
- **Authoritative SDK 0.2.112 env/model contract**: `query()` has `model`/`fallbackModel`/`env` but **no apiKey/baseUrl options**; **`ANTHROPIC_BASE_URL` only** (API_URL undocumented); **`ANTHROPIC_AUTH_TOKEN` precedes `ANTHROPIC_API_KEY` → clear the unused one**; alias vars **gateway-only**; `/v1/messages` probe + status-code classification (200/401/404-or-400/429/timeout).
- References digest (CraftAgent/LobeChat/LibreChat/claude-agent-kit — borrow vs skip), env reference, **6-PR build sequence**, risks + a verification line.

## Next

Implement per the §E sequence (DB+registry → probe+6h job → selection+routing → picker → admin board → per-session persist), each an independent PR.

Two minor confirmations open in PRD §13 (D2 hideUnhealthy default; D3 new-connection secret goes in `.env`, not UI) — both have a recommended default; not blocking.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)