### PR TITLE
feat(models): admin CRUD for connections + models (PR6b)

### DIFF
--- a/src/routes/admin/models/route.tsx
+++ b/src/routes/admin/models/route.tsx
@@ -1,30 +1,34 @@
 /**
- * Admin · Model health board (PR6)
+ * Admin · Model board + CRUD (PR6 + PR6b)
  *
  * Lists ALL configured models (incl. disabled/unhealthy) grouped by connection,
- * with health + last-probe + reason + latency. Admins can enable/disable, set the
- * default, and trigger a re-probe. Admin access is enforced by the parent /admin
- * loader (requireSystemAdmin) and again by the server fns (requireAdmin).
- *
- * Connection/model CRUD forms are a fast-follow (PR6b); definitions bootstrap from
- * OXY_MODELS_SEED. Tokens are never shown — only whether the tokenEnv resolves.
+ * with health + last-probe + reason + latency. Admins can add/delete connections
+ * and models, enable/disable, set the default, and re-probe. Admin access is
+ * enforced by the parent /admin loader (requireSystemAdmin) + each server fn
+ * (requireAdmin). Tokens are never shown — only whether the tokenEnv resolves;
+ * a new connection's secret must be set in the server env (.env) under tokenEnv.
  */
 
 import { useMemo, useState } from 'react';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { useServerFn } from '@tanstack/react-start';
 import { toast } from 'sonner';
-import { Loader2, RefreshCw, Star } from 'lucide-react';
+import { Loader2, RefreshCw, Star, Trash2, Plus } from 'lucide-react';
 import {
   listModelsAdminFn,
   setModelEnabledFn,
   setDefaultModelFn,
   reprobeModelsFn,
+  upsertConnectionFn,
+  deleteConnectionFn,
+  upsertModelFn,
+  deleteModelFn,
 } from '~/server/function/models-admin.server';
 import type { AdminModelRow } from '~/server/models/registry';
 import { Button } from '~/components/ui/button';
 import { Badge } from '~/components/ui/badge';
 import { Switch } from '~/components/ui/switch';
+import { Input } from '~/components/ui/input';
 
 export const Route = createFileRoute('/admin/models')({
   loader: async () => ({ models: await listModelsAdminFn() }),
@@ -43,13 +47,24 @@ function fmtWhen(d: Date | string | null): string {
   return Number.isNaN(t.getTime()) ? '—' : t.toLocaleString();
 }
 
+const emptyConn = { id: '', label: '', baseUrl: '', authStyle: 'bearer', tokenEnv: '', aliasHaiku: '' };
+const emptyModel = { id: '', label: '', connectionId: '', model: '', tags: '' };
+
 function AdminModelsPage() {
   const { models } = Route.useLoaderData();
   const router = useRouter();
   const setEnabled = useServerFn(setModelEnabledFn);
   const setDefault = useServerFn(setDefaultModelFn);
   const reprobe = useServerFn(reprobeModelsFn);
+  const upsertConn = useServerFn(upsertConnectionFn);
+  const delConn = useServerFn(deleteConnectionFn);
+  const upsertMdl = useServerFn(upsertModelFn);
+  const delMdl = useServerFn(deleteModelFn);
+
   const [busy, setBusy] = useState<string | null>(null);
+  const [connForm, setConnForm] = useState({ ...emptyConn });
+  const [modelForm, setModelForm] = useState({ ...emptyModel });
+  const [showForms, setShowForms] = useState(false);
 
   const groups = useMemo(() => {
     const map = new Map<string, { label: string; baseUrl: string; authStyle: string; tokenEnv: string; tokenResolved: boolean; items: AdminModelRow[] }>();
@@ -60,8 +75,10 @@ function AdminModelsPage() {
       g.items.push(m);
       map.set(m.connectionId, g);
     }
-    return [...map.values()];
+    return [...map.entries()].map(([id, g]) => ({ id, ...g }));
   }, [models]);
+
+  const connectionIds = useMemo(() => [...new Set(models.map((m) => m.connectionId))], [models]);
 
   const run = async (key: string, fn: () => Promise<unknown>, okMsg: string) => {
     setBusy(key);
@@ -81,22 +98,70 @@ function AdminModelsPage() {
       <div className="mb-4 flex items-center justify-between">
         <div>
           <h1 className="text-lg font-semibold">模型与健康（多模型）</h1>
-          <p className="text-sm text-muted-foreground">来源/model id 在 <code>OXY_MODELS_SEED</code>(.env) 配置；这里看健康度并启用/停用、设默认、重测。</p>
+          <p className="text-sm text-muted-foreground">来源也可在 <code>OXY_MODELS_SEED</code>(.env) 配置。密钥仅放服务器 env（按 tokenEnv 名），不在此存。</p>
         </div>
-        <Button variant="outline" size="sm" disabled={busy === 'all'} onClick={() => run('all', () => reprobe({ data: {} }), '已触发全部重测')}>
-          {busy === 'all' ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-          全部重测
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => setShowForms((v) => !v)}>
+            <Plus className="h-4 w-4" />{showForms ? '收起' : '新增'}
+          </Button>
+          <Button variant="outline" size="sm" disabled={busy === 'all'} onClick={() => run('all', () => reprobe({ data: {} }), '已触发全部重测')}>
+            {busy === 'all' ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            全部重测
+          </Button>
+        </div>
       </div>
 
-      {models.length === 0 && (
+      {showForms && (
+        <div className="mb-6 grid gap-4 rounded-lg border bg-muted/20 p-4 md:grid-cols-2">
+          {/* Add/Update connection */}
+          <form
+            className="space-y-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void run('conn-form', () => upsertConn({ data: { id: connForm.id.trim(), label: connForm.label.trim(), baseUrl: connForm.baseUrl.trim(), authStyle: connForm.authStyle as 'bearer' | 'x-api-key', tokenEnv: connForm.tokenEnv.trim(), aliasHaiku: connForm.aliasHaiku.trim() || null } }), '连接已保存').then(() => setConnForm({ ...emptyConn }));
+            }}
+          >
+            <div className="text-xs font-semibold text-foreground">新增/更新连接</div>
+            <Input required placeholder="id 如 ark-coding" value={connForm.id} onChange={(e) => setConnForm({ ...connForm, id: e.target.value })} />
+            <Input required placeholder="显示名" value={connForm.label} onChange={(e) => setConnForm({ ...connForm, label: e.target.value })} />
+            <Input required placeholder="baseUrl 如 https://ark.cn-beijing.volces.com/api/coding" value={connForm.baseUrl} onChange={(e) => setConnForm({ ...connForm, baseUrl: e.target.value })} />
+            <select className="h-9 w-full rounded-md border bg-background px-3 text-sm" value={connForm.authStyle} onChange={(e) => setConnForm({ ...connForm, authStyle: e.target.value })}>
+              <option value="bearer">bearer (ANTHROPIC_AUTH_TOKEN 风格)</option>
+              <option value="x-api-key">x-api-key (原生)</option>
+            </select>
+            <Input required placeholder="tokenEnv 如 ANTHROPIC_AUTH_TOKEN（env 变量名，非值）" value={connForm.tokenEnv} onChange={(e) => setConnForm({ ...connForm, tokenEnv: e.target.value })} />
+            <Input placeholder="aliasHaiku（可选，后台档模型）" value={connForm.aliasHaiku} onChange={(e) => setConnForm({ ...connForm, aliasHaiku: e.target.value })} />
+            <Button type="submit" size="sm" disabled={busy === 'conn-form'}>保存连接</Button>
+          </form>
+
+          {/* Add/Update model */}
+          <form
+            className="space-y-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void run('model-form', () => upsertMdl({ data: { id: modelForm.id.trim(), label: modelForm.label.trim(), connectionId: modelForm.connectionId.trim(), model: modelForm.model.trim(), tags: modelForm.tags.split(',').map((t) => t.trim()).filter(Boolean) } }), '模型已保存').then(() => setModelForm({ ...emptyModel }));
+            }}
+          >
+            <div className="text-xs font-semibold text-foreground">新增/更新模型</div>
+            <Input required placeholder="id 如 ark/glm-5.1（线上传输用）" value={modelForm.id} onChange={(e) => setModelForm({ ...modelForm, id: e.target.value })} />
+            <Input required placeholder="显示名 如 GLM 5.1" value={modelForm.label} onChange={(e) => setModelForm({ ...modelForm, label: e.target.value })} />
+            <input list="conn-ids" required className="h-9 w-full rounded-md border bg-background px-3 text-sm" placeholder="connectionId 如 ark-coding" value={modelForm.connectionId} onChange={(e) => setModelForm({ ...modelForm, connectionId: e.target.value })} />
+            <datalist id="conn-ids">{connectionIds.map((id) => <option key={id} value={id} />)}</datalist>
+            <Input required placeholder="model（网关认的串）如 glm-5.1" value={modelForm.model} onChange={(e) => setModelForm({ ...modelForm, model: e.target.value })} />
+            <Input placeholder="tags 逗号分隔（可选）如 coding,fast" value={modelForm.tags} onChange={(e) => setModelForm({ ...modelForm, tags: e.target.value })} />
+            <Button type="submit" size="sm" disabled={busy === 'model-form'}>保存模型</Button>
+          </form>
+        </div>
+      )}
+
+      {models.length === 0 && !showForms && (
         <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
-          暂无模型。在 <code>.env</code> 配置 <code>OXY_MODELS_SEED</code> 后重启，或检查种子是否写入。
+          暂无模型。点「新增」添加，或在 <code>.env</code> 配置 <code>OXY_MODELS_SEED</code> 后重启。
         </div>
       )}
 
       {groups.map((g) => (
-        <div key={g.label} className="mb-6 rounded-lg border">
+        <div key={g.id} className="mb-6 rounded-lg border">
           <div className="flex flex-wrap items-center gap-2 border-b bg-muted/40 px-4 py-2 text-xs">
             <span className="font-semibold text-foreground">{g.label}</span>
             <span className="text-muted-foreground">{g.baseUrl}</span>
@@ -104,6 +169,10 @@ function AdminModelsPage() {
             <Badge variant="outline" className={g.tokenResolved ? 'text-emerald-600' : 'text-red-600'}>
               {g.tokenEnv}{g.tokenResolved ? ' ✓' : ' ✗未配置'}
             </Badge>
+            <Button variant="ghost" size="sm" className="ml-auto text-red-600" disabled={busy === g.id}
+              onClick={() => { if (confirm(`删除连接「${g.label}」及其所有模型？`)) void run(g.id, () => delConn({ data: { id: g.id } }), '连接已删除'); }}>
+              <Trash2 className="h-4 w-4" />
+            </Button>
           </div>
           <div className="divide-y">
             {g.items.map((m) => (
@@ -114,7 +183,7 @@ function AdminModelsPage() {
                     {m.isDefault && <Badge className="gap-1"><Star className="h-3 w-3" />默认</Badge>}
                     {m.tags.map((t) => <Badge key={t} variant="secondary">{t}</Badge>)}
                   </div>
-                  <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">{m.model}</div>
+                  <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">{m.id} · {m.model}</div>
                 </div>
 
                 <div className="min-w-44 text-[11px] text-muted-foreground">
@@ -125,20 +194,19 @@ function AdminModelsPage() {
 
                 <div className="flex items-center gap-2">
                   <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <Switch
-                      checked={m.enabled}
-                      disabled={busy === m.id}
-                      onCheckedChange={(v) => run(m.id, () => setEnabled({ data: { id: m.id, enabled: v } }), v ? '已启用' : '已停用')}
-                    />
+                    <Switch checked={m.enabled} disabled={busy === m.id}
+                      onCheckedChange={(v) => run(m.id, () => setEnabled({ data: { id: m.id, enabled: v } }), v ? '已启用' : '已停用')} />
                     启用
                   </label>
                   <Button variant="ghost" size="sm" disabled={busy === m.id || m.isDefault}
-                    onClick={() => run(m.id, () => setDefault({ data: { id: m.id } }), '已设为默认')}>
-                    设默认
-                  </Button>
+                    onClick={() => run(m.id, () => setDefault({ data: { id: m.id } }), '已设为默认')}>设默认</Button>
                   <Button variant="ghost" size="sm" disabled={busy === m.id}
                     onClick={() => run(m.id, () => reprobe({ data: { modelId: m.id } }), '已触发重测')}>
                     {busy === m.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  </Button>
+                  <Button variant="ghost" size="sm" className="text-red-600" disabled={busy === m.id}
+                    onClick={() => { if (confirm(`删除模型「${m.label}」？`)) void run(m.id, () => delMdl({ data: { id: m.id } }), '模型已删除'); }}>
+                    <Trash2 className="h-4 w-4" />
                   </Button>
                 </div>
               </div>

--- a/src/server/function/models-admin.server.ts
+++ b/src/server/function/models-admin.server.ts
@@ -15,8 +15,13 @@ import {
   listModelsAdmin,
   setModelEnabled,
   setDefaultModelById,
+  upsertConnection,
+  deleteConnection,
+  upsertModel,
+  deleteModel,
   type AdminModelRow,
 } from '~/server/models/registry';
+import { AUTH_STYLES } from '~/server/models/model-config';
 import { systemQueue } from '~/jobs/queues';
 
 const requireAdmin = async () => {
@@ -63,5 +68,63 @@ export const reprobeModelsFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     await requireAdmin();
     await systemQueue.add('probe-models', data.modelId ? { modelId: data.modelId } : {});
+    return { ok: true };
+  });
+
+// ── CRUD (PR6b) ───────────────────────────────────────────────────────────────
+
+const idRe = /^[a-zA-Z0-9._/-]+$/;
+
+const connectionInputSchema = z.object({
+  id: z.string().min(1).regex(idRe),
+  label: z.string().min(1),
+  baseUrl: z.string().url(),
+  authStyle: z.enum(AUTH_STYLES),
+  tokenEnv: z.string().min(1),
+  anthropicVersion: z.string().optional(),
+  aliasOpus: z.string().nullish(),
+  aliasSonnet: z.string().nullish(),
+  aliasHaiku: z.string().nullish(),
+  aliasSubagent: z.string().nullish(),
+});
+
+const modelInputSchema = z.object({
+  id: z.string().min(1).regex(idRe),
+  label: z.string().min(1),
+  connectionId: z.string().min(1),
+  model: z.string().min(1),
+  tags: z.array(z.string()).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const upsertConnectionFn = createServerFn({ method: 'POST' })
+  .inputValidator(connectionInputSchema)
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await upsertConnection({ ...data, aliasOpus: data.aliasOpus ?? null, aliasSonnet: data.aliasSonnet ?? null, aliasHaiku: data.aliasHaiku ?? null, aliasSubagent: data.aliasSubagent ?? null });
+    return { ok: true };
+  });
+
+export const deleteConnectionFn = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await deleteConnection(data.id);
+    return { ok: true };
+  });
+
+export const upsertModelFn = createServerFn({ method: 'POST' })
+  .inputValidator(modelInputSchema)
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await upsertModel(data);
+    return { ok: true };
+  });
+
+export const deleteModelFn = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    await requireAdmin();
+    await deleteModel(data.id);
     return { ok: true };
   });

--- a/src/server/models/registry.ts
+++ b/src/server/models/registry.ts
@@ -249,3 +249,82 @@ export async function setDefaultModelById(id: string): Promise<void> {
   await db.update(modelDefinition).set({ isDefault: false }).where(eq(modelDefinition.isDefault, true));
   await db.update(modelDefinition).set({ isDefault: true }).where(eq(modelDefinition.id, id));
 }
+
+// ── Admin CRUD (PR6b) ─────────────────────────────────────────────────────────
+// Definitions live in the DB; secrets stay in env (tokenEnv NAME only). Adding a
+// connection here records its tokenEnv; the value must exist in the server env.
+
+export type ConnectionInput = {
+  id: string;
+  label: string;
+  baseUrl: string;
+  authStyle: AuthStyle;
+  tokenEnv: string;
+  anthropicVersion?: string;
+  aliasOpus?: string | null;
+  aliasSonnet?: string | null;
+  aliasHaiku?: string | null;
+  aliasSubagent?: string | null;
+};
+
+export type ModelInput = {
+  id: string;
+  label: string;
+  connectionId: string;
+  model: string;
+  tags?: string[];
+  enabled?: boolean;
+};
+
+/** Create or update a connection (upsert by id). */
+export async function upsertConnection(c: ConnectionInput): Promise<void> {
+  const values = {
+    id: c.id,
+    label: c.label,
+    baseUrl: c.baseUrl,
+    authStyle: c.authStyle,
+    tokenEnv: c.tokenEnv,
+    anthropicVersion: c.anthropicVersion || '2023-06-01',
+    aliasOpus: c.aliasOpus ?? null,
+    aliasSonnet: c.aliasSonnet ?? null,
+    aliasHaiku: c.aliasHaiku ?? null,
+    aliasSubagent: c.aliasSubagent ?? null,
+  };
+  await db
+    .insert(modelConnection)
+    .values(values)
+    .onConflictDoUpdate({ target: modelConnection.id, set: { ...values, updatedAt: new Date() } });
+}
+
+/** Delete a connection (cascades to its models + health rows). */
+export async function deleteConnection(id: string): Promise<void> {
+  await db.delete(modelConnection).where(eq(modelConnection.id, id));
+}
+
+/** Create or update a model (upsert by id). Verifies the connection exists. */
+export async function upsertModel(m: ModelInput): Promise<void> {
+  const [conn] = await db
+    .select({ id: modelConnection.id })
+    .from(modelConnection)
+    .where(eq(modelConnection.id, m.connectionId))
+    .limit(1);
+  if (!conn) throw new Error(`Unknown connection "${m.connectionId}"`);
+  const values = {
+    id: m.id,
+    label: m.label,
+    connectionId: m.connectionId,
+    model: m.model,
+    tags: m.tags ?? [],
+    enabled: m.enabled ?? true,
+  };
+  await db
+    .insert(modelDefinition)
+    .values(values)
+    .onConflictDoUpdate({ target: modelDefinition.id, set: { ...values, updatedAt: new Date() } });
+  await db.insert(modelHealth).values({ modelId: m.id, health: 'unknown' }).onConflictDoNothing();
+}
+
+/** Delete a model (cascades to its health row). */
+export async function deleteModel(id: string): Promise<void> {
+  await db.delete(modelDefinition).where(eq(modelDefinition.id, id));
+}


### PR DESCRIPTION
## What

**PR6b** completes `/admin/models` with **create/update/delete** for connections + models — the last piece of "configure in the backend".

- **`registry.ts`** — `upsertConnection` / `deleteConnection` (cascades to models+health) / `upsertModel` (verifies the connection exists, seeds an `unknown` health row) / `deleteModel`.
- **`models-admin.server.ts`** — `requireAdmin` + Zod fns: `upsertConnectionFn`, `deleteConnectionFn`, `upsertModelFn`, `deleteModelFn` (id regex, `authStyle` from `AUTH_STYLES`). **Secrets stay in env** — forms take the `tokenEnv` *name* only (a new connection's token value must be set in the server env).
- **`/admin/models`** — add/update forms (connection + model; `connectionId` via `<datalist>`) + per-connection & per-model delete (with confirm). The health/enable/default/reprobe board is unchanged.

## Verified

`registry.ts` + `models-admin.server.ts` tsc clean + `oxlint` 0 errors. The `route.tsx` local tsc errors are the **stale-gen-tree cascade** (`useLoaderData` types as `never` until the tree regenerates) — resolved by the CI **build**, same as PR6/PR4a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)