### PR TITLE
feat(models): typed internal resolve endpoint + shared contract (PR4a)

### DIFF
--- a/src/routes/api/models/resolve.$id.ts
+++ b/src/routes/api/models/resolve.$id.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal model-resolve endpoint (PR4) — token-free metadata for ws-server routing.
+ *
+ * GET /api/models/resolve/:id → the connection metadata ws-server needs to build the
+ * worker env for the selected model. Returns NO secret (only `tokenEnv`, the name).
+ * Cookie-authed like the other internal endpoints (src/routes/api/agent-sessions/*).
+ * Response shape is validated against the shared contract (arch finding A1).
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { requireUser } from '~/server/require-user';
+import { resolveModelMeta } from '~/server/models/registry';
+import {
+  RESOLVE_MODEL_CONTRACT_VERSION,
+  resolveModelResponseSchema,
+} from '~/server/models/resolve-contract';
+
+export const Route = createFileRoute('/api/models/resolve/$id')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        await requireUser(request); // any authenticated org user; metadata is non-secret
+        const meta = await resolveModelMeta(params.id);
+        if (!meta) {
+          return new Response(JSON.stringify({ error: 'Model not found' }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        // Validate our own output against the shared contract before sending.
+        const body = resolveModelResponseSchema.parse({ v: RESOLVE_MODEL_CONTRACT_VERSION, ...meta });
+        return Response.json(body);
+      },
+    },
+  },
+});

--- a/src/server/models/resolve-contract.ts
+++ b/src/server/models/resolve-contract.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal-API contract for model resolution (PR4 / arch finding A1).
+ *
+ * The shared, versioned shape exchanged across the ws-server ↔ web-app process
+ * boundary. The web-app route validates its response against this schema; ws-server
+ * (plain JS) validates the response it receives with the same field set. Defining the
+ * contract once is the template the project's other untyped internal `/api/*`
+ * endpoints should converge to (see 2026-06-architecture-observations.md §A1).
+ *
+ * NOTE: this carries `tokenEnv` (the env-var NAME) but NEVER a token value — the
+ * secret stays in the backend process env and is read at spawn time.
+ */
+
+import { z } from 'zod';
+
+export const RESOLVE_MODEL_CONTRACT_VERSION = 1;
+
+export const resolveModelResponseSchema = z.object({
+  v: z.literal(RESOLVE_MODEL_CONTRACT_VERSION),
+  id: z.string(),
+  model: z.string(),
+  connectionId: z.string(),
+  baseUrl: z.string().url(),
+  authStyle: z.enum(['bearer', 'x-api-key']),
+  tokenEnv: z.string(),
+  anthropicVersion: z.string(),
+  customHeaders: z.record(z.string(), z.string()).nullable(),
+  aliasOpus: z.string().nullable(),
+  aliasSonnet: z.string().nullable(),
+  aliasHaiku: z.string().nullable(),
+  aliasSubagent: z.string().nullable(),
+  enabled: z.boolean(),
+  health: z.enum(['healthy', 'unhealthy', 'unknown']),
+});
+
+export type ResolveModelResponse = z.infer<typeof resolveModelResponseSchema>;

--- a/tests/unit/resolve-contract.test.ts
+++ b/tests/unit/resolve-contract.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import {
+  RESOLVE_MODEL_CONTRACT_VERSION,
+  resolveModelResponseSchema,
+} from '../../src/server/models/resolve-contract';
+
+const sample = {
+  v: RESOLVE_MODEL_CONTRACT_VERSION,
+  id: 'ark/glm-5.1',
+  model: 'glm-5.1',
+  connectionId: 'ark-coding',
+  baseUrl: 'https://ark.cn-beijing.volces.com/api/coding',
+  authStyle: 'bearer' as const,
+  tokenEnv: 'ARK_AUTH_TOKEN',
+  anthropicVersion: '2023-06-01',
+  customHeaders: null,
+  aliasOpus: null,
+  aliasSonnet: null,
+  aliasHaiku: 'doubao-seed-2.0-lite',
+  aliasSubagent: null,
+  enabled: true,
+  health: 'healthy' as const,
+};
+
+describe('resolveModelResponseSchema', () => {
+  it('validates a well-formed resolve response', () => {
+    expect(() => resolveModelResponseSchema.parse(sample)).not.toThrow();
+  });
+
+  it('rejects a wrong/missing contract version', () => {
+    expect(() => resolveModelResponseSchema.parse({ ...sample, v: 999 })).toThrow();
+    const { v: _v, ...noV } = sample;
+    expect(() => resolveModelResponseSchema.parse(noV)).toThrow();
+  });
+
+  it('rejects a bad baseUrl / unknown authStyle / unknown health', () => {
+    expect(() => resolveModelResponseSchema.parse({ ...sample, baseUrl: 'nope' })).toThrow();
+    expect(() => resolveModelResponseSchema.parse({ ...sample, authStyle: 'oauth' })).toThrow();
+    expect(() => resolveModelResponseSchema.parse({ ...sample, health: 'great' })).toThrow();
+  });
+
+  it('never surfaces a token value (parsed output strips unknown keys)', () => {
+    const parsed = resolveModelResponseSchema.parse({ ...sample, token: 'SECRET' } as Record<string, unknown>);
+    expect('token' in parsed).toBe(false);
+    expect(parsed.tokenEnv).toBe('ARK_AUTH_TOKEN'); // only the NAME is carried
+  });
+});


### PR DESCRIPTION
## What

**PR4a** — the token-free **model-resolve endpoint** ws-server will call, plus a **shared zod contract**. This is also the template for arch finding **A1** (typed ws-server↔web-app boundary).

- **`resolve-contract.ts`** — versioned `resolveModelResponseSchema` (the cross-process shape). Carries `tokenEnv` (the env-var *name*) but **never a token value**.
- **`src/routes/api/models/resolve.$id.ts`** — `GET /api/models/resolve/:id`, cookie-authed (mirrors `api/agent-sessions/*`), returns `resolveModelMeta()` **validated against the contract**; 404 for unknown id.
- **contract test** — valid parse, version guard, bad url/authStyle/health, unknown-key strip (proves no token leaks).

## Note on the route tree

`src/routeTree.gen.ts` is **gitignored** and regenerated by the build/dev (TanStack Router plugin). The route name (`resolve.$id.ts` → `/api/models/resolve/$id`) mirrors the working `by-sdk-id.$sdkId.ts` exactly, so the **CI build regenerates + validates it**. (Local `tsc` shows a stale-tree error on the `createFileRoute` path until the tree is regenerated; typecheck is a non-blocking gate.)

## Verified

contract test **4/4**; `resolve-contract.ts` tsc + oxlint clean; `validate-routes` recognizes the route.

## Next (PR4b)

ws-server side: a JS resolve client (+ short-TTL cache, **A4**) → `buildWorkerEnv` routing in `handleChat`; `chat` gains `model`; store gains `selectedModelId`; reject-on-unhealthy; worker drops its dual `ANTHROPIC_*` source (**A5**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)