### PR TITLE
feat(models): DB schema for multi-model (connection/definition/health)

### DIFF
--- a/drizzle/0022_multi_model.sql
+++ b/drizzle/0022_multi_model.sql
@@ -1,0 +1,42 @@
+CREATE TYPE "public"."model_auth_style" AS ENUM('bearer', 'x-api-key');--> statement-breakpoint
+CREATE TYPE "public"."model_health" AS ENUM('healthy', 'unhealthy', 'unknown');--> statement-breakpoint
+CREATE TABLE "model_connection" (
+	"id" text PRIMARY KEY NOT NULL,
+	"label" text NOT NULL,
+	"base_url" text NOT NULL,
+	"auth_style" "model_auth_style" DEFAULT 'bearer' NOT NULL,
+	"token_env" text NOT NULL,
+	"anthropic_version" text DEFAULT '2023-06-01' NOT NULL,
+	"custom_headers" jsonb,
+	"alias_opus" text,
+	"alias_sonnet" text,
+	"alias_haiku" text,
+	"alias_subagent" text,
+	"sort" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "model_definition" (
+	"id" text PRIMARY KEY NOT NULL,
+	"label" text NOT NULL,
+	"connection_id" text NOT NULL,
+	"model" text NOT NULL,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"sort" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "model_health" (
+	"model_id" text PRIMARY KEY NOT NULL,
+	"health" "model_health" DEFAULT 'unknown' NOT NULL,
+	"last_probe_at" timestamp with time zone,
+	"probe_error" text,
+	"latency_ms" integer
+);
+--> statement-breakpoint
+ALTER TABLE "model_definition" ADD CONSTRAINT "model_definition_connection_id_model_connection_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."model_connection"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "model_health" ADD CONSTRAINT "model_health_model_id_model_definition_id_fk" FOREIGN KEY ("model_id") REFERENCES "public"."model_definition"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "f05ea8d9-0386-4248-9795-b1f93b64f107",
-  "prevId": "d9eebdf2-d45d-4817-bb29-69f589dfb6d8",
+  "id": "4c3a488f-9098-4cee-ae54-d73f3353b927",
+  "prevId": "f05ea8d9-0386-4248-9795-b1f93b64f107",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -2846,6 +2846,261 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
+    },
+    "public.model_connection": {
+      "name": "model_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_style": {
+          "name": "auth_style",
+          "type": "model_auth_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bearer'"
+        },
+        "token_env": {
+          "name": "token_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anthropic_version": {
+          "name": "anthropic_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2023-06-01'"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_opus": {
+          "name": "alias_opus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_sonnet": {
+          "name": "alias_sonnet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_haiku": {
+          "name": "alias_haiku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_subagent": {
+          "name": "alias_subagent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_definition": {
+      "name": "model_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_definition_connection_id_model_connection_id_fk": {
+          "name": "model_definition_connection_id_model_connection_id_fk",
+          "tableFrom": "model_definition",
+          "tableTo": "model_connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_health": {
+      "name": "model_health",
+      "schema": "",
+      "columns": {
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "model_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probe_error": {
+          "name": "probe_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_health_model_id_model_definition_id_fk": {
+          "name": "model_health_model_id_model_definition_id_fk",
+          "tableFrom": "model_health",
+          "tableTo": "model_definition",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {
@@ -2918,6 +3173,23 @@
         "upstream",
         "builtin",
         "upload"
+      ]
+    },
+    "public.model_auth_style": {
+      "name": "model_auth_style",
+      "schema": "public",
+      "values": [
+        "bearer",
+        "x-api-key"
+      ]
+    },
+    "public.model_health": {
+      "name": "model_health",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy",
+        "unknown"
       ]
     }
   },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1780511640220,
       "tag": "0021_careless_dazzler",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1780824189166,
+      "tag": "0022_multi_model",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -12,3 +12,4 @@ export * from './knowledge-base.schema';
 export * from './kb-document.schema';
 export * from './profile.schema';
 export * from './skill-catalog.schema';
+export * from './model.schema';

--- a/src/db/schema/model.schema.ts
+++ b/src/db/schema/model.schema.ts
@@ -1,0 +1,87 @@
+/**
+ * Multi-model schema (model switching, PR1 of the full version)
+ *
+ * DB = runtime source of truth for which models/connections exist and are enabled;
+ * seeded on first boot from `.env` (OXY_MODELS_SEED) and editable by admins in
+ * `/admin/models`. **Secrets are NEVER stored here** — a connection only records the
+ * NAME of the env var holding its token (`tokenEnv`); the value lives in `.env` and is
+ * resolved server-side at spawn time. Health is produced by the 6h backend probe.
+ *
+ * See docs/project/prd/2026-06-multi-model-switching-prd.md (rev.3) §3 and
+ * docs/project/research/2026-06-multi-model-context-pack.md.
+ */
+
+import { pgTable, text, integer, boolean, jsonb, pgEnum } from 'drizzle-orm/pg-core';
+import { createdAt, updatedAt, timestamptz } from './_shared';
+
+// How the connection authenticates to its Anthropic-compatible gateway.
+// bearer  → ANTHROPIC_AUTH_TOKEN (Authorization: Bearer) — ARK / gateways
+// x-api-key → ANTHROPIC_API_KEY (x-api-key header) — native Anthropic
+export const modelAuthStyleEnum = pgEnum('model_auth_style', ['bearer', 'x-api-key']);
+
+// Probe result. unknown = never probed / probe in flight.
+export const modelHealthEnum = pgEnum('model_health', ['healthy', 'unhealthy', 'unknown']);
+
+// ── model_connection ─ an Anthropic-compatible endpoint + one credential (an account)
+export const modelConnection = pgTable('model_connection', {
+  // Stable key, e.g. "ark-coding" (used as FK target; not user-facing).
+  id: text('id').primaryKey(),
+  label: text('label').notNull(),
+  // Anthropic-compatible base URL WITHOUT the /v1 suffix, e.g.
+  // https://ark.cn-beijing.volces.com/api/coding . Probe + worker append /v1/messages
+  // (the SDK reads ANTHROPIC_BASE_URL = this value).
+  baseUrl: text('base_url').notNull(),
+  authStyle: modelAuthStyleEnum('auth_style').notNull().default('bearer'),
+  // NAME of the env var holding the secret (e.g. "ARK_AUTH_TOKEN"). The value is
+  // never stored — resolved from process.env on the server only.
+  tokenEnv: text('token_env').notNull(),
+  anthropicVersion: text('anthropic_version').notNull().default('2023-06-01'),
+  // Optional extra headers for gateway routing → ANTHROPIC_CUSTOM_HEADERS.
+  customHeaders: jsonb('custom_headers').$type<Record<string, string> | null>(),
+  // Per-connection alias/sub-agent models (gateway-only env vars). Null → fall back to
+  // the connection's selected model so sub-agents/background calls stay on this account.
+  aliasOpus: text('alias_opus'),
+  aliasSonnet: text('alias_sonnet'),
+  aliasHaiku: text('alias_haiku'),
+  aliasSubagent: text('alias_subagent'),
+  sort: integer('sort').default(0).notNull(),
+  createdAt: createdAt(),
+  updatedAt: updatedAt(),
+});
+
+// ── model_definition ─ a selectable model belonging to a connection ──────────────
+export const modelDefinition = pgTable('model_definition', {
+  // Global unique id sent over the wire / shown in the picker, e.g. "ark/glm-5.1".
+  id: text('id').primaryKey(),
+  label: text('label').notNull(),
+  connectionId: text('connection_id')
+    .notNull()
+    .references(() => modelConnection.id, { onDelete: 'cascade' }),
+  // The model string the gateway expects, e.g. "glm-5.1".
+  model: text('model').notNull(),
+  tags: jsonb('tags').$type<string[]>().default([]).notNull(),
+  enabled: boolean('enabled').notNull().default(true),
+  isDefault: boolean('is_default').notNull().default(false),
+  sort: integer('sort').default(0).notNull(),
+  createdAt: createdAt(),
+  updatedAt: updatedAt(),
+});
+
+// ── model_health ─ produced by the 6h backend probe; read by the board + the menu ─
+export const modelHealth = pgTable('model_health', {
+  modelId: text('model_id')
+    .primaryKey()
+    .references(() => modelDefinition.id, { onDelete: 'cascade' }),
+  health: modelHealthEnum('health').notNull().default('unknown'),
+  lastProbeAt: timestamptz('last_probe_at'),
+  // Failure classification: network | auth | model | timeout | http_4xx | http_5xx
+  probeError: text('probe_error'),
+  latencyMs: integer('latency_ms'),
+});
+
+export type ModelConnection = typeof modelConnection.$inferSelect;
+export type NewModelConnection = typeof modelConnection.$inferInsert;
+export type ModelDefinition = typeof modelDefinition.$inferSelect;
+export type NewModelDefinition = typeof modelDefinition.$inferInsert;
+export type ModelHealthRow = typeof modelHealth.$inferSelect;
+export type NewModelHealthRow = typeof modelHealth.$inferInsert;


### PR DESCRIPTION
## What

**PR1** of the full multi-model feature (per `prd/2026-06-multi-model-switching-prd.md` rev.3 §3 + `research/2026-06-multi-model-context-pack.md` §E build sequence).

Adds the DB foundation:
- **`src/db/schema/model.schema.ts`**:
  - `model_connection` — an Anthropic-compatible endpoint + one credential (= an account): `baseUrl`, `authStyle` (bearer | x-api-key), **`tokenEnv`** (the env-var *name*, never the secret), `anthropicVersion`, `customHeaders`, and per-connection alias models (opus/sonnet/haiku/subagent).
  - `model_definition` — a selectable model → connection: `model` string, `enabled`, `isDefault`, `tags`.
  - `model_health` — probe result (`health`/`lastProbeAt`/`probeError`/`latencyMs`).
  - **Secrets are never stored** — only `tokenEnv`. Mirrors `skill-catalog.schema` conventions.
- **`drizzle/0022_multi_model.sql`** + snapshot: 2 enums + 3 tables + 2 FKs (CREATE only, no DROP).

## Note: drizzle snapshot reconcile (not a DB change)

`generate` kept going interactive because **`mastra_thread`** is still in the drizzle snapshot — its schema was removed in #109 but no drop migration was ever generated, so every diff treats it as a pending delete/rename. This PR removes it from the **0021 snapshot baseline** so `generate` runs clean. **This does NOT drop the table from any database** — it only stops drizzle tracking a table the schema already removed (the orphan table, if present, simply lingers harmlessly; a real drop can be done later with owner sign-off).

## Verified

`drizzle-kit generate` clean & non-interactive; `tsc --noEmit` no errors in the new schema; `tsx` import resolves all exports. No runtime wiring yet (that's PR2+: registry/seed → probe → selection → picker → admin board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)