### PR TITLE
ci(tunnel): forward multi-model env to app + worker

### DIFF
--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -194,6 +194,13 @@ services:
       MEILI_HOST: http://meilisearch:7700
       MEILI_API_KEY: ${MEILI_API_KEY:-${MEILI_MASTER_KEY}}
       SEARCH_REINDEX_ON_BOOT: ${SEARCH_REINDEX_ON_BOOT:-false}
+      # Multi-model health probe (runs here): needs the ARK Bearer token to call
+      # {baseUrl}/v1/messages. baseUrl/model come from the DB; the token is read by
+      # name (tokenEnv). Probes on boot + every 6h.
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      MODEL_PROBE_ON_BOOT: ${MODEL_PROBE_ON_BOOT:-true}
+      MODEL_PROBE_CRON: ${MODEL_PROBE_CRON:-0 */6 * * *}
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     command: ['npx', 'tsx', 'src/worker/index.ts']
@@ -288,6 +295,9 @@ services:
       ANTHROPIC_DEFAULT_OPUS_MODEL: ${ANTHROPIC_DEFAULT_OPUS_MODEL:-}
       ANTHROPIC_DEFAULT_HAIKU_MODEL: ${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}
       CLAUDE_CODE_SUBAGENT_MODEL: ${CLAUDE_CODE_SUBAGENT_MODEL:-}
+      # Multi-model: non-secret JSON of connections+models (seeds the DB on boot).
+      # Secrets stay in env by tokenEnv name (e.g. ANTHROPIC_AUTH_TOKEN above).
+      OXY_MODELS_SEED: ${OXY_MODELS_SEED:-}
       # Gemini API for skill icon generation
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       CLAUDE_SESSIONS_ROOT: /data/users


### PR DESCRIPTION
## What

The tunnel compose passes env via explicit `environment:` lists (not `env_file`), so the multi-model vars weren't reaching the containers. Forward them:

- **app**: `OXY_MODELS_SEED` — `seedModelsFromEnv()` runs here on boot.
- **worker**: `ANTHROPIC_AUTH_TOKEN` (+ `ANTHROPIC_API_KEY`) so the **health probe** can auth its `/v1/messages` call; `MODEL_PROBE_ON_BOOT` (default true) + `MODEL_PROBE_CRON`.

Values come from the deploy env file (e.g. `~/oxygenie-deploy/secrets.env`, where `OXY_MODELS_SEED` is now set). Without this, `OXY_MODELS_SEED` never reaches `app` (nothing seeded) and the `worker` probe has no token (all models stay `unhealthy` → empty picker).

## Scope

Tunnel compose only (owner's OrbStack stack). `docker-compose.yml` (selfhost) + `docker-compose.dokploy.yml` need the same forwarding for multi-model — follow-up (selfhost is also native-Anthropic-shaped, would also need `ANTHROPIC_AUTH_TOKEN` on `app` + `ANTHROPIC_API_KEY` relaxed to optional).

YAML validated (compose parses past it to interpolation). CI/deploy-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)