### PR TITLE
docs(env): verified 4-model ARK seed example (one endpoint, switch model-id)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,14 +35,17 @@ ANTHROPIC_API_KEY="sk-ant-api03-xxxxx"
 
 # ── Multi-model switching (optional) ──────────────────────────────────────────
 # If unset, the single ANTHROPIC_* above is used as one connection (a 1-item menu).
-# To offer multiple switchable models across accounts/gateways, set OXY_MODELS_SEED:
-# a NON-SECRET JSON of connections + models. Secrets are referenced by `tokenEnv`
-# NAME only (the value lives in its own env var below) — never put a token in here,
-# the DB, or the UI. This seeds the DB on first boot; admins then manage models in
+# To offer switchable models, set OXY_MODELS_SEED: a NON-SECRET JSON of connections
+# + models. Secrets are referenced by `tokenEnv` NAME only — never put a token in
+# here, the DB, or the UI. Seeds the DB on first boot; admins then manage models in
 # /admin/models. See docs/project/prd/2026-06-multi-model-switching-prd.md.
-# OXY_MODELS_SEED='{"default":"ark/glm-5.1","connections":[{"id":"ark-coding","label":"火山 ARK","baseUrl":"https://ark.cn-beijing.volces.com/api/coding","authStyle":"bearer","tokenEnv":"ARK_AUTH_TOKEN","aliasHaiku":"doubao-seed-2.0-lite"},{"id":"zhipu","label":"智谱 GLM","baseUrl":"https://open.bigmodel.cn/api/anthropic","authStyle":"bearer","tokenEnv":"ZHIPU_AUTH_TOKEN"}],"models":[{"id":"ark/glm-5.1","label":"GLM 5.1","connection":"ark-coding","model":"glm-5.1","isDefault":true,"tags":["general"]},{"id":"ark/doubao-code","label":"Doubao Code 2.0","connection":"ark-coding","model":"doubao-seed-2.0-code","tags":["coding"]},{"id":"zhipu/glm-5.1","label":"GLM 5.1 (Zhipu)","connection":"zhipu","model":"glm-5.1","tags":["general"]}]}'
-# Per-connection secrets (names referenced by tokenEnv above; values only here):
-# ARK_AUTH_TOKEN="..."
+#
+# Example below = ONE ARK coding endpoint, 4 models switchable by model-id, reusing
+# the existing ANTHROPIC_AUTH_TOKEN above (no new secret). All 4 verified on ARK.
+# OXY_MODELS_SEED='{"default":"ark/glm-5.1","connections":[{"id":"ark-coding","label":"火山 ARK","baseUrl":"https://ark.cn-beijing.volces.com/api/coding","authStyle":"bearer","tokenEnv":"ANTHROPIC_AUTH_TOKEN"}],"models":[{"id":"ark/glm-5.1","label":"GLM 5.1","connection":"ark-coding","model":"glm-5.1","isDefault":true,"tags":["general"]},{"id":"ark/doubao-code","label":"Doubao Seed 2.0 Code","connection":"ark-coding","model":"doubao-seed-2.0-code","tags":["coding"]},{"id":"ark/doubao-pro","label":"Doubao Seed 2.0 Pro","connection":"ark-coding","model":"doubao-seed-2.0-pro","tags":["general"]},{"id":"ark/minimax","label":"MiniMax","connection":"ark-coding","model":"minimax-latest","tags":["general"]}]}'
+#
+# For cross-account/cross-gateway, add more connections each with their own
+# baseUrl + a distinct tokenEnv, and set that token below. e.g.:
 # ZHIPU_AUTH_TOKEN="..."
 # Health probe cadence (BullMQ repeat; default every 6h):
 # MODEL_PROBE_CRON="0 */6 * * *"


### PR DESCRIPTION
## What

ARK's coding gateway serves **GLM-5.1, Doubao-Seed-2.0-Code, Doubao-Seed-2.0-Pro, MiniMax-latest** behind **one endpoint + one token** — switchable by model-id alone. Replaces the `.env.example` `OXY_MODELS_SEED` placeholder with this **verified single-connection 4-model** example, reusing the existing `ANTHROPIC_AUTH_TOKEN` (no new secret).

All 4 confirmed **HTTP 200** on `https://ark.cn-beijing.volces.com/api/coding/v1/messages` (the exact path the SDK + the health probe use).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)