### PR TITLE
feat(models): probe models once on worker boot (PR7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ ANTHROPIC_API_KEY="sk-ant-api03-xxxxx"
 # ZHIPU_AUTH_TOKEN="..."
 # Health probe cadence (BullMQ repeat; default every 6h):
 # MODEL_PROBE_CRON="0 */6 * * *"
+# Probe once on worker boot so freshly-seeded models become selectable in minutes
+# (default on). Set to "false" to wait for the first scheduled tick instead.
+# MODEL_PROBE_ON_BOOT="true"
 
 # Optional: Zhipu API key — only needed for the built-in GLM image-generation tool and the
 # Zhipu MCP servers (zhipu-search/reader/zread/vision). Leave unset if you don't use them.

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -67,6 +67,14 @@ events.on('failed', ({ jobId, failedReason }) =>
     logger.info('[worker] scheduled probe-models', { cron: probeCron })
   }
 
+  // Probe once on boot (default on) so freshly-seeded models become selectable in
+  // minutes instead of waiting for the first 6h tick. Set MODEL_PROBE_ON_BOOT=false
+  // to disable.
+  if ((process.env.MODEL_PROBE_ON_BOOT ?? 'true').toLowerCase() !== 'false') {
+    await queue.add('probe-models', {}, { jobId: `probe-boot-${Date.now()}` })
+    logger.info('[worker] queued probe-models on boot')
+  }
+
   if (process.env.SEARCH_REINDEX_ON_BOOT === 'true') {
     await queue.add('reindex-all', {}, { jobId: `reindex-${Date.now()}` })
     logger.info('[worker] queued reindex-all on boot')


### PR DESCRIPTION
## What

Probe all models **once on worker boot** (default on, `MODEL_PROBE_ON_BOOT`) so freshly-seeded models become **selectable within minutes** of start — instead of showing an empty picker until the first 6h tick or a manual `/admin/models` "全部重测".

Mirrors the existing `SEARCH_REINDEX_ON_BOOT` bootstrap. `.env.example` documented.

## Why it matters

`getSelectableModels()` requires `health = 'healthy'`; seed rows start `unknown`. Without a boot probe the menu is empty on a fresh deploy until the schedule runs. This makes the feature work out-of-the-box (and makes the OrbStack test immediate).

Verified: `worker/index.ts` lint clean; tsc shows only the pre-existing `.ts`-import / `j.cron` patterns (worker runs via tsx/loader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)