### PR TITLE
feat(models): registry + Zod config + seed-on-boot + buildWorkerEnv (PR2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,20 @@ ANTHROPIC_API_KEY="sk-ant-api03-xxxxx"
 # Optional: model override (must match the gateway above)
 # ANTHROPIC_MODEL="ark-code-latest"
 
+# ── Multi-model switching (optional) ──────────────────────────────────────────
+# If unset, the single ANTHROPIC_* above is used as one connection (a 1-item menu).
+# To offer multiple switchable models across accounts/gateways, set OXY_MODELS_SEED:
+# a NON-SECRET JSON of connections + models. Secrets are referenced by `tokenEnv`
+# NAME only (the value lives in its own env var below) — never put a token in here,
+# the DB, or the UI. This seeds the DB on first boot; admins then manage models in
+# /admin/models. See docs/project/prd/2026-06-multi-model-switching-prd.md.
+# OXY_MODELS_SEED='{"default":"ark/glm-5.1","connections":[{"id":"ark-coding","label":"火山 ARK","baseUrl":"https://ark.cn-beijing.volces.com/api/coding","authStyle":"bearer","tokenEnv":"ARK_AUTH_TOKEN","aliasHaiku":"doubao-seed-2.0-lite"},{"id":"zhipu","label":"智谱 GLM","baseUrl":"https://open.bigmodel.cn/api/anthropic","authStyle":"bearer","tokenEnv":"ZHIPU_AUTH_TOKEN"}],"models":[{"id":"ark/glm-5.1","label":"GLM 5.1","connection":"ark-coding","model":"glm-5.1","isDefault":true,"tags":["general"]},{"id":"ark/doubao-code","label":"Doubao Code 2.0","connection":"ark-coding","model":"doubao-seed-2.0-code","tags":["coding"]},{"id":"zhipu/glm-5.1","label":"GLM 5.1 (Zhipu)","connection":"zhipu","model":"glm-5.1","tags":["general"]}]}'
+# Per-connection secrets (names referenced by tokenEnv above; values only here):
+# ARK_AUTH_TOKEN="..."
+# ZHIPU_AUTH_TOKEN="..."
+# Health probe cadence (BullMQ repeat; default every 6h):
+# MODEL_PROBE_CRON="0 */6 * * *"
+
 # Optional: Zhipu API key — only needed for the built-in GLM image-generation tool and the
 # Zhipu MCP servers (zhipu-search/reader/zread/vision). Leave unset if you don't use them.
 # Get a key from: https://open.bigmodel.cn/

--- a/src/server/models/build-worker-env.js
+++ b/src/server/models/build-worker-env.js
@@ -1,0 +1,80 @@
+/**
+ * buildWorkerEnv — request-time provider/model routing for the agent worker (PR2).
+ *
+ * Plain JS (no .ts) so `ws-server.mjs` can import it directly (ws-server runs as a
+ * separate `node` process and imports only .js from src/, no tsx loader).
+ *
+ * Given a model's connection metadata + the source env, returns a NEW env object
+ * with the ANTHROPIC_* vars set to route the spawned Claude Agent SDK child to that
+ * connection + model. The secret is read from `sourceEnv[meta.tokenEnv]` — tokens
+ * never travel in metadata/DB/UI.
+ *
+ * SDK 0.2.112 contract (see research/2026-06-multi-model-context-pack.md §C):
+ *  - auth via env only (no query() apiKey/baseUrl option);
+ *  - ANTHROPIC_AUTH_TOKEN (Bearer) PRECEDES ANTHROPIC_API_KEY (x-api-key) → set
+ *    exactly one and DELETE the other to avoid ambiguity / double headers;
+ *  - alias vars (DEFAULT_*_MODEL / SUBAGENT) only take effect on a gateway; set them
+ *    per-connection so sub-agents/background calls stay on THIS account.
+ *
+ * @typedef {Object} ModelRouteMeta
+ * @property {string} baseUrl
+ * @property {'bearer'|'x-api-key'} authStyle
+ * @property {string} tokenEnv     - NAME of the env var holding the token
+ * @property {string} model        - gateway model string (e.g. "glm-5.1")
+ * @property {Record<string,string>=} customHeaders
+ * @property {string=} aliasOpus
+ * @property {string=} aliasSonnet
+ * @property {string=} aliasHaiku
+ * @property {string=} aliasSubagent
+ *
+ * @param {ModelRouteMeta} meta
+ * @param {Record<string,string|undefined>} sourceEnv
+ * @returns {Record<string,string|undefined>} a new env object
+ */
+export function buildWorkerEnv(meta, sourceEnv) {
+  if (!meta || !meta.baseUrl || !meta.tokenEnv || !meta.model) {
+    throw new Error('buildWorkerEnv: incomplete model metadata (need baseUrl, tokenEnv, model)');
+  }
+  const token = sourceEnv?.[meta.tokenEnv];
+  if (!token || !String(token).trim()) {
+    throw new Error(`buildWorkerEnv: token env "${meta.tokenEnv}" is not set on the server`);
+  }
+
+  const env = { ...sourceEnv };
+
+  // Route. Only ANTHROPIC_BASE_URL is documented; set API_URL too so a stale value
+  // from the parent env can't shadow it.
+  env.ANTHROPIC_BASE_URL = meta.baseUrl;
+  env.ANTHROPIC_API_URL = meta.baseUrl;
+
+  // Mutually-exclusive auth.
+  if (meta.authStyle === 'x-api-key') {
+    env.ANTHROPIC_API_KEY = token;
+    delete env.ANTHROPIC_AUTH_TOKEN;
+  } else {
+    env.ANTHROPIC_AUTH_TOKEN = token;
+    delete env.ANTHROPIC_API_KEY;
+  }
+
+  env.ANTHROPIC_MODEL = meta.model;
+
+  // Aliases fall back to the selected model so sub-agents/background calls don't
+  // cross accounts. (Gateway-only env vars; inert on direct api.anthropic.com.)
+  env.ANTHROPIC_DEFAULT_OPUS_MODEL = meta.aliasOpus || meta.model;
+  env.ANTHROPIC_DEFAULT_SONNET_MODEL = meta.aliasSonnet || meta.model;
+  env.ANTHROPIC_DEFAULT_HAIKU_MODEL = meta.aliasHaiku || meta.model;
+  env.CLAUDE_CODE_SUBAGENT_MODEL = meta.aliasSubagent || meta.model;
+
+  if (meta.customHeaders && Object.keys(meta.customHeaders).length > 0) {
+    env.ANTHROPIC_CUSTOM_HEADERS = serializeCustomHeaders(meta.customHeaders);
+  }
+
+  return env;
+}
+
+/** ANTHROPIC_CUSTOM_HEADERS is a newline-separated list of `Name: Value`. */
+export function serializeCustomHeaders(headers) {
+  return Object.entries(headers)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}

--- a/src/server/models/model-config.ts
+++ b/src/server/models/model-config.ts
@@ -1,0 +1,104 @@
+/**
+ * Multi-model config parsing (PR2).
+ *
+ * The `.env` var OXY_MODELS_SEED holds a NON-SECRET JSON describing connections +
+ * models (secrets are referenced by `tokenEnv` NAME only). This module parses +
+ * validates that seed with Zod; it is the bootstrap source written into the DB on
+ * first boot (see registry.seedModelsFromEnv). DB is the runtime source of truth.
+ *
+ * See docs/project/prd/2026-06-multi-model-switching-prd.md (rev.3) §4 +
+ * docs/project/research/2026-06-multi-model-context-pack.md.
+ */
+
+import { z } from 'zod';
+
+export const AUTH_STYLES = ['bearer', 'x-api-key'] as const;
+export type AuthStyle = (typeof AUTH_STYLES)[number];
+
+const connectionSeedSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    baseUrl: z.string().url(),
+    authStyle: z.enum(AUTH_STYLES).default('bearer'),
+    // NAME of the env var holding the secret — never the secret itself.
+    tokenEnv: z.string().min(1),
+    anthropicVersion: z.string().default('2023-06-01'),
+    customHeaders: z.record(z.string(), z.string()).optional(),
+    // Per-connection alias / sub-agent models (gateway-only). Optional.
+    aliasOpus: z.string().optional(),
+    aliasSonnet: z.string().optional(),
+    aliasHaiku: z.string().optional(),
+    aliasSubagent: z.string().optional(),
+  })
+  .strict();
+
+const modelSeedSchema = z
+  .object({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    connection: z.string().min(1),
+    model: z.string().min(1),
+    tags: z.array(z.string()).default([]),
+    enabled: z.boolean().default(true),
+    isDefault: z.boolean().default(false),
+  })
+  .strict();
+
+export const modelSeedConfigSchema = z
+  .object({
+    default: z.string().optional(),
+    connections: z.array(connectionSeedSchema).default([]),
+    models: z.array(modelSeedSchema).default([]),
+  })
+  .strict()
+  .superRefine((cfg, ctx) => {
+    const connIds = new Set<string>();
+    for (const c of cfg.connections) {
+      if (connIds.has(c.id)) {
+        ctx.addIssue({ code: 'custom', message: `duplicate connection id: ${c.id}`, path: ['connections'] });
+      }
+      connIds.add(c.id);
+    }
+    const modelIds = new Set<string>();
+    for (const m of cfg.models) {
+      if (modelIds.has(m.id)) {
+        ctx.addIssue({ code: 'custom', message: `duplicate model id: ${m.id}`, path: ['models'] });
+      }
+      modelIds.add(m.id);
+      if (!connIds.has(m.connection)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `model "${m.id}" references unknown connection "${m.connection}"`,
+          path: ['models'],
+        });
+      }
+    }
+    if (cfg.default && !modelIds.has(cfg.default)) {
+      ctx.addIssue({ code: 'custom', message: `default "${cfg.default}" is not a known model id`, path: ['default'] });
+    }
+  });
+
+export type ModelSeedConfig = z.infer<typeof modelSeedConfigSchema>;
+export type ConnectionSeed = ModelSeedConfig['connections'][number];
+export type ModelSeed = ModelSeedConfig['models'][number];
+
+/**
+ * Parse + validate OXY_MODELS_SEED. Returns null when unset/empty (no seed → the
+ * single-value ANTHROPIC_* env stays as the only connection, see registry).
+ * Throws on invalid JSON or schema so a misconfig fails loudly at boot.
+ */
+export function parseModelSeed(raw: string | undefined = process.env.OXY_MODELS_SEED): ModelSeedConfig | null {
+  if (!raw || !raw.trim()) return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`OXY_MODELS_SEED is not valid JSON: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  const result = modelSeedConfigSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(`OXY_MODELS_SEED failed validation: ${JSON.stringify(result.error.issues)}`);
+  }
+  return result.data;
+}

--- a/src/server/models/registry.ts
+++ b/src/server/models/registry.ts
@@ -1,0 +1,183 @@
+/**
+ * Multi-model registry — DB-backed runtime source of truth (PR2).
+ *
+ * Server-only (imports the DB client). The web app + server fns use this; the
+ * separate `ws-server.mjs` process does NOT import it — it fetches token-free model
+ * metadata over HTTP and routes via build-worker-env.js (keeps secrets in-process).
+ *
+ * Seed-on-boot: OXY_MODELS_SEED (or a legacy ANTHROPIC_* fallback) is upserted with
+ * onConflictDoNothing so admin edits in /admin/models are never clobbered. DB wins
+ * thereafter. Secrets are never stored — only tokenEnv (the env-var NAME).
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { db } from '~/db/client';
+import { modelConnection, modelDefinition, modelHealth } from '~/db/schema/model.schema';
+import { parseModelSeed, type AuthStyle, type ModelSeedConfig } from './model-config';
+
+/** Token-free metadata the ws-server resolve endpoint returns for routing. */
+export type ModelRouteMeta = {
+  id: string;
+  model: string;
+  connectionId: string;
+  baseUrl: string;
+  authStyle: AuthStyle;
+  tokenEnv: string;
+  anthropicVersion: string;
+  customHeaders: Record<string, string> | null;
+  aliasOpus: string | null;
+  aliasSonnet: string | null;
+  aliasHaiku: string | null;
+  aliasSubagent: string | null;
+  enabled: boolean;
+  health: 'healthy' | 'unhealthy' | 'unknown';
+};
+
+/** A selectable model for the composer picker (never includes secrets). */
+export type SelectableModel = {
+  id: string;
+  label: string;
+  connectionId: string;
+  connectionLabel: string;
+  tags: string[];
+};
+
+/**
+ * If OXY_MODELS_SEED is unset, synthesize a single connection+model from the legacy
+ * single-value ANTHROPIC_* env so existing deployments keep working (and get a
+ * one-item menu) without any new config.
+ */
+function legacyFallbackSeed(): ModelSeedConfig | null {
+  const baseUrl = process.env.ANTHROPIC_BASE_URL;
+  const model = process.env.ANTHROPIC_MODEL;
+  if (!baseUrl || !model) return null;
+  // ARK uses ANTHROPIC_AUTH_TOKEN (Bearer); native uses ANTHROPIC_API_KEY.
+  const authStyle: AuthStyle = process.env.ANTHROPIC_AUTH_TOKEN ? 'bearer' : 'x-api-key';
+  const tokenEnv = authStyle === 'bearer' ? 'ANTHROPIC_AUTH_TOKEN' : 'ANTHROPIC_API_KEY';
+  const id = `default/${model}`;
+  return {
+    default: id,
+    connections: [
+      {
+        id: 'default',
+        label: 'Default',
+        baseUrl,
+        authStyle,
+        tokenEnv,
+        anthropicVersion: '2023-06-01',
+      },
+    ],
+    models: [{ id, label: model, connection: 'default', model, tags: [], enabled: true, isDefault: true }],
+  };
+}
+
+/** Idempotently seed connections + models + health rows from env (boot-time). */
+export async function seedModelsFromEnv(): Promise<{ connections: number; models: number } | null> {
+  const seed = parseModelSeed() ?? legacyFallbackSeed();
+  if (!seed) {
+    console.log('[Models] No OXY_MODELS_SEED and no legacy ANTHROPIC_* — skipping seed.');
+    return null;
+  }
+
+  for (const c of seed.connections) {
+    await db
+      .insert(modelConnection)
+      .values({
+        id: c.id,
+        label: c.label,
+        baseUrl: c.baseUrl,
+        authStyle: c.authStyle,
+        tokenEnv: c.tokenEnv,
+        anthropicVersion: c.anthropicVersion,
+        customHeaders: c.customHeaders ?? null,
+        aliasOpus: c.aliasOpus ?? null,
+        aliasSonnet: c.aliasSonnet ?? null,
+        aliasHaiku: c.aliasHaiku ?? null,
+        aliasSubagent: c.aliasSubagent ?? null,
+      })
+      .onConflictDoNothing();
+  }
+
+  for (const m of seed.models) {
+    await db
+      .insert(modelDefinition)
+      .values({
+        id: m.id,
+        label: m.label,
+        connectionId: m.connection,
+        model: m.model,
+        tags: m.tags,
+        enabled: m.enabled,
+        isDefault: m.isDefault || seed.default === m.id,
+      })
+      .onConflictDoNothing();
+    // Seed an 'unknown' health row so the model shows as "checking…" until first probe.
+    await db.insert(modelHealth).values({ modelId: m.id, health: 'unknown' }).onConflictDoNothing();
+  }
+
+  console.log(`[Models] Seed: ${seed.connections.length} connections, ${seed.models.length} models (idempotent).`);
+  return { connections: seed.connections.length, models: seed.models.length };
+}
+
+/** Models the user may pick right now: enabled && healthy. No secrets. */
+export async function getSelectableModels(): Promise<SelectableModel[]> {
+  const rows = await db
+    .select({
+      id: modelDefinition.id,
+      label: modelDefinition.label,
+      connectionId: modelConnection.id,
+      connectionLabel: modelConnection.label,
+      tags: modelDefinition.tags,
+      connSort: modelConnection.sort,
+      defSort: modelDefinition.sort,
+    })
+    .from(modelDefinition)
+    .innerJoin(modelConnection, eq(modelDefinition.connectionId, modelConnection.id))
+    .innerJoin(modelHealth, eq(modelHealth.modelId, modelDefinition.id))
+    .where(and(eq(modelDefinition.enabled, true), eq(modelHealth.health, 'healthy')));
+
+  return rows
+    .sort((a, b) => a.connSort - b.connSort || a.defSort - b.defSort)
+    .map(({ connSort: _c, defSort: _d, ...m }) => m);
+}
+
+/** Token-free metadata for the ws-server resolve endpoint. Null if unknown id. */
+export async function resolveModelMeta(id: string): Promise<ModelRouteMeta | null> {
+  const [row] = await db
+    .select({
+      id: modelDefinition.id,
+      model: modelDefinition.model,
+      enabled: modelDefinition.enabled,
+      connectionId: modelConnection.id,
+      baseUrl: modelConnection.baseUrl,
+      authStyle: modelConnection.authStyle,
+      tokenEnv: modelConnection.tokenEnv,
+      anthropicVersion: modelConnection.anthropicVersion,
+      customHeaders: modelConnection.customHeaders,
+      aliasOpus: modelConnection.aliasOpus,
+      aliasSonnet: modelConnection.aliasSonnet,
+      aliasHaiku: modelConnection.aliasHaiku,
+      aliasSubagent: modelConnection.aliasSubagent,
+      health: modelHealth.health,
+    })
+    .from(modelDefinition)
+    .innerJoin(modelConnection, eq(modelDefinition.connectionId, modelConnection.id))
+    .leftJoin(modelHealth, eq(modelHealth.modelId, modelDefinition.id))
+    .where(eq(modelDefinition.id, id))
+    .limit(1);
+  if (!row) return null;
+  return { ...row, health: row.health ?? 'unknown' };
+}
+
+/** Default model id: the isDefault one if healthy, else the first selectable. */
+export async function getDefaultModelId(): Promise<string | null> {
+  const selectable = await getSelectableModels();
+  if (selectable.length === 0) return null;
+  const [def] = await db
+    .select({ id: modelDefinition.id })
+    .from(modelDefinition)
+    .innerJoin(modelHealth, eq(modelHealth.modelId, modelDefinition.id))
+    .where(and(eq(modelDefinition.isDefault, true), eq(modelHealth.health, 'healthy')))
+    .limit(1);
+  return def?.id ?? selectable[0].id;
+}

--- a/src/start.ts
+++ b/src/start.ts
@@ -17,6 +17,16 @@ if (import.meta.env.SSR) {
       throw error;
     }
   }
+
+  // Seed the multi-model registry from OXY_MODELS_SEED (or the legacy ANTHROPIC_*
+  // fallback) into the DB. Idempotent (onConflictDoNothing) — admin edits win.
+  // Best-effort: never block startup if seeding fails.
+  try {
+    const { seedModelsFromEnv } = await import('~/server/models/registry');
+    await seedModelsFromEnv();
+  } catch (error) {
+    console.error('[Startup] Model registry seed failed (non-fatal):', error);
+  }
 } else {
   // Client init (captures console + network)
   await import('~/lib/observability/sentry.client')

--- a/tests/unit/build-worker-env.test.js
+++ b/tests/unit/build-worker-env.test.js
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { buildWorkerEnv, serializeCustomHeaders } from '../../src/server/models/build-worker-env.js';
+
+const baseMeta = {
+  baseUrl: 'https://ark.cn-beijing.volces.com/api/coding',
+  authStyle: 'bearer',
+  tokenEnv: 'ARK_AUTH_TOKEN',
+  model: 'glm-5.1',
+};
+
+describe('buildWorkerEnv', () => {
+  it('routes base URL + bearer auth + model, and clears API_KEY', () => {
+    const env = buildWorkerEnv(baseMeta, { ARK_AUTH_TOKEN: 'tok', ANTHROPIC_API_KEY: 'stale', PATH: '/usr/bin' });
+    expect(env.ANTHROPIC_BASE_URL).toBe(baseMeta.baseUrl);
+    expect(env.ANTHROPIC_API_URL).toBe(baseMeta.baseUrl);
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('tok');
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined(); // the stale one is cleared
+    expect(env.ANTHROPIC_MODEL).toBe('glm-5.1');
+    expect(env.PATH).toBe('/usr/bin'); // unrelated env preserved
+  });
+
+  it('x-api-key style sets API_KEY and clears AUTH_TOKEN', () => {
+    const env = buildWorkerEnv(
+      { ...baseMeta, authStyle: 'x-api-key', tokenEnv: 'ANTHROPIC_API_KEY' },
+      { ANTHROPIC_API_KEY: 'k', ANTHROPIC_AUTH_TOKEN: 'stale' },
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe('k');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it('aliases fall back to the selected model (no cross-account sub-agents)', () => {
+    const env = buildWorkerEnv(baseMeta, { ARK_AUTH_TOKEN: 'tok' });
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.1');
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5.1');
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5.1');
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe('glm-5.1');
+  });
+
+  it('explicit aliases override the fallback', () => {
+    const env = buildWorkerEnv(
+      { ...baseMeta, aliasHaiku: 'doubao-seed-2.0-lite', aliasSubagent: 'glm-4.5' },
+      { ARK_AUTH_TOKEN: 'tok' },
+    );
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('doubao-seed-2.0-lite');
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe('glm-4.5');
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5.1'); // unspecified → fallback
+  });
+
+  it('serializes custom headers into ANTHROPIC_CUSTOM_HEADERS', () => {
+    const env = buildWorkerEnv(
+      { ...baseMeta, customHeaders: { 'x-route': 'a', 'x-tenant': 'b' } },
+      { ARK_AUTH_TOKEN: 'tok' },
+    );
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toBe('x-route: a\nx-tenant: b');
+  });
+
+  it('throws when the token env var is missing/empty', () => {
+    expect(() => buildWorkerEnv(baseMeta, {})).toThrow(/token env "ARK_AUTH_TOKEN" is not set/);
+    expect(() => buildWorkerEnv(baseMeta, { ARK_AUTH_TOKEN: '   ' })).toThrow(/not set/);
+  });
+
+  it('throws on incomplete metadata', () => {
+    expect(() => buildWorkerEnv({ baseUrl: 'x' }, { X: 'y' })).toThrow(/incomplete model metadata/);
+  });
+
+  it('serializeCustomHeaders joins Name: Value by newline', () => {
+    expect(serializeCustomHeaders({ a: '1', b: '2' })).toBe('a: 1\nb: 2');
+  });
+});

--- a/tests/unit/model-config.test.ts
+++ b/tests/unit/model-config.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { parseModelSeed } from '../../src/server/models/model-config';
+
+const validSeed = JSON.stringify({
+  default: 'ark/glm-5.1',
+  connections: [
+    { id: 'ark-coding', label: 'ARK', baseUrl: 'https://ark.cn-beijing.volces.com/api/coding', authStyle: 'bearer', tokenEnv: 'ARK_AUTH_TOKEN', aliasHaiku: 'doubao-seed-2.0-lite' },
+    { id: 'zhipu', label: 'Zhipu', baseUrl: 'https://open.bigmodel.cn/api/anthropic', authStyle: 'bearer', tokenEnv: 'ZHIPU_AUTH_TOKEN' },
+  ],
+  models: [
+    { id: 'ark/glm-5.1', label: 'GLM 5.1', connection: 'ark-coding', model: 'glm-5.1', tags: ['general'] },
+    { id: 'zhipu/glm-5.1', label: 'GLM 5.1 (Zhipu)', connection: 'zhipu', model: 'glm-5.1' },
+  ],
+});
+
+describe('parseModelSeed', () => {
+  it('returns null for unset/empty', () => {
+    expect(parseModelSeed(undefined)).toBeNull();
+    expect(parseModelSeed('')).toBeNull();
+    expect(parseModelSeed('   ')).toBeNull();
+  });
+
+  it('parses a valid seed and applies defaults', () => {
+    const cfg = parseModelSeed(validSeed)!;
+    expect(cfg.connections).toHaveLength(2);
+    expect(cfg.models).toHaveLength(2);
+    expect(cfg.default).toBe('ark/glm-5.1');
+    // defaults filled
+    expect(cfg.connections[0].anthropicVersion).toBe('2023-06-01');
+    expect(cfg.models[1].enabled).toBe(true);
+    expect(cfg.models[1].isDefault).toBe(false);
+    expect(cfg.models[1].tags).toEqual([]);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseModelSeed('{not json')).toThrow(/not valid JSON/);
+  });
+
+  it('rejects a model referencing an unknown connection', () => {
+    const bad = JSON.stringify({
+      connections: [{ id: 'a', label: 'A', baseUrl: 'https://x.example.com', tokenEnv: 'T' }],
+      models: [{ id: 'a/m', label: 'M', connection: 'nope', model: 'm' }],
+    });
+    expect(() => parseModelSeed(bad)).toThrow(/unknown connection/);
+  });
+
+  it('rejects duplicate connection / model ids', () => {
+    const dupConn = JSON.stringify({
+      connections: [
+        { id: 'a', label: 'A', baseUrl: 'https://x.example.com', tokenEnv: 'T' },
+        { id: 'a', label: 'A2', baseUrl: 'https://y.example.com', tokenEnv: 'T2' },
+      ],
+      models: [],
+    });
+    expect(() => parseModelSeed(dupConn)).toThrow(/duplicate connection id/);
+  });
+
+  it('rejects a default that is not a known model', () => {
+    const bad = JSON.stringify({
+      default: 'ghost',
+      connections: [{ id: 'a', label: 'A', baseUrl: 'https://x.example.com', tokenEnv: 'T' }],
+      models: [{ id: 'a/m', label: 'M', connection: 'a', model: 'm' }],
+    });
+    expect(() => parseModelSeed(bad)).toThrow(/not a known model id/);
+  });
+
+  it('rejects an invalid baseUrl', () => {
+    const bad = JSON.stringify({
+      connections: [{ id: 'a', label: 'A', baseUrl: 'not-a-url', tokenEnv: 'T' }],
+      models: [],
+    });
+    expect(() => parseModelSeed(bad)).toThrow();
+  });
+});


### PR DESCRIPTION
## What

**PR2** of the full multi-model feature (per `prd/2026-06-multi-model-switching-prd.md` rev.3 §4/§8 + context pack §E). Pure backend foundation — no UI/routing wired yet (that's PR3+).

- **`model-config.ts`** — Zod schema + `parseModelSeed(OXY_MODELS_SEED)`. Non-secret JSON of connections+models; cross-validates (unknown connection ref, duplicate ids, default→known model). Secrets are referenced by `tokenEnv` **name** only.
- **`build-worker-env.js`** — **plain JS** (so `ws-server.mjs` can import it). Request-time provider/model routing: `ANTHROPIC_BASE_URL` + exactly one auth var (clears the other, per the SDK's *AUTH_TOKEN precedes API_KEY* rule) + `ANTHROPIC_MODEL` + per-connection aliases (fall back to the chosen model so sub-agents don't cross accounts) + optional `ANTHROPIC_CUSTOM_HEADERS`. Token read from `sourceEnv[tokenEnv]`.
- **`registry.ts`** — DB runtime source of truth: `seedModelsFromEnv()` (idempotent `onConflictDoNothing`; **legacy single `ANTHROPIC_*` fallback** so existing deploys get a 1-item menu with zero new config), `getSelectableModels()` (enabled && healthy, no secrets), `resolveModelMeta(id)` (token-free, for the ws-server resolve endpoint), `getDefaultModelId()`.
- **`src/start.ts`** — seed on boot after `autoMigrate` (best-effort, non-fatal).
- **`.env.example`** — `OXY_MODELS_SEED` / per-connection `*_AUTH_TOKEN` / `MODEL_PROBE_CRON`.

## Verified locally

- `vitest` **15/15** — `build-worker-env` (auth mutual-exclusion, alias fallback/override, custom headers, missing-token throw, incomplete-meta throw) + `model-config` (valid parse + defaults, null on empty, bad JSON, unknown-connection ref, dup ids, bad default, bad URL).
- `tsc --noEmit` clean on the new modules; `oxlint` clean (2 `no-console` warnings, matching `migrate.ts`/`store-seeder.ts`).

## Secrets posture

Tokens never enter the JSON config, the DB, server-fn responses, or the UI — only the `tokenEnv` *name* is stored; the value is read from `process.env` at spawn time in the backend.

## Next (PR3)

Probe module (`/v1/messages`) + 6h BullMQ repeat job → `model_health` + manual reprobe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)