### PR TITLE
feat(models): ws-server per-request model routing + selection wire (PR4b)

### DIFF
--- a/src/claude/adapters/ws-adapter.ts
+++ b/src/claude/adapters/ws-adapter.ts
@@ -109,7 +109,7 @@ type StreamEvent = {
 type InboundMessage =
   | { type: 'create_session' }
   | { type: 'init_session'; sessionId: string }
-  | { type: 'chat'; content: string; sessionId?: string; skillSlug?: string; permissionTier?: string }
+  | { type: 'chat'; content: string; sessionId?: string; skillSlug?: string; permissionTier?: string; model?: string }
   | { type: 'resume'; sessionId: string }
   | { type: 'abort' }
   | { type: 'start_preview'; sessionId?: string; mode?: 'static' | 'live' }
@@ -849,6 +849,9 @@ const ClaudeAgentWSAdapter: ChatModelAdapter = {
           skillSlug: selectedSkill?.slug,
           // PR-B: client-preferred permission tier (server clamps to org ceiling).
           permissionTier: useChatSessionStore.getState().selectedTier,
+          // Multi-model: per-conversation selected model id (server validates +
+          // rejects on unknown/disabled/unhealthy; undefined → server default).
+          model: useChatSessionStore.getState().selectedModelId,
         });
         console.log('[WS Adapter] ✅ Message sent successfully');
       } catch (connectError) {

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -182,6 +182,10 @@ interface ChatSessionState {
   // Holds the interaction mode ('ask' | 'act'); field name kept for wire compat.
   selectedTier?: InteractionMode;
 
+  // Selected model id for this conversation (multi-model). undefined → server uses
+  // the configured default. Ephemeral per-session UI choice (DB-persisted in PR7).
+  selectedModelId?: string;
+
   // Actions
   setSessionId: (sessionId: string | null) => void;
   setMessages: (messages: ThreadMessage[]) => void;
@@ -209,6 +213,7 @@ interface ChatSessionState {
   addTemporarySkill: (skillSlug: string) => void;
   clearTemporarySkills: () => void;
   setSelectedTier: (mode: InteractionMode | undefined) => void;
+  setSelectedModelId: (id: string | undefined) => void;
 
   // Load historical messages from SDK format
   loadHistoricalMessages: (sdkMessages: SDKMessage[]) => void;
@@ -418,9 +423,14 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
   queueCount: 0, // Number of pending runs waiting to be processed
   temporarySkills: [],
   selectedTier: 'act' as const, // default: 执行(Act) — full capability, sandbox is the guard
+  selectedModelId: undefined,
 
   setSelectedTier: (selectedTier) => {
     set({ selectedTier });
+  },
+
+  setSelectedModelId: (selectedModelId) => {
+    set({ selectedModelId });
   },
 
   setSessionId: (sessionId) => {

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -25,6 +25,7 @@ import { shouldReapIdle } from './src/server/concurrency/idle-reaper.js';
 import { resolveEffectivePermission } from './src/lib/permission-tier.js';
 import { PreviewAuth } from './src/preview/auth.js';
 import { PreviewRuntime } from './src/preview/runtime.js';
+import { buildWorkerEnv } from './src/server/models/build-worker-env.js';
 
 // Get directory of current module
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1024,8 +1025,41 @@ async function handleStopPreview(ws, message) {
  * Handle chat message using child process for user and session isolation
  * Note: Thinking/reasoning is handled by SDK's claude_code preset automatically
  */
+// ── Multi-model: resolve the selected model's connection metadata (token-free)
+// from the web app, with a short-TTL cache so it stays off the per-message hot path
+// (arch finding A4). Secrets never cross the wire — the endpoint returns only the
+// tokenEnv NAME; the token value stays here in process.env. Contract:
+// src/server/models/resolve-contract.ts.
+const MODEL_RESOLVE_TTL_MS = Number(process.env.MODEL_RESOLVE_TTL_MS) || 60_000;
+const modelResolveCache = new Map(); // modelId → { meta: object|null, expiresAt: number }
+
+async function resolveModelForChat(cookie, modelId) {
+  if (!modelId) return null;
+  const cached = modelResolveCache.get(modelId);
+  if (cached && cached.expiresAt > Date.now()) return cached.meta;
+  try {
+    const response = await fetch(`${APP_URL}/api/models/resolve/${encodeURIComponent(modelId)}`, {
+      headers: { cookie: cookie || '' },
+    });
+    if (response.status === 404) {
+      modelResolveCache.set(modelId, { meta: null, expiresAt: Date.now() + MODEL_RESOLVE_TTL_MS });
+      return null;
+    }
+    if (!response.ok) {
+      console.error(`[WS Server] model resolve failed (${response.status}) for ${modelId}`);
+      return undefined; // transient — distinguish from a definitive 404 (null)
+    }
+    const meta = await response.json();
+    modelResolveCache.set(modelId, { meta, expiresAt: Date.now() + MODEL_RESOLVE_TTL_MS });
+    return meta;
+  } catch (error) {
+    console.error('[WS Server] model resolve error:', error);
+    return undefined; // transient
+  }
+}
+
 async function handleChat(ws, prompt, resumeSessionId, options = {}) {
-  const { silentInit = false, skillSlug = null, permissionTier = null } = options;
+  const { silentInit = false, skillSlug = null, permissionTier = null, model: selectedModel = null } = options;
   // Kill any existing worker for this connection
   if (ws.workerProcess) {
     console.log('[WS Server] Killing existing worker process');
@@ -1103,7 +1137,7 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     }
 
     // Build environment for worker process
-    const workerEnv = { ...process.env };
+    let workerEnv = { ...process.env };
     // Set both CLAUDE_HOME and HOME - SDK might use either
     workerEnv.CLAUDE_HOME = claudeHome;
     workerEnv.HOME = claudeHome;  // Override HOME so os.homedir() returns user dir
@@ -1115,6 +1149,35 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
     }
     if (config.model) workerEnv.ANTHROPIC_MODEL = config.model;
     workerEnv.ENABLE_TOOL_SEARCH = 'auto:10';  // Enable Tool Search when many MCP tools available
+
+    // Multi-model: if the client selected a model, route THIS run to its connection.
+    // Per owner decision #2, reject (don't silently fall back) on an unknown/disabled/
+    // unhealthy/unresolvable selection. No selection → keep the deployment default above.
+    if (selectedModel) {
+      const meta = await resolveModelForChat(ws.cookie, selectedModel);
+      if (meta === undefined) {
+        sendMessage(ws, { type: 'error', code: 'model_resolve_failed', message: 'Could not resolve the selected model right now. Please retry.', retriable: true });
+        return;
+      }
+      if (meta === null) {
+        sendMessage(ws, { type: 'error', code: 'model_not_found', message: `Selected model "${selectedModel}" no longer exists. Pick another model.`, retriable: false });
+        return;
+      }
+      if (!meta.enabled || meta.health !== 'healthy') {
+        const why = !meta.enabled ? 'disabled' : meta.health;
+        sendMessage(ws, { type: 'error', code: 'model_unavailable', message: `Selected model "${meta.id}" is currently ${why}. Pick another model.`, retriable: false });
+        return;
+      }
+      try {
+        // buildWorkerEnv returns a fresh env (copies workerEnv, sets ANTHROPIC_* and
+        // DELETES the unused auth var) — reassign so the deletion takes effect.
+        workerEnv = buildWorkerEnv(meta, workerEnv);
+        console.log(`[WS Server] Routed run to model ${meta.id} (connection ${meta.connectionId})`);
+      } catch (error) {
+        sendMessage(ws, { type: 'error', code: 'model_config_error', message: error instanceof Error ? error.message : String(error), retriable: false });
+        return;
+      }
+    }
 
     // Fetch permission info from API (includes organization settings)
     const permissionInfo = await fetchPermissionInfo(ws.cookie);
@@ -1480,6 +1543,7 @@ async function handleMessage(ws, msg) {
       await handleChat(ws, message.content, message.sessionId, {
         skillSlug: message.skillSlug,
         permissionTier: message.permissionTier,
+        model: message.model,
       });
       break;
 


### PR DESCRIPTION
## What

**PR4b** — the integration that makes model switching **route end-to-end** (prd rev.3 §8; absorbs arch findings A4/A5).

**`ws-server.mjs`**
- `resolveModelForChat(cookie, id)` — calls `GET /api/models/resolve/:id` (cookie-authed) with a **short-TTL cache** (`MODEL_RESOLVE_TTL_MS`, default 60s) to keep resolution off the per-message hot path (**A4**). `null` = definitive 404; `undefined` = transient failure.
- `handleChat` accepts `model`; after the base `workerEnv`, if a model is selected it **resolves + validates (enabled && healthy)** and **rejects** on unknown/disabled/unhealthy/unresolvable (**owner decision #2 — no silent fallback**), else routes via `buildWorkerEnv` (reassigned so the unused-auth-var delete sticks). **No selection → unchanged deployment-default behavior.**
- chat dispatch forwards `message.model`.

**`ws-adapter.ts`** — `model?` on the chat message; sends `selectedModelId`.
**`chat-session-store.ts`** — `selectedModelId` + `setSelectedModelId` (per-conversation).

## Safe to land standalone

The picker (PR5) sets `selectedModelId`; until then it's `undefined` → server uses the default → **no behavior change for existing chats**. This PR just wires the path + the reject logic.

## Verified

`node --check ws-server.mjs` OK · model unit tests **27/27** · `oxlint` 0 errors · no **new** tsc errors (the 2 in `ws-adapter` are pre-existing attachment-type issues, unrelated to the `model` field).

## Next

PR5 composer picker (reads `getSelectableModels`, writes `selectedModelId`) → PR6 `/admin/models` board+CRUD → PR7 `agent_session.model` persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)