### PR TITLE
feat(models): /admin/models health board (PR6)

### DIFF
--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -105,6 +105,18 @@ function AdminDashboard() {
               {content.dashboard.manageOrgsDesc}
             </p>
           </a>
+
+          <a
+            href="/admin/models"
+            className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 hover:shadow-lg transition-shadow"
+          >
+            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              模型与健康
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              查看模型健康度、启用/停用、设默认、重新探活（多模型）
+            </p>
+          </a>
         </div>
       </div>
     </div>

--- a/src/routes/admin/models/route.tsx
+++ b/src/routes/admin/models/route.tsx
@@ -1,0 +1,151 @@
+/**
+ * Admin · Model health board (PR6)
+ *
+ * Lists ALL configured models (incl. disabled/unhealthy) grouped by connection,
+ * with health + last-probe + reason + latency. Admins can enable/disable, set the
+ * default, and trigger a re-probe. Admin access is enforced by the parent /admin
+ * loader (requireSystemAdmin) and again by the server fns (requireAdmin).
+ *
+ * Connection/model CRUD forms are a fast-follow (PR6b); definitions bootstrap from
+ * OXY_MODELS_SEED. Tokens are never shown — only whether the tokenEnv resolves.
+ */
+
+import { useMemo, useState } from 'react';
+import { createFileRoute, useRouter } from '@tanstack/react-router';
+import { useServerFn } from '@tanstack/react-start';
+import { toast } from 'sonner';
+import { Loader2, RefreshCw, Star } from 'lucide-react';
+import {
+  listModelsAdminFn,
+  setModelEnabledFn,
+  setDefaultModelFn,
+  reprobeModelsFn,
+} from '~/server/function/models-admin.server';
+import type { AdminModelRow } from '~/server/models/registry';
+import { Button } from '~/components/ui/button';
+import { Badge } from '~/components/ui/badge';
+import { Switch } from '~/components/ui/switch';
+
+export const Route = createFileRoute('/admin/models')({
+  loader: async () => ({ models: await listModelsAdminFn() }),
+  component: AdminModelsPage,
+});
+
+const HEALTH_STYLE: Record<AdminModelRow['health'], string> = {
+  healthy: 'bg-emerald-500/15 text-emerald-600 border-emerald-500/30',
+  unhealthy: 'bg-red-500/15 text-red-600 border-red-500/30',
+  unknown: 'bg-muted text-muted-foreground border-border',
+};
+
+function fmtWhen(d: Date | string | null): string {
+  if (!d) return '从未';
+  const t = typeof d === 'string' ? new Date(d) : d;
+  return Number.isNaN(t.getTime()) ? '—' : t.toLocaleString();
+}
+
+function AdminModelsPage() {
+  const { models } = Route.useLoaderData();
+  const router = useRouter();
+  const setEnabled = useServerFn(setModelEnabledFn);
+  const setDefault = useServerFn(setDefaultModelFn);
+  const reprobe = useServerFn(reprobeModelsFn);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const groups = useMemo(() => {
+    const map = new Map<string, { label: string; baseUrl: string; authStyle: string; tokenEnv: string; tokenResolved: boolean; items: AdminModelRow[] }>();
+    for (const m of models) {
+      const g = map.get(m.connectionId) ?? {
+        label: m.connectionLabel, baseUrl: m.baseUrl, authStyle: m.authStyle, tokenEnv: m.tokenEnv, tokenResolved: m.tokenResolved, items: [],
+      };
+      g.items.push(m);
+      map.set(m.connectionId, g);
+    }
+    return [...map.values()];
+  }, [models]);
+
+  const run = async (key: string, fn: () => Promise<unknown>, okMsg: string) => {
+    setBusy(key);
+    try {
+      await fn();
+      await router.invalidate();
+      toast.success(okMsg);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : '操作失败');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold">模型与健康（多模型）</h1>
+          <p className="text-sm text-muted-foreground">来源/model id 在 <code>OXY_MODELS_SEED</code>(.env) 配置；这里看健康度并启用/停用、设默认、重测。</p>
+        </div>
+        <Button variant="outline" size="sm" disabled={busy === 'all'} onClick={() => run('all', () => reprobe({ data: {} }), '已触发全部重测')}>
+          {busy === 'all' ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          全部重测
+        </Button>
+      </div>
+
+      {models.length === 0 && (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          暂无模型。在 <code>.env</code> 配置 <code>OXY_MODELS_SEED</code> 后重启，或检查种子是否写入。
+        </div>
+      )}
+
+      {groups.map((g) => (
+        <div key={g.label} className="mb-6 rounded-lg border">
+          <div className="flex flex-wrap items-center gap-2 border-b bg-muted/40 px-4 py-2 text-xs">
+            <span className="font-semibold text-foreground">{g.label}</span>
+            <span className="text-muted-foreground">{g.baseUrl}</span>
+            <Badge variant="outline">{g.authStyle}</Badge>
+            <Badge variant="outline" className={g.tokenResolved ? 'text-emerald-600' : 'text-red-600'}>
+              {g.tokenEnv}{g.tokenResolved ? ' ✓' : ' ✗未配置'}
+            </Badge>
+          </div>
+          <div className="divide-y">
+            {g.items.map((m) => (
+              <div key={m.id} className="flex flex-wrap items-center gap-3 px-4 py-3">
+                <div className="min-w-40 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{m.label}</span>
+                    {m.isDefault && <Badge className="gap-1"><Star className="h-3 w-3" />默认</Badge>}
+                    {m.tags.map((t) => <Badge key={t} variant="secondary">{t}</Badge>)}
+                  </div>
+                  <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">{m.model}</div>
+                </div>
+
+                <div className="min-w-44 text-[11px] text-muted-foreground">
+                  <Badge variant="outline" className={HEALTH_STYLE[m.health]}>{m.health}</Badge>
+                  {m.probeError && <span className="ml-1 text-red-600">{m.probeError}</span>}
+                  <div className="mt-0.5">探活: {fmtWhen(m.lastProbeAt)}{m.latencyMs != null ? ` · ${m.latencyMs}ms` : ''}</div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Switch
+                      checked={m.enabled}
+                      disabled={busy === m.id}
+                      onCheckedChange={(v) => run(m.id, () => setEnabled({ data: { id: m.id, enabled: v } }), v ? '已启用' : '已停用')}
+                    />
+                    启用
+                  </label>
+                  <Button variant="ghost" size="sm" disabled={busy === m.id || m.isDefault}
+                    onClick={() => run(m.id, () => setDefault({ data: { id: m.id } }), '已设为默认')}>
+                    设默认
+                  </Button>
+                  <Button variant="ghost" size="sm" disabled={busy === m.id}
+                    onClick={() => run(m.id, () => reprobe({ data: { modelId: m.id } }), '已触发重测')}>
+                    {busy === m.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/server/function/models-admin.server.ts
+++ b/src/server/function/models-admin.server.ts
@@ -1,0 +1,67 @@
+/**
+ * Multi-model admin server functions (PR6).
+ *
+ * Admin-only board controls: list all models (incl. disabled/unhealthy) with health,
+ * toggle enabled, set the default, and enqueue a re-probe. Connection/model CRUD
+ * forms are a fast-follow (PR6b); definitions bootstrap from OXY_MODELS_SEED. All
+ * fns require system admin; none return a token value.
+ */
+
+import { createServerFn } from '@tanstack/react-start';
+import { getRequest } from '@tanstack/react-start/server';
+import { z } from 'zod';
+import { auth } from '~/server/auth.server';
+import {
+  listModelsAdmin,
+  setModelEnabled,
+  setDefaultModelById,
+  type AdminModelRow,
+} from '~/server/models/registry';
+import { systemQueue } from '~/jobs/queues';
+
+const requireAdmin = async () => {
+  const { headers } = getRequest();
+  const session = await auth.api.getSession({ headers });
+  if (!session?.user) throw new Error('UNAUTHORIZED');
+  const { db } = await import('~/db/db-config');
+  const { user: userTable } = await import('~/db/schema');
+  const { eq } = await import('drizzle-orm');
+  const userData = await db.query.user.findFirst({
+    where: eq(userTable.id, session.user.id),
+    columns: { systemRole: true },
+  });
+  if (userData?.systemRole !== 'admin') throw new Error('FORBIDDEN: Admin access required');
+  return session.user;
+};
+
+export const listModelsAdminFn = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<AdminModelRow[]> => {
+    await requireAdmin();
+    return listModelsAdmin();
+  },
+);
+
+export const setModelEnabledFn = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ id: z.string().min(1), enabled: z.boolean() }))
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await setModelEnabled(data.id, data.enabled);
+    return { ok: true };
+  });
+
+export const setDefaultModelFn = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await setDefaultModelById(data.id);
+    return { ok: true };
+  });
+
+/** Enqueue a health re-probe (one model when modelId given, else the full sweep). */
+export const reprobeModelsFn = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ modelId: z.string().optional() }))
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await systemQueue.add('probe-models', data.modelId ? { modelId: data.modelId } : {});
+    return { ok: true };
+  });

--- a/src/server/models/registry.ts
+++ b/src/server/models/registry.ts
@@ -181,3 +181,71 @@ export async function getDefaultModelId(): Promise<string | null> {
     .limit(1);
   return def?.id ?? selectable[0].id;
 }
+
+// ── Admin board (PR6) ─────────────────────────────────────────────────────────
+
+/** A model row for the admin board: full state incl. disabled/unhealthy. No token. */
+export type AdminModelRow = {
+  id: string;
+  label: string;
+  model: string;
+  tags: string[];
+  enabled: boolean;
+  isDefault: boolean;
+  connectionId: string;
+  connectionLabel: string;
+  baseUrl: string;
+  authStyle: AuthStyle;
+  tokenEnv: string;
+  tokenResolved: boolean; // whether process.env[tokenEnv] is set (server-side; value never shown)
+  health: 'healthy' | 'unhealthy' | 'unknown';
+  lastProbeAt: Date | null;
+  probeError: string | null;
+  latencyMs: number | null;
+};
+
+/** All models (incl. disabled/unhealthy) for the admin board. Token-free. */
+export async function listModelsAdmin(): Promise<AdminModelRow[]> {
+  const rows = await db
+    .select({
+      id: modelDefinition.id,
+      label: modelDefinition.label,
+      model: modelDefinition.model,
+      tags: modelDefinition.tags,
+      enabled: modelDefinition.enabled,
+      isDefault: modelDefinition.isDefault,
+      defSort: modelDefinition.sort,
+      connectionId: modelConnection.id,
+      connectionLabel: modelConnection.label,
+      connSort: modelConnection.sort,
+      baseUrl: modelConnection.baseUrl,
+      authStyle: modelConnection.authStyle,
+      tokenEnv: modelConnection.tokenEnv,
+      health: modelHealth.health,
+      lastProbeAt: modelHealth.lastProbeAt,
+      probeError: modelHealth.probeError,
+      latencyMs: modelHealth.latencyMs,
+    })
+    .from(modelDefinition)
+    .innerJoin(modelConnection, eq(modelDefinition.connectionId, modelConnection.id))
+    .leftJoin(modelHealth, eq(modelHealth.modelId, modelDefinition.id));
+
+  return rows
+    .sort((a, b) => a.connSort - b.connSort || a.defSort - b.defSort)
+    .map(({ connSort: _c, defSort: _d, ...r }) => ({
+      ...r,
+      tokenResolved: !!process.env[r.tokenEnv],
+      health: r.health ?? 'unknown',
+    }));
+}
+
+/** Toggle a model's enabled flag. */
+export async function setModelEnabled(id: string, enabled: boolean): Promise<void> {
+  await db.update(modelDefinition).set({ enabled }).where(eq(modelDefinition.id, id));
+}
+
+/** Make `id` the single default model (clears the previous default). */
+export async function setDefaultModelById(id: string): Promise<void> {
+  await db.update(modelDefinition).set({ isDefault: false }).where(eq(modelDefinition.isDefault, true));
+  await db.update(modelDefinition).set({ isDefault: true }).where(eq(modelDefinition.id, id));
+}


### PR DESCRIPTION
## What

**PR6** — the admin health board (prd rev.3 §7; owner decisions #3/#5).

- **`registry.ts`** — `listModelsAdmin()` (all models incl. disabled/unhealthy + health + a **`tokenResolved`** flag, never the token value), `setModelEnabled()`, `setDefaultModelById()`.
- **`models-admin.server.ts`** — `requireAdmin` server fns: `listModelsAdminFn`, `setModelEnabledFn`, `setDefaultModelFn`, `reprobeModelsFn` (enqueues the `probe-models` BullMQ job, optionally for one `modelId`).
- **`/admin/models`** — board grouped by connection (baseUrl/authStyle + **`tokenEnv` ✓/✗未配置**), per-model **health badge + last-probe + reason + latency**, **enable/disable** Switch, **set-default**, **re-probe** (single + all). Admin-gated by the parent `/admin` loader *and* each fn's `requireAdmin`.
- **`admin/index.tsx`** — a "模型与健康" nav card.

## Scope note

Connection/model **CRUD forms** are a fast-follow (PR6b); definitions bootstrap from `OXY_MODELS_SEED`, so the board already covers see-health / enable / default / re-probe — the operational core of decisions #3/#5.

## Verified

`registry.ts` + `models-admin.server.ts` tsc clean; `oxlint` 0 errors; model unit tests **27/27**. The `route.tsx` local tsc errors are the **stale-gen-tree cascade** (route not in the local tree → `useLoaderData` types as `never`), resolved by the CI **build** — same as the PR4a route. `routeTree.gen.ts` is gitignored + regenerated by the build.

## Next

PR7 — `agent_session.model` per-conversation persistence (resume remembers the model). Then ready for the OrbStack browser test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)