### PR TITLE
feat(models): health probe + 6h BullMQ probe job (PR3)

### DIFF
--- a/src/server/models/probe.ts
+++ b/src/server/models/probe.ts
@@ -1,0 +1,86 @@
+/**
+ * Model health probe (PR3).
+ *
+ * Sends the SAME minimal request the SDK would (Anthropic Messages API at
+ * `{baseUrl}/v1/messages`) to decide whether a model is actually usable
+ * (reachable + authed + model-accepted). DB-free + dependency-injectable so it
+ * unit-tests without a live DB or network. The DB write lives in the worker
+ * processor (src/worker/processors/probeModels.ts).
+ *
+ * Status-code classification (see context pack §C / §G):
+ *  200 → healthy · 429 → healthy (throttled but usable) · 401/403 → auth
+ *  400/404 → model (gateways differ; ARK verified empirically) · 5xx → http_5xx
+ *  abort → timeout · throw → network · missing token → auth
+ */
+
+export type ProbeHealth = 'healthy' | 'unhealthy';
+export type ProbeError = 'auth' | 'model' | 'network' | 'timeout' | 'http_5xx' | `http_${number}` | null;
+export type ProbeResult = { health: ProbeHealth; probeError: ProbeError; latencyMs: number };
+
+export interface ProbeInput {
+  baseUrl: string;
+  authStyle: 'bearer' | 'x-api-key';
+  tokenEnv: string;
+  model: string;
+  anthropicVersion?: string;
+  customHeaders?: Record<string, string> | null;
+}
+
+export interface ProbeOptions {
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Map an HTTP status to a probe verdict. */
+export function classifyProbeStatus(status: number, latencyMs: number): ProbeResult {
+  if (status >= 200 && status < 300) return { health: 'healthy', probeError: null, latencyMs };
+  if (status === 429) return { health: 'healthy', probeError: null, latencyMs }; // throttled but usable
+  if (status === 401 || status === 403) return { health: 'unhealthy', probeError: 'auth', latencyMs };
+  if (status === 400 || status === 404) return { health: 'unhealthy', probeError: 'model', latencyMs };
+  if (status >= 500) return { health: 'unhealthy', probeError: 'http_5xx', latencyMs };
+  return { health: 'unhealthy', probeError: `http_${status}`, latencyMs };
+}
+
+/** Probe one model's connection. Reads the token from env[tokenEnv] (never logged). */
+export async function probeModelMeta(meta: ProbeInput, opts: ProbeOptions = {}): Promise<ProbeResult> {
+  const env = opts.env ?? process.env;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? 15000;
+
+  const token = env[meta.tokenEnv];
+  if (!token || !String(token).trim()) {
+    return { health: 'unhealthy', probeError: 'auth', latencyMs: 0 };
+  }
+
+  const url = `${meta.baseUrl.replace(/\/+$/, '')}/v1/messages`;
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'anthropic-version': meta.anthropicVersion || '2023-06-01',
+    ...meta.customHeaders,
+  };
+  if (meta.authStyle === 'x-api-key') headers['x-api-key'] = token;
+  else headers['authorization'] = `Bearer ${token}`;
+
+  const body = JSON.stringify({
+    model: meta.model,
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'ping' }],
+  });
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const started = Date.now();
+  try {
+    const res = await fetchImpl(url, { method: 'POST', headers, body, signal: controller.signal });
+    return classifyProbeStatus(res.status, Date.now() - started);
+  } catch (error) {
+    const latencyMs = Date.now() - started;
+    if (error instanceof Error && error.name === 'AbortError') {
+      return { health: 'unhealthy', probeError: 'timeout', latencyMs };
+    }
+    return { health: 'unhealthy', probeError: 'network', latencyMs };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -5,6 +5,7 @@ import { Worker, Queue, QueueEvents, JobsOptions } from 'bullmq'
 import { logger } from '~/lib/logger'
 import { runDailyCreditRefill } from './processors/dailyCreditRefill.ts'
 import { reindexDocuments } from './processors/reindexDocuments.ts'
+import { probeModels } from './processors/probeModels.ts'
 
 const connection = new IORedis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
   maxRetriesPerRequest: null,
@@ -25,6 +26,9 @@ const worker = new Worker(
       case 'reindex-all':
         logger.info('[worker] running reindex-all job')
         return reindexDocuments()
+      case 'probe-models':
+        logger.info('[worker] running probe-models job')
+        return probeModels((job.data as { modelId?: string } | undefined)?.modelId)
       default:
         logger.warn(`[worker] Unknown job "${job.name}" - ignoring`)
     }
@@ -52,6 +56,15 @@ events.on('failed', ({ jobId, failedReason }) =>
     const opts: JobsOptions = { repeat: { pattern: cron }, jobId: 'daily-credit-refill' }
     await queue.add('daily-credit-refill', {}, opts)
     logger.info('[worker] scheduled daily-credit-refill', { cron })
+  }
+
+  // Model health probe (multi-model): re-check every model's connection on a cadence
+  // (default every 6h) so the picker/board only offer currently-usable models.
+  const probeCron = process.env.MODEL_PROBE_CRON ?? '0 */6 * * *'
+  const hasProbe = existing.some((j) => j.name === 'probe-models' && j.cron === probeCron)
+  if (!hasProbe) {
+    await queue.add('probe-models', {}, { repeat: { pattern: probeCron }, jobId: 'probe-models' })
+    logger.info('[worker] scheduled probe-models', { cron: probeCron })
   }
 
   if (process.env.SEARCH_REINDEX_ON_BOOT === 'true') {

--- a/src/worker/processors/probeModels.ts
+++ b/src/worker/processors/probeModels.ts
@@ -1,0 +1,52 @@
+/**
+ * BullMQ processor: probe model health and persist to model_health (PR3).
+ *
+ * Runs on the 6h `probe-models` repeat job (and on-demand for a single model from
+ * the admin "re-probe" action). Resolves token-free metadata from the registry,
+ * probes via the Anthropic Messages API, and upserts the verdict.
+ */
+
+import { db } from '~/db/client';
+import { modelDefinition, modelHealth } from '~/db/schema/model.schema';
+import { resolveModelMeta } from '~/server/models/registry';
+import { probeModelMeta } from '~/server/models/probe';
+import { logger } from '~/lib/logger';
+
+/** Probe a single model and upsert its health row. */
+export async function probeAndStore(modelId: string): Promise<void> {
+  const meta = await resolveModelMeta(modelId);
+  if (!meta) {
+    logger.warn('[probe] unknown model id, skipping', { modelId });
+    return;
+  }
+  const result = await probeModelMeta(meta);
+  const now = new Date();
+  await db
+    .insert(modelHealth)
+    .values({
+      modelId,
+      health: result.health,
+      lastProbeAt: now,
+      probeError: result.probeError,
+      latencyMs: result.latencyMs,
+    })
+    .onConflictDoUpdate({
+      target: modelHealth.modelId,
+      set: { health: result.health, lastProbeAt: now, probeError: result.probeError, latencyMs: result.latencyMs },
+    });
+  logger.info('[probe] result', { modelId, health: result.health, error: result.probeError, latencyMs: result.latencyMs });
+}
+
+/** Probe all models (periodic) or one model (on-demand). Never throws per-model. */
+export async function probeModels(modelId?: string): Promise<{ probed: number }> {
+  if (modelId) {
+    await probeAndStore(modelId).catch((e) => logger.error('[probe] failed', { modelId, error: e }));
+    return { probed: 1 };
+  }
+  const defs = await db.select({ id: modelDefinition.id }).from(modelDefinition);
+  for (const d of defs) {
+    await probeAndStore(d.id).catch((e) => logger.error('[probe] failed', { modelId: d.id, error: e }));
+  }
+  logger.info('[probe] swept all models', { count: defs.length });
+  return { probed: defs.length };
+}

--- a/tests/unit/model-probe.test.ts
+++ b/tests/unit/model-probe.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { classifyProbeStatus, probeModelMeta, type ProbeInput } from '../../src/server/models/probe';
+
+const meta: ProbeInput = {
+  baseUrl: 'https://ark.cn-beijing.volces.com/api/coding',
+  authStyle: 'bearer',
+  tokenEnv: 'ARK_AUTH_TOKEN',
+  model: 'glm-5.1',
+};
+const env = { ARK_AUTH_TOKEN: 'tok' } as unknown as NodeJS.ProcessEnv;
+
+function fetchReturning(status: number): typeof fetch {
+  return (async () => new Response(null, { status })) as unknown as typeof fetch;
+}
+
+describe('classifyProbeStatus', () => {
+  it('maps status codes to verdicts', () => {
+    expect(classifyProbeStatus(200, 5)).toMatchObject({ health: 'healthy', probeError: null });
+    expect(classifyProbeStatus(429, 5)).toMatchObject({ health: 'healthy', probeError: null }); // throttled but usable
+    expect(classifyProbeStatus(401, 5)).toMatchObject({ health: 'unhealthy', probeError: 'auth' });
+    expect(classifyProbeStatus(403, 5)).toMatchObject({ health: 'unhealthy', probeError: 'auth' });
+    expect(classifyProbeStatus(404, 5)).toMatchObject({ health: 'unhealthy', probeError: 'model' });
+    expect(classifyProbeStatus(400, 5)).toMatchObject({ health: 'unhealthy', probeError: 'model' });
+    expect(classifyProbeStatus(500, 5)).toMatchObject({ health: 'unhealthy', probeError: 'http_5xx' });
+    expect(classifyProbeStatus(418, 5)).toMatchObject({ health: 'unhealthy', probeError: 'http_418' });
+  });
+});
+
+describe('probeModelMeta', () => {
+  it('healthy on 200', async () => {
+    const r = await probeModelMeta(meta, { env, fetchImpl: fetchReturning(200) });
+    expect(r.health).toBe('healthy');
+    expect(r.probeError).toBeNull();
+  });
+
+  it('auth-unhealthy when the token env is missing (no fetch attempted)', async () => {
+    let called = false;
+    const spyFetch = (async () => {
+      called = true;
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    const r = await probeModelMeta(meta, { env: {} as NodeJS.ProcessEnv, fetchImpl: spyFetch });
+    expect(r).toMatchObject({ health: 'unhealthy', probeError: 'auth' });
+    expect(called).toBe(false);
+  });
+
+  it('classifies a 401 from the gateway as auth', async () => {
+    const r = await probeModelMeta(meta, { env, fetchImpl: fetchReturning(401) });
+    expect(r).toMatchObject({ health: 'unhealthy', probeError: 'auth' });
+  });
+
+  it('network error → network', async () => {
+    const boom = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const r = await probeModelMeta(meta, { env, fetchImpl: boom });
+    expect(r.probeError).toBe('network');
+  });
+
+  it('abort → timeout', async () => {
+    const aborting = (async () => {
+      const e = new Error('aborted');
+      e.name = 'AbortError';
+      throw e;
+    }) as unknown as typeof fetch;
+    const r = await probeModelMeta(meta, { env, fetchImpl: aborting });
+    expect(r.probeError).toBe('timeout');
+  });
+
+  it('sends bearer auth + the messages body to {baseUrl}/v1/messages', async () => {
+    let seenUrl = '';
+    let seenInit: RequestInit | undefined;
+    const capture = (async (url: string, init: RequestInit) => {
+      seenUrl = url;
+      seenInit = init;
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    await probeModelMeta(meta, { env, fetchImpl: capture });
+    expect(seenUrl).toBe('https://ark.cn-beijing.volces.com/api/coding/v1/messages');
+    const headers = seenInit?.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer tok');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(JSON.parse(seenInit?.body as string)).toMatchObject({ model: 'glm-5.1', max_tokens: 1 });
+  });
+
+  it('x-api-key auth uses the x-api-key header', async () => {
+    let headers: Record<string, string> = {};
+    const capture = (async (_url: string, init: RequestInit) => {
+      headers = init.headers as Record<string, string>;
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    await probeModelMeta(
+      { ...meta, authStyle: 'x-api-key', tokenEnv: 'NATIVE_KEY' },
+      { env: { NATIVE_KEY: 'k' } as unknown as NodeJS.ProcessEnv, fetchImpl: capture },
+    );
+    expect(headers['x-api-key']).toBe('k');
+    expect(headers.authorization).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

**PR3** — model health probe + the periodic sweep (prd rev.3 §5 + context pack §E).

- **`src/server/models/probe.ts`** — `probeModelMeta()` sends the **SDK-equivalent** minimal request (`POST {baseUrl}/v1/messages`, `anthropic-version` + one auth header + `{model, max_tokens:1, ping}`) and classifies: **200→healthy**, **429→healthy** (throttled but usable), **401/403→auth**, **400/404→model**, **5xx→http_5xx**, abort→**timeout**, throw→**network**, missing token→**auth**. DB-free + dependency-injectable (`fetchImpl`/`env`) → unit-tested without DB/network.
- **`src/worker/processors/probeModels.ts`** — `probeModels(modelId?)`: resolve token-free metadata via the registry → probe → upsert `model_health`. Per-model isolated (the sweep never throws).
- **`src/worker/index.ts`** — `probe-models` job case + a **6h repeat bootstrap** (`MODEL_PROBE_CRON`, default `0 */6 * * *`), mirroring `daily-credit-refill`. Single-model re-probe supported via `job.data.modelId` (the admin "re-probe" path in PR6).

## Verified

`vitest` **8/8** (status classification, bearer vs x-api-key headers, the `/v1/messages` URL + body, missing-token short-circuit before any fetch, network/timeout). `probe.ts` tsc + oxlint clean. (The worker's `.ts`-extension imports + `j.cron` match the existing sibling processors — the worker runs via `tsx/loader`, not tsc; typecheck is a non-blocking gate.)

## Next (PR4)

Selection plumbing + the **typed** resolve endpoint (A1 template) + ws-server `buildWorkerEnv` routing + reject-on-unhealthy + the resolve cache (A4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)