### PR TITLE
fix(models): rename model_health enum → model_health_status (migrate collision)

### DIFF
--- a/drizzle/0022_multi_model.sql
+++ b/drizzle/0022_multi_model.sql
@@ -1,5 +1,5 @@
 CREATE TYPE "public"."model_auth_style" AS ENUM('bearer', 'x-api-key');--> statement-breakpoint
-CREATE TYPE "public"."model_health" AS ENUM('healthy', 'unhealthy', 'unknown');--> statement-breakpoint
+CREATE TYPE "public"."model_health_status" AS ENUM('healthy', 'unhealthy', 'unknown');--> statement-breakpoint
 CREATE TABLE "model_connection" (
 	"id" text PRIMARY KEY NOT NULL,
 	"label" text NOT NULL,
@@ -32,7 +32,7 @@ CREATE TABLE "model_definition" (
 --> statement-breakpoint
 CREATE TABLE "model_health" (
 	"model_id" text PRIMARY KEY NOT NULL,
-	"health" "model_health" DEFAULT 'unknown' NOT NULL,
+	"health" "model_health_status" DEFAULT 'unknown' NOT NULL,
 	"last_probe_at" timestamp with time zone,
 	"probe_error" text,
 	"latency_ms" integer

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "4c3a488f-9098-4cee-ae54-d73f3353b927",
+  "id": "6930dda5-6ebd-4985-85ba-50be9d0156d9",
   "prevId": "f05ea8d9-0386-4248-9795-b1f93b64f107",
   "version": "7",
   "dialect": "postgresql",
@@ -3055,7 +3055,7 @@
         },
         "health": {
           "name": "health",
-          "type": "model_health",
+          "type": "model_health_status",
           "typeSchema": "public",
           "primaryKey": false,
           "notNull": true,
@@ -3183,8 +3183,8 @@
         "x-api-key"
       ]
     },
-    "public.model_health": {
-      "name": "model_health",
+    "public.model_health_status": {
+      "name": "model_health_status",
       "schema": "public",
       "values": [
         "healthy",

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -159,7 +159,7 @@
     {
       "idx": 22,
       "version": "7",
-      "when": 1780824189166,
+      "when": 1780849669183,
       "tag": "0022_multi_model",
       "breakpoints": true
     }

--- a/src/db/schema/model.schema.ts
+++ b/src/db/schema/model.schema.ts
@@ -20,7 +20,10 @@ import { createdAt, updatedAt, timestamptz } from './_shared';
 export const modelAuthStyleEnum = pgEnum('model_auth_style', ['bearer', 'x-api-key']);
 
 // Probe result. unknown = never probed / probe in flight.
-export const modelHealthEnum = pgEnum('model_health', ['healthy', 'unhealthy', 'unknown']);
+// NOTE: the enum's Postgres name MUST differ from the `model_health` table name —
+// `CREATE TABLE model_health` auto-creates a type of the same name, which would
+// collide with the enum (Postgres error 42710). Hence `model_health_status`.
+export const modelHealthEnum = pgEnum('model_health_status', ['healthy', 'unhealthy', 'unknown']);
 
 // ── model_connection ─ an Anthropic-compatible endpoint + one credential (an account)
 export const modelConnection = pgTable('model_connection', {


### PR DESCRIPTION
## Bug

`migrate` failed on the multi-model migration:
```
type "model_health" already exists  (42710)
  while running CREATE TABLE "model_health"
```
PR1 named **both the enum and the table `model_health`**. In Postgres, `CREATE TABLE model_health` auto-creates a composite type of the same name → collides with the `model_health` enum. The migration runs in a transaction, so it **rolled back cleanly** (DB stays at 0021, no partial state).

## Fix

Rename the enum's Postgres name → **`model_health_status`** (TS var `modelHealthEnum` unchanged; the column `health` still uses it). Regenerated `drizzle/0022_multi_model.sql` + snapshot. No other code references the enum's SQL name (everything uses the TS literal union `'healthy'|'unhealthy'|'unknown'`).

## Verified

Regenerated migration: `CREATE TYPE "model_health_status"` + `CREATE TABLE "model_health"` — no collision; no stray DROP; `model.schema.ts` tsc clean.

After merge: rebuild the image + re-run `migrate` and it applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)