### PR TITLE
feat(a2composer): derive skill shortcuts from the catalog (PRD + impl)

### DIFF
--- a/docs/project/prd/2026-06-a2composer-prd.md
+++ b/docs/project/prd/2026-06-a2composer-prd.md
@@ -1,0 +1,209 @@
+# PRD：A2Composer —— 对话内「技能快捷入口」（重做）
+
+> 日期：2026-06-07 ｜ 状态：草案待 owner 评审
+> 关联：
+> - `prd/2026-06-skills-integration-prd.md`（Skills 三层模型、D6 默认只启用 2 个、**D7 手动加载＝聊天窗快捷入口**、D9 baoyu 模板暂失效待重做）—— 本 PRD 即 D7 那个「快捷入口」的正式设计。
+> - `research/2026-06-skills-existing-architecture-and-redesign.md`（启用＝物化 SKILL.md 到 FS、本地生成变量 schema）。
+> - `VISION.md`（自托管 / 单组织 / 半可信同事威胁模型 / 精选非市场）。
+> - 数据源：`src/db/seed/curated-skills.json`（精选 100，含 category/level/firstTaskZh/suitableForZh/problemZh/iconEmoji/riskNotesZh）。
+
+---
+
+## 0. 决议与关键约束（2026-06-07）
+
+**Owner 已拍板：**
+- **保留 + 重做（派生自技能目录）**（K1+K2）。
+- 分类**收成 5 个面向任务的大类**（映射自技能 `category`，给中文展示名）（K3 取「大类」方案）。
+
+**面向任务的 5 大类 ↔ 技能 `category` 映射：**
+
+| 任务大类（展示） | 映射自 `category` | 约数 |
+|---|---|---|
+| 写作与内容 | writing | 18 |
+| 设计与前端 | design_frontend | 21 |
+| 自动化与集成 | automation + security | 19 |
+| 研究与策略 | research + learning | 22 |
+| AI 工程 | ai_engineering | 20 |
+
+> 映射只是**展示层**（`category → bucket` 的常量表），不改技能底层 `category` 字段；目录仍是单一真相。
+
+**关键技术约束（来自 STATUS.md · Skills S2，已 owner 测试）：**
+> 启用技能＝物化 SKILL.md 到 `~/.claude/skills/<slug>/`，但 **SDK 0.2.112 无法热加载正在运行的会话；新启用的技能「下次对话生效」**。
+
+**对本功能的硬影响（必须设计进去）：**
+- **当场用不了未启用的技能。** 选中一个**未启用**技能：可一键启用+物化，但要等**新对话**才被 SDK 加载。
+- 因此把技能分两态呈现：
+  - **已启用（本会话可用）** → 选中＝直接填 `firstTaskZh` 起手，立即可发。
+  - **未启用** → 选中＝启用+物化 + 填起手 prompt + **明确提示「已加入，新对话生效」**，并提供「**开启新对话并加载**」一键动作。
+- 这也精确回答了原始疑问：**要在当前对话里真正跑某技能，它必须已启用（上次启用、本会话起始已物化）**；快捷入口的「按需启用」是为**下一次对话**准备，不是当场注入。
+
+---
+
+## 1. 现状（代码核对，2026-06-07）
+
+- **是什么**：聊天 composer 上方的分类下拉胶囊（内容创作 / 内容整理 / 设计与呈现 / 策略与研究），每类挂若干「模板」，选中后把一段起始 prompt 填进输入框。
+- **数据**：`src/lib/a2composer/config.ts` 手写 **4 个分类 + 8 个模板**；持久化为 `templates.json`（admin 可在 `/admin/a2composer` 编辑）。
+- **绑定技能的代码**：`a2composer-panel.tsx` `handleSelectTemplate` —— 仅当 `template.skillId` 存在时才 `ensureSkillEnabled(skillId)`（按需启用）+ `addTemporarySkill`。
+- **关键缺陷**：
+  - **F1 未接线**：8 个模板 **`skillId` 全为空**，只有 `skillHint`（装饰用，仅渲染一个 badge，从不解析）→ **选中模板今天只填 prompt，不启用/不加载任何技能**。
+  - **F2 分类对不上**：手写的 4 个分类与精选技能自带的 7 个 `category` 完全不一致。
+  - **F3 双重维护 + 漂移**：模板的 title/summary/prompt/图标都在手写，与技能自身的 `titleZh/summaryZh/firstTaskZh/iconEmoji` 重复且已漂移；其中 2 个 `skillHint`（`baoyu-danger-x-to-markdown`、`design-md`）在 store 里根本不存在（D9 删除 baoyu 本地资产的已知后果）。
+  - **F4 违反 DS**：4 个分类图标是 emoji（✍️🧩🎨🧠），违反新设计系统「无 emoji」。
+
+> 一句话：这个功能是 skills 架构 **D7「手动加载」** 的落地面，但当前是一套**与技能脱钩、手工维护、已漂移、且未接线**的平行模板库。
+
+---
+
+## 2. 该不该存在？—— 该，但要换底座
+
+**该存在。** 理由直接来自既定的 skills 架构：
+
+- **D6 决定默认只启用 2 个技能**（`find-skills` + `skill-creator`），其余 98 个**不预加载**（否则每次对话都把上百份 SKILL.md 塞进上下文，污染且烧 token）。
+- 既然不预加载，就**必须有一个「在对话里按需把某个技能拉进来」的入口** —— 这正是 D7，也正是 A2Composer 的位置。
+- 没有它，用户要用第 3~100 个技能只能去 Skills 页逐个手动启用，**断了「边聊边用」的心流**，精选 100 的价值大打折扣。
+
+**它解决的真实问题（JTBD）：**
+1. **冷启动 / 空白页**：「今天我能帮你什么？」对着空输入框无从下手 → 给到「这类活儿可以这样开头」。
+2. **发现**：100 个技能太多、记不住 → 按「我现在要干的活」分类浮现相关技能。
+3. **按需加载（上下文卫生）**：选中即把**那一个**技能物化进当前会话（D7），而非全量加载。
+4. **零安装门槛**：不要求用户事先在 Skills 页启用 —— 选中即 `ensureSkillEnabled` 当场启用（**不依赖已安装**，回答了核对中的疑问）。
+5. **引导式输入**：技能有 `.schema.json` 时，渲染可填充变量表单，降低 prompt 工程门槛。
+
+> 注意「硬加载 skill.md」的边界：入口**只能拉精选 store 里存在的技能**（`enableSkill` 作用于已知 slug，启用＝把该技能的 SKILL.md 物化到 `~/.claude/skills/<slug>/` 让 SDK 读）。**不会**注入任意外部 skill.md —— 与 VISION「精选非公开市场」一致。
+
+**给谁：**
+- **主要**：组织内会用聊天、但不熟悉「有哪些技能 / 该启用哪个」的成员（半可信同事）—— 让他们不查文档也能用对技能。
+- **次要**：熟练用户的加速器（少点几下就把对的技能 + 起手 prompt 一并就位）。
+
+---
+
+## 3. 核心洞察：派生自技能，而非平行模板库
+
+精选技能**已经**带齐了快捷入口所需的一切，无需另写模板：
+
+| 快捷入口需要 | 直接取自技能字段 |
+|---|---|
+| 分类分组 | `category`（design_frontend / ai_engineering / automation / writing / research / learning / security） |
+| 胶囊/卡片标题 | `titleZh` / `name` |
+| 一句话说明 | `summaryZh` |
+| **起手 prompt** | `firstTaskZh`（天然的 starter） |
+| 适合谁 | `suitableForZh` |
+| 图标 | `iconEmoji`（DS 场景改用 lucide 线性图标） |
+| 风险提示 | `riskNotesZh`（启用前护栏文案） |
+| 排序 | `sortWeight` / `level` |
+| 绑定的技能 | **就是这条技能自己**（slug，天然 `skillId`） |
+
+**结论**：A2Composer 从「手写 4 分类 + 8 模板（漂移、未接线）」改为「**精选技能的一个对话内视图**」：按 `category` 分组，卡片＝技能，起手＝`firstTaskZh`，选中＝`ensureSkillEnabled(slug)` + 物化 + 把 `firstTaskZh` 填入 composer（+ 有 schema 则展开变量表单）。**单一真相＝技能目录，零重复维护。**
+
+> 模板能力不丢：`A2Template` 降级为**可选的覆盖层**（admin 想给某技能定制更细的多步模板/变量时才写；默认不需要），`templates.json` 从「必需的平行库」变为「可选 override」。
+
+---
+
+## 4. 目标 / 非目标
+
+**目标**
+- G1 快捷入口**派生自精选技能目录**（DB 为真相），按技能 `category` 分组，卡片用技能自带元数据；**删除手写的 4 分类与漂移模板**。
+- G2 选中即**按需启用 + 物化**该技能进当前会话（D7），**不依赖事先启用**；起手 prompt＝`firstTaskZh`。
+- G3 有 `.schema.json` 时渲染**可填充变量表单**；无则只填起手 prompt（优雅降级）。
+- G4 **风险感知**：`riskNotesZh` 非空（如触达 Shell / 内网 / 浏览器）时，启用前给一句轻量提示（warn-not-ban，符合威胁模型）。
+- G5 **符合 DS**：emoji → lucide 线性图标 + 信号绿；胶囊改 hairline/mono 编辑风。
+- G6 与 Skills 页（能力中心）**分工清晰**：能力中心＝浏览/搜索/治理/持久启用；A2Composer＝对话内即时发现 + 按需加载 + 起手。
+
+**非目标（本期）**
+- 不做公开市场 / 评分 / 付费 / 技能包 bundle（VISION）。
+- 不在快捷入口里直接「从上游 9600 搜索添加」（那是 Skills 页 G5 的事；这里只面向**已精选**的目录）。
+- 不做团队级共享模板（org 级留 backlog）。
+- 不保留手写平行模板库为「必需」（降级为可选 override）。
+
+---
+
+## 5. 关键决策（待 owner 拍板）
+
+| # | 决策 | 倾向 / 依据 |
+|---|------|------|
+| K1 | **保留功能**（不删） | 它是 skills D7 的落地面，删了「按需加载」断链 |
+| K2 | **底座换成「派生自技能目录」**，删手写 4 分类 + 漂移模板 | §3；消除 F1/F2/F3 |
+| K3 | 分组用技能自带 `category`（7 类，可中文化重命名） | 与目录单一真相一致 |
+| K4 | 起手 prompt＝`firstTaskZh`；变量表单＝本地 schema（有则展开） | 零重复维护 + 既有 generator |
+| K5 | 选中＝`ensureSkillEnabled(slug)`（按需启用，不依赖预启用）+ 物化进当前会话 | D7 |
+| K6 | `A2Template` 降级为**可选 override**（admin 想定制才写） | 不丢能力、不强制维护 |
+| K7 | 启用高风险技能（`riskNotesZh` 非空）前给轻量提示 | 威胁模型「warn-not-ban」 |
+| K8 | emoji → lucide 线性图标，胶囊改 DS 编辑风 | 设计系统 |
+| K9 | 入口可被关闭（admin 开关 / feature flag），默认开 | 可控落地 |
+
+---
+
+## 6. 重新设计的交互模型
+
+1. **入口**：composer 上方的分类胶囊 = **5 个任务大类**（lucide 图标，映射自技能 `category`）。只展示有 ≥1 个技能的大类。
+2. **展开大类** → 该大类下的技能卡片（`titleZh` + `summaryZh` + `suitableForZh`，按 `sortWeight`/`level`）；每张卡标注**状态徽标**：`已启用·本会话可用` / `未启用·新对话生效`。
+3. **选中一个技能** —— 按状态分流（受 SDK「下次对话生效」约束，见 §0）：
+   - **已启用** → 直接把 `firstTaskZh`（或该技能 override 模板）填入 composer；有 `.schema.json` 则展开变量表单（沿用 `getSkillSchema` + `applyTemplate`）→ **可立即发送**。
+   - **未启用** → 若 `riskNotesZh` 非空先弹一行护栏（继续/取消）→ `ensureSkillEnabled(slug)` 启用+物化 → 填起手 prompt → 明确提示 **「已加入，新对话生效」**，并给「**开启新对话并加载**」一键动作。
+4. **发送**：照常走 ws → SDK；**已物化**的技能由 `settingSources:['project']` 在会话起始加载（当前会话只对「会话开始前已物化」的技能生效）。
+5. **会话结束**：临时加载的技能按既有 `disableUserSkills`/session 清理回收（保持默认集精简）。
+
+**降级**：技能无 `firstTaskZh` → 用 `summaryZh` 兜底；无 schema → 仅填 prompt；分类无技能 → 不显示该胶囊。全程不报错。
+
+---
+
+## 7. 与 Skills 能力中心的分工
+
+| 维度 | Skills 页（能力中心） | A2Composer（对话内快捷入口） |
+|---|---|---|
+| 场景 | 事前浏览 / 搜索 / 治理 | 对话中即时、按当前任务 |
+| 操作 | 持久启用/停用、看详情、从上游添加 | 按需把**一个**技能拉进**当前会话** + 起手 |
+| 真相 | 同一 DB 目录 | **同一 DB 目录的对话内视图** |
+| 心智 | 「我管理我的技能箱」 | 「我现在要干这活，给我对的技能 + 开头」 |
+
+二者共享同一目录与启用机制，A2Composer 不再有独立数据。
+
+---
+
+## 8. 实施分期
+
+- **P0｜接线 + 派生（最小可用）**：分类来自技能 `category`；卡片来自技能元数据；选中＝`ensureSkillEnabled(slug)` + 填 `firstTaskZh`。删 `config.ts` 手写分类/模板对 UI 的依赖（`A2_TEMPLATES` 退为可选 override）。修 F1/F2/F3。
+- **P1｜引导输入 + 风险护栏**：有 schema 展开变量表单；`riskNotesZh` 启用前提示（K7）。
+- **P2｜DS 视觉**：emoji→lucide、胶囊编辑风（K8），与首页/composer 一致。
+- **P3｜admin override + 开关**：`/admin/a2composer` 改为「给某技能写可选 override 模板」；feature flag（K9）。
+- **P4（backlog）**：按 `recommendationTags`/`level` 二级筛选、最近使用、按当前对话上下文智能推荐技能。
+
+> 依赖：P0 依赖 skills 执行层（启用→物化、目录 DB 为真相）已就绪到「能 `ensureSkillEnabled` 任意精选 slug」。需先确认该前置（skills-integration PRD 的 S2 执行层状态）。
+
+---
+
+## 9. 成功标准 / 度量
+
+- 选中快捷入口后，目标技能**确实被启用并在该次对话生效**（可观测：会话 metadata 出现该 slug）。
+- 「填了 prompt 但没加载技能」的现象归零（F1 闭环）。
+- 分类与精选目录 100% 一致，无漂移、无指向不存在 slug 的死链（F2/F3 闭环）。
+- 视觉无 emoji、符合 DS（F4 闭环）。
+- （软指标）新成员不看文档即可经快捷入口用上正确技能。
+
+---
+
+## 10. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 按需启用了触达宿主的高风险技能 | K7 启用前 `riskNotesZh` 提示；沙盒护栏（既有） |
+| 7 个英文 category 直接示人偏技术 | 给中文展示名映射（design_frontend→「前端 / 设计」等），不改底层值 |
+| 100 技能铺开太满 | 每类默认折叠 + 取 topN（`sortWeight`），「更多」进 Skills 页 |
+| 执行层「任意 slug 按需物化」未完全就绪 | P0 前先核对 skills S2 状态；未就绪则先做派生 UI + 优雅降级 |
+
+---
+
+## 11. 待 owner 确认
+
+**已定（2026-06-07）：**
+- ✅ K1/K2 方向：保留 + 派生自技能重做。
+- ✅ K3 分类：收成 5 个面向任务大类（映射见 §0）。
+- ✅ P0 前置就绪：skills 执行层 S2 已 owner 测试（STATUS 2026-06-04：启用→物化任意精选 slug，**下次对话生效**）。
+
+**已定（续，2026-06-07）：**
+- ✅ 未启用技能选中 → **启用+物化 + 填起手 prompt + 「开启新对话并加载」一键**。
+- ✅ 快捷入口**全展示**技能，**未启用默认折叠**（已启用置顶可立即用）。
+- ✅（默认，owner 未异议即采用）K7 高风险技能（`riskNotesZh` 非空）启用前**轻量一行提示**（非强制二次确认）。
+- ✅（默认）K6 模板 override 层 → **backlog**，本期纯派生。
+
+> 至此设计决策全部收敛，进入实施（见 §8 分期；P0 先行）。

--- a/src/components/claude-chat/a2composer-panel.tsx
+++ b/src/components/claude-chat/a2composer-panel.tsx
@@ -1,6 +1,19 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
+import {
+  AlertTriangle,
+  ArrowRight,
+  ChevronLeft,
+  Compass,
+  Cpu,
+  Minimize2,
+  PenLine,
+  Plus,
+  Shapes,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
 import { Textarea } from '~/components/ui/textarea';
@@ -13,14 +26,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '~/components/ui/select';
-import { ChevronDown, Minimize2 } from 'lucide-react';
-import type { A2Category, A2Template, A2ComposerStore } from '~/lib/a2composer/types';
-import { resolveSkillMatch } from '~/lib/a2composer/skill-match';
-import { applyTemplate, extractVariables } from '~/lib/a2composer/template-utils';
-import { listAllSkillsFn, getCuratedSkillSchemaFn, ensureUserSkillEnabledFn } from '~/server/function/skills.server';
-import { getA2ComposerStoreFn } from '~/server/function/a2composer.server';
-import type { ExtendedSkillInfo, SkillInputField } from '~/claude/skills';
+import {
+  getComposerCatalogFn,
+  getCuratedSkillSchemaFn,
+  ensureUserSkillEnabledFn,
+} from '~/server/function/skills.server';
+import type { ComposerSkill } from '~/lib/a2composer/types';
+import type { SkillInputField } from '~/claude/skills';
+import { A2_BUCKETS, CATEGORY_TO_BUCKET, type BucketId } from '~/lib/a2composer/buckets';
 import { useChatSessionStore } from '~/lib/chat-session-store';
+
+type SkillOption = NonNullable<SkillInputField['options']>[number];
+
+const BUCKET_ICONS: Record<string, LucideIcon> = { PenLine, Shapes, Workflow, Compass, Cpu };
 
 interface A2ComposerPanelProps {
   composerText: string;
@@ -31,229 +49,172 @@ interface A2ComposerPanelProps {
   onOpenChange?: (open: boolean) => void;
   /** Explicitly select a skill for this message */
   onSkillSelect?: (skill: { slug: string; name: string }) => void;
+  /** Open a fresh conversation so a just-enabled skill loads (SDK can't hot-reload) */
+  onOpenNewConversation?: () => void;
 }
 
-export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOpenChange, onSkillSelect }: A2ComposerPanelProps) {
-  // Panel state
-  const [isMinimized, setIsMinimized] = useState(true);
-  const [activeCategoryId, setActiveCategoryId] = useState<string>('');
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
-  const [variableValues, setVariableValues] = useState<Record<string, string>>({});
+const starterOf = (s: ComposerSkill) => s.firstTaskZh || s.summaryZh || '';
+const displayName = (s: ComposerSkill) => s.titleZh || s.name;
 
-  const listAllSkills = useServerFn(listAllSkillsFn);
+export function A2ComposerPanel({
+  composerText,
+  onSetComposerText,
+  onReset,
+  onOpenChange,
+  onSkillSelect,
+  onOpenNewConversation,
+}: A2ComposerPanelProps) {
+  const [isMinimized, setIsMinimized] = useState(true);
+  const [activeBucketId, setActiveBucketId] = useState<BucketId>(A2_BUCKETS[0].id);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [variableValues, setVariableValues] = useState<Record<string, string>>({});
+  const [showUnenabled, setShowUnenabled] = useState(false);
+  const [riskSkill, setRiskSkill] = useState<ComposerSkill | null>(null);
+  const [justEnabled, setJustEnabled] = useState<ComposerSkill | null>(null);
+
+  const getCatalog = useServerFn(getComposerCatalogFn);
   const getSkillSchema = useServerFn(getCuratedSkillSchemaFn);
   const ensureSkillEnabled = useServerFn(ensureUserSkillEnabledFn);
-  const getStore = useServerFn(getA2ComposerStoreFn);
-  const addTemporarySkill = useChatSessionStore((state) => state.addTemporarySkill);
+  const addTemporarySkill = useChatSessionStore((s) => s.addTemporarySkill);
+  const setPendingComposerText = useChatSessionStore((s) => s.setPendingComposerText);
 
-  const { data: store } = useQuery<A2ComposerStore>({
-    queryKey: ['a2composer-store'],
-    queryFn: () => getStore(),
-  });
-  const { data: skillData, isLoading: isLoadingSkills } = useQuery({
-    queryKey: ['a2composer-skills'],
-    queryFn: () => listAllSkills(),
+  const { data: catalog = [], isLoading } = useQuery<ComposerSkill[]>({
+    queryKey: ['a2composer-catalog'],
+    queryFn: () => getCatalog(),
   });
 
-  const skills = useMemo<ExtendedSkillInfo[]>(() => {
-    if (!skillData) return [];
-    return [...skillData.official, ...skillData.user];
-  }, [skillData]);
+  // Group skills into the 5 task buckets.
+  const byBucket = useMemo(() => {
+    const map = new Map<BucketId, ComposerSkill[]>();
+    for (const b of A2_BUCKETS) map.set(b.id, []);
+    for (const s of catalog) {
+      const bucket = s.category ? CATEGORY_TO_BUCKET[s.category] : undefined;
+      if (bucket && map.has(bucket)) map.get(bucket)?.push(s);
+    }
+    return map;
+  }, [catalog]);
 
-  const categories = useMemo<A2Category[]>(() => {
-    return (store?.categories ?? []).filter((category) => !category.hidden);
-  }, [store]);
-
-  const selectedCategory = useMemo(() => {
-    if (!activeCategoryId) return null;
-    return categories.find((cat) => cat.id === activeCategoryId) ?? null;
-  }, [activeCategoryId, categories]);
-
-  const templates = useMemo<A2Template[]>(
-    () => (store?.templates ?? [])
-      .filter((template) => template.categoryId === activeCategoryId && !template.hidden),
-    [activeCategoryId, store]
+  const buckets = useMemo(
+    () => A2_BUCKETS.filter((b) => (byBucket.get(b.id)?.length ?? 0) > 0),
+    [byBucket],
   );
 
-  const selectedTemplate = useMemo(() => {
-    if (!selectedTemplateId) return null;
-    return (store?.templates ?? []).find((template) => template.id === selectedTemplateId) ?? null;
-  }, [selectedTemplateId, store]);
+  const activeSkills = byBucket.get(activeBucketId) ?? [];
+  const enabledSkills = activeSkills.filter((s) => s.enabled);
+  const unenabledSkills = activeSkills.filter((s) => !s.enabled);
+  const activeBucket = A2_BUCKETS.find((b) => b.id === activeBucketId) ?? null;
 
+  const selectedSkill = useMemo(
+    () => catalog.find((s) => s.slug === selectedSlug) ?? null,
+    [catalog, selectedSlug],
+  );
+
+  // Variable schema (only for an already-enabled, selected skill).
   const { data: schemaData } = useQuery({
-    queryKey: ['a2composer-schema', selectedTemplate?.skillId],
-    // S4: read the fillable-variable schema from the DB cache (skill_schema_cache)
-    queryFn: () => getSkillSchema({ data: { slug: selectedTemplate?.skillId ?? '' } }),
-    enabled: Boolean(selectedTemplate?.skillId),
+    queryKey: ['a2composer-skill-schema', selectedSkill?.enabled ? selectedSlug : null],
+    queryFn: () => getSkillSchema({ data: { slug: selectedSlug ?? '' } }),
+    enabled: Boolean(selectedSkill?.enabled && selectedSlug),
   });
+  const schemaInputs: SkillInputField[] = useMemo(
+    () => schemaData?.schema?.inputs ?? [],
+    [schemaData],
+  );
 
-  const schemaInputs = useMemo<SkillInputField[]>(() => {
-    return schemaData?.schema?.inputs ?? [];
-  }, [schemaData]);
-
-  const schemaAvailable = Boolean(schemaData?.schema && schemaInputs.length > 0);
-
-  const normalizeKey = (value: string) => value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-
-  // Reset selected template if no longer in current category
+  // Keep active bucket valid.
   useEffect(() => {
-    if (!selectedTemplateId) return;
-    if (!templates.some((template) => template.id === selectedTemplateId)) {
-      setSelectedTemplateId(null);
-      setVariableValues({});
+    if (buckets.length && !buckets.some((b) => b.id === activeBucketId)) {
+      setActiveBucketId(buckets[0].id);
     }
-  }, [selectedTemplateId, templates]);
+  }, [buckets, activeBucketId]);
 
-  // Auto-select first category if none selected
-  useEffect(() => {
-    if (!categories.length) {
-      setActiveCategoryId('');
-      return;
-    }
-    if (!activeCategoryId || !categories.some((category) => category.id === activeCategoryId)) {
-      setActiveCategoryId(categories[0]?.id ?? '');
-    }
-  }, [activeCategoryId, categories]);
-
-  // Notify parent when open state changes
   useEffect(() => {
     onOpenChange?.(!isMinimized);
   }, [isMinimized, onOpenChange]);
 
-  const variables = useMemo(() => {
-    if (!selectedTemplate) return [];
-    return extractVariables(selectedTemplate.template);
-  }, [selectedTemplate]);
-
-  const schemaInputMap = useMemo(() => {
-    const map = new Map<string, SkillInputField>();
-    for (const field of schemaInputs) {
-      map.set(field.name, field);
-    }
-    return map;
-  }, [schemaInputs]);
-
-  const schemaNormalizedMap = useMemo(() => {
-    const map = new Map<string, SkillInputField>();
-    for (const field of schemaInputs) {
-      map.set(normalizeKey(field.name), field);
-    }
-    return map;
-  }, [schemaInputs]);
-
-  const variableFields = useMemo(() => {
-    return variables.map((name) => ({
-      name,
-      field: schemaInputMap.get(name) ?? schemaNormalizedMap.get(normalizeKey(name)),
-    }));
-  }, [schemaInputMap, schemaNormalizedMap, variables]);
-
-  const matchMap = useMemo(() => {
-    const map = new Map<string, ExtendedSkillInfo | null>();
-    for (const template of store?.templates ?? []) {
-      map.set(template.id, resolveSkillMatch(template, skills));
-    }
-    return map;
-  }, [skills, store]);
-
-  // Auto-fill default values from schema
-  useEffect(() => {
-    if (!selectedTemplate || schemaInputs.length === 0) return;
-    const templateVars = new Set(variables.map((name) => normalizeKey(name)));
-    setVariableValues((prev) => {
-      if (Object.keys(prev).length > 0) return prev;
-      const next: Record<string, string> = {};
-      for (const field of schemaInputs) {
-        const normalizedField = normalizeKey(field.name);
-        if (!templateVars.has(normalizedField)) continue;
-        const templateVar = variables.find((name) => normalizeKey(name) === normalizedField) ?? field.name;
-        if (field.defaultValue !== undefined && field.defaultValue !== null) {
-          if (Array.isArray(field.defaultValue)) {
-            next[templateVar] = field.defaultValue.join(', ');
-          } else {
-            next[templateVar] = String(field.defaultValue);
-          }
-        }
-      }
-      return next;
-    });
-  }, [schemaInputs, selectedTemplate, variables]);
-
-  // Handle category click - expand panel
-  const handleCategoryClick = (categoryId: string) => {
-    setActiveCategoryId(categoryId);
-    setIsMinimized(false);
+  const buildPrompt = (skill: ComposerSkill, values: Record<string, string>) => {
+    const base = starterOf(skill);
+    const filled = schemaInputs
+      .filter((f) => values[f.name] && String(values[f.name]).trim())
+      .map((f) => `- ${f.label || f.name}：${values[f.name]}`);
+    return filled.length ? `${base}\n\n${filled.join('\n')}` : base;
   };
 
-  // Handle template selection
-  const handleSelectTemplate = async (template: A2Template) => {
-    setSelectedTemplateId(template.id);
-    setVariableValues({});
-    const appliedText = applyTemplate(template.template, {});
-    onSetComposerText(appliedText);
-    if (template.skillId) {
-      try {
-        const result = await ensureSkillEnabled({ data: { skillName: template.skillId } });
-        if (result?.enabledNow) {
-          addTemporarySkill(result.skillName ?? template.skillId);
-        }
-        const matchedSkill = skills.find((skill) => skill.slug === template.skillId);
-        onSkillSelect?.({ slug: template.skillId, name: matchedSkill?.name ?? template.skillId });
-      } catch (error) {
-        console.error('[A2Composer] Failed to auto-enable skill:', error);
-      }
-    }
-  };
-
-  // Handle variable change
-  const handleVariableChange = (key: string, value: string) => {
-    setVariableValues((prev) => {
-      const next = { ...prev, [key]: value };
-      if (selectedTemplate) {
-        const appliedText = applyTemplate(selectedTemplate.template, next);
-        onSetComposerText(appliedText);
-      }
-      return next;
-    });
-  };
-
-  // Handle minimize
+  // ── actions ────────────────────────────────────────────────────────────
   const handleMinimize = () => {
     setIsMinimized(true);
-    setSelectedTemplateId(null);
+    setSelectedSlug(null);
     setVariableValues({});
+    setRiskSkill(null);
+    setJustEnabled(null);
+    setShowUnenabled(false);
     onReset?.();
   };
 
-  // Auto-collapse on external reset
+  const openEnabledSkill = (skill: ComposerSkill) => {
+    setSelectedSlug(skill.slug);
+    setVariableValues({});
+    onSetComposerText(starterOf(skill));
+    onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
+  };
+
+  const enableSkill = async (skill: ComposerSkill) => {
+    setRiskSkill(null);
+    onSetComposerText(starterOf(skill));
+    onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
+    try {
+      const res = await ensureSkillEnabled({ data: { skillName: skill.slug } });
+      if (res?.enabledNow) addTemporarySkill(res.skillName ?? skill.slug);
+    } catch (error) {
+      console.error('[A2Composer] Failed to enable skill:', error);
+    }
+    setJustEnabled(skill);
+  };
+
+  const handlePick = (skill: ComposerSkill) => {
+    if (skill.enabled) {
+      openEnabledSkill(skill);
+      return;
+    }
+    if (skill.riskNotesZh?.trim()) {
+      setRiskSkill(skill);
+      return;
+    }
+    void enableSkill(skill);
+  };
+
+  const handleOpenNewChat = (skill: ComposerSkill) => {
+    setPendingComposerText(starterOf(skill));
+    onOpenNewConversation?.();
+    handleMinimize();
+  };
+
+  const handleVariableChange = (key: string, value: string) => {
+    setVariableValues((prev) => {
+      const next = { ...prev, [key]: value };
+      if (selectedSkill) onSetComposerText(buildPrompt(selectedSkill, next));
+      return next;
+    });
+  };
+
+  // Auto-collapse when the composer was cleared externally (e.g. after send).
   useEffect(() => {
-    if (onReset && composerText === '' && selectedTemplateId) {
+    if (onReset && composerText === '' && (selectedSlug || justEnabled)) {
       handleMinimize();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [composerText, onReset]);
 
-  const getOptionValue = (option: SkillInputField['options'][number], index: number) => {
-    if (typeof option === 'string') return option;
-    return option.value ?? option.label ?? `option-${index}`;
-  };
-
-  const getOptionLabel = (option: SkillInputField['options'][number]) => {
-    if (typeof option === 'string') return option;
-    return option.label ?? option.value ?? '';
-  };
-
-  const parseMultiValue = (value: string | undefined) => {
-    if (!value) return [];
-    return value
-      .split(',')
-      .map((item) => item.trim())
-      .filter(Boolean);
-  };
+  // ── variable form controls (schema-driven) ─────────────────────────────
+  const getOptionValue = (option: SkillOption, index: number) =>
+    typeof option === 'string' ? option : option.value ?? option.label ?? `option-${index}`;
+  const getOptionLabel = (option: SkillOption) =>
+    typeof option === 'string' ? option : option.label ?? option.value ?? '';
+  const parseMultiValue = (value: string | undefined) =>
+    value ? value.split(',').map((v) => v.trim()).filter(Boolean) : [];
 
   const renderVariableControl = (variable: string, field?: SkillInputField) => {
     const value = variableValues[variable] ?? '';
-    const label = field?.label ?? variable;
-    const placeholder = field?.placeholder ?? field?.description ?? `请输入${label}`;
+    const placeholder = field?.placeholder ?? field?.description ?? `请输入${field?.label ?? variable}`;
     const type = field?.type ?? 'text';
     const options = field?.options ?? [];
 
@@ -264,7 +225,7 @@ export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOp
             value={value}
             placeholder={placeholder}
             rows={3}
-            onChange={(event) => handleVariableChange(variable, event.target.value)}
+            onChange={(e) => handleVariableChange(variable, e.target.value)}
             className="resize-none"
           />
         );
@@ -274,29 +235,30 @@ export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOp
             type="number"
             value={value}
             placeholder={placeholder}
-            onChange={(event) => handleVariableChange(variable, event.target.value)}
+            onChange={(e) => handleVariableChange(variable, e.target.value)}
           />
         );
       case 'select':
         return (
-          <Select
-            value={value}
-            onValueChange={(next) => handleVariableChange(variable, next)}
-          >
+          <Select value={value} onValueChange={(v) => handleVariableChange(variable, v)}>
             <SelectTrigger className="w-full">
               <SelectValue placeholder={placeholder || '请选择'} />
             </SelectTrigger>
             <SelectContent>
               {options.length === 0 ? (
-                <SelectItem value="__empty__" disabled>暂无选项</SelectItem>
-              ) : options.map((option, index) => {
-                const optionValue = getOptionValue(option, index);
-                return (
-                  <SelectItem key={optionValue} value={optionValue}>
-                    {getOptionLabel(option)}
-                  </SelectItem>
-                );
-              })}
+                <SelectItem value="__empty__" disabled>
+                  暂无选项
+                </SelectItem>
+              ) : (
+                options.map((option, index) => {
+                  const optionValue = getOptionValue(option, index);
+                  return (
+                    <SelectItem key={optionValue} value={optionValue}>
+                      {getOptionLabel(option)}
+                    </SelectItem>
+                  );
+                })
+              )}
             </SelectContent>
           </Select>
         );
@@ -306,30 +268,25 @@ export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOp
           <div className="flex flex-wrap gap-3">
             {options.length === 0 ? (
               <div className="text-sm text-muted-foreground">暂无选项</div>
-            ) : options.map((option, index) => {
-              const optionValue = getOptionValue(option, index);
-              const checked = selected.has(optionValue);
-              return (
-                <label
-                  key={optionValue}
-                  className="flex items-center gap-2 text-sm cursor-pointer select-none"
-                >
-                  <Checkbox
-                    checked={checked}
-                    onCheckedChange={(next) => {
-                      const nextSelected = new Set(selected);
-                      if (next === true) {
-                        nextSelected.add(optionValue);
-                      } else {
-                        nextSelected.delete(optionValue);
-                      }
-                      handleVariableChange(variable, Array.from(nextSelected).join(', '));
-                    }}
-                  />
-                  <span>{getOptionLabel(option)}</span>
-                </label>
-              );
-            })}
+            ) : (
+              options.map((option, index) => {
+                const optionValue = getOptionValue(option, index);
+                return (
+                  <label key={optionValue} className="flex cursor-pointer select-none items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={selected.has(optionValue)}
+                      onCheckedChange={(next) => {
+                        const nextSel = new Set(selected);
+                        if (next === true) nextSel.add(optionValue);
+                        else nextSel.delete(optionValue);
+                        handleVariableChange(variable, Array.from(nextSel).join(', '));
+                      }}
+                    />
+                    <span>{getOptionLabel(option)}</span>
+                  </label>
+                );
+              })
+            )}
           </div>
         );
       }
@@ -345,207 +302,246 @@ export function A2ComposerPanel({ composerText, onSetComposerText, onReset, onOp
             </span>
           </div>
         );
-      case 'file':
-        return (
-          <Input
-            type="text"
-            value={value}
-            placeholder={placeholder || '请输入文件名或链接'}
-            onChange={(event) => handleVariableChange(variable, event.target.value)}
-          />
-        );
-      case 'text':
       default:
         return (
           <Input
             value={value}
             placeholder={placeholder}
-            onChange={(event) => handleVariableChange(variable, event.target.value)}
+            onChange={(e) => handleVariableChange(variable, e.target.value)}
           />
         );
     }
   };
 
-  // ===== MINIMIZED STATE: Category buttons only =====
+  // ── small presentational bits ──────────────────────────────────────────
+  const StatusBadge = ({ skill }: { skill: ComposerSkill }) =>
+    skill.enabled ? (
+      <span className="inline-flex items-center gap-1 font-mono text-[10px] text-primary">
+        <span className="h-1.5 w-1.5 rounded-full bg-primary" /> 可用
+      </span>
+    ) : (
+      <span className="inline-flex items-center gap-1 font-mono text-[10px] text-muted-foreground">
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" /> 未启用
+      </span>
+    );
+
+  const SkillCard = ({ skill }: { skill: ComposerSkill }) => (
+    <button
+      type="button"
+      className="group flex w-64 shrink-0 flex-col justify-between rounded-md border border-border bg-card p-4 text-left transition-colors hover:border-primary/50 hover:bg-accent"
+      onClick={() => handlePick(skill)}
+    >
+      <div>
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <h3 className="line-clamp-1 font-medium text-sm">{displayName(skill)}</h3>
+          {skill.level && <span className="font-mono text-[10px] text-muted-foreground">{skill.level}</span>}
+        </div>
+        <p className="line-clamp-2 min-h-[2.5rem] text-muted-foreground text-xs">{skill.summaryZh}</p>
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <StatusBadge skill={skill} />
+        <span className="inline-flex items-center gap-1 font-mono text-[11px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+          {skill.enabled ? '使用' : '启用'} <ArrowRight className="h-3 w-3" />
+        </span>
+      </div>
+    </button>
+  );
+
+  // ===== MINIMIZED: bucket pills only =====
   if (isMinimized) {
     return (
-      <div className="mx-auto w-full max-w-3xl rounded-xl border bg-card/70 backdrop-blur-sm p-2 shadow-sm">
-        <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-thin scrollbar-thumb-muted-foreground/20 scrollbar-track-transparent">
-          {categories.map((category) => (
-            <Button
-              key={category.id}
-              variant="ghost"
-              size="sm"
-              className="shrink-0 gap-1.5 rounded-full border border-border bg-card hover:bg-accent"
-              onClick={() => handleCategoryClick(category.id)}
-            >
-              <span className="text-base">{category.icon}</span>
-              <span>{category.label}</span>
-              <ChevronDown className="h-4 w-4 opacity-50" />
-            </Button>
-          ))}
-          {!categories.length && (
-            <span className="text-sm text-muted-foreground px-2">暂无任务分类</span>
+      <div className="mx-auto w-full max-w-3xl rounded-lg border border-border bg-card/70 p-2 shadow-sm backdrop-blur-sm">
+        <div className="scrollbar-thin scrollbar-thumb-muted-foreground/20 flex items-center gap-2 overflow-x-auto pb-1">
+          {buckets.map((bucket) => {
+            const Icon = BUCKET_ICONS[bucket.icon] ?? Plus;
+            return (
+              <Button
+                key={bucket.id}
+                variant="ghost"
+                size="sm"
+                className="shrink-0 gap-1.5 rounded-md border border-border bg-card font-mono text-xs hover:bg-accent"
+                onClick={() => {
+                  setActiveBucketId(bucket.id);
+                  setIsMinimized(false);
+                }}
+              >
+                <Icon className="h-3.5 w-3.5 text-primary" />
+                <span>{bucket.label}</span>
+              </Button>
+            );
+          })}
+          {!buckets.length && (
+            <span className="px-2 text-muted-foreground text-sm">
+              {isLoading ? '加载技能…' : '暂无可用技能'}
+            </span>
           )}
         </div>
       </div>
     );
   }
 
-  // ===== EXPANDED STATE =====
+  const variables = schemaInputs.map((f) => f.name);
+
+  // ===== EXPANDED =====
   return (
-    <div className="mx-auto w-full max-w-3xl rounded-xl border bg-card shadow-sm">
-      {/* Header with minimize button */}
-      <div className="flex items-center justify-between border-b px-4 py-2">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{selectedCategory?.label ?? '任务入口'}</span>
-          {selectedTemplate && (
-            <span className="text-sm text-muted-foreground">/ {selectedTemplate.title}</span>
-          )}
+    <div className="mx-auto w-full max-w-3xl rounded-lg border border-border bg-card shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+        <div className="flex items-center gap-2 font-mono text-sm">
+          <span className="font-medium">{activeBucket?.label ?? '技能'}</span>
+          {selectedSkill && <span className="text-muted-foreground">/ {displayName(selectedSkill)}</span>}
         </div>
-        <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-xs"
-            onClick={handleMinimize}
-          >
-            <Minimize2 className="h-3.5 w-3.5 mr-1" />
-            收起
-          </Button>
-        </div>
+        <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={handleMinimize}>
+          <Minimize2 className="mr-1 h-3.5 w-3.5" />
+          收起
+        </Button>
       </div>
 
-      {/* Category Tabs (horizontal scroll) */}
-      <div className="border-b">
-        <div className="flex items-center gap-1 overflow-x-auto px-2 scrollbar-thin scrollbar-thumb-muted-foreground/20">
-          {categories.map((category) => {
-            const isActive = category.id === activeCategoryId;
+      {/* Bucket tabs */}
+      <div className="border-b border-border">
+        <div className="scrollbar-thin scrollbar-thumb-muted-foreground/20 flex items-center gap-1 overflow-x-auto px-2">
+          {buckets.map((bucket) => {
+            const Icon = BUCKET_ICONS[bucket.icon] ?? Plus;
+            const isActive = bucket.id === activeBucketId;
             return (
               <button
-                key={category.id}
-                className={`
-                  shrink-0 flex items-center gap-1.5 px-3 py-2 text-sm transition-colors border-b-2
-                  ${isActive
-                    ? 'border-primary text-foreground font-medium'
+                type="button"
+                key={bucket.id}
+                className={`flex shrink-0 items-center gap-1.5 border-b-2 px-3 py-2 font-mono text-sm transition-colors ${
+                  isActive
+                    ? 'border-primary font-medium text-foreground'
                     : 'border-transparent text-muted-foreground hover:text-foreground'
-                  }
-                `}
-                onClick={() => setActiveCategoryId(category.id)}
+                }`}
+                onClick={() => {
+                  setActiveBucketId(bucket.id);
+                  setSelectedSlug(null);
+                  setRiskSkill(null);
+                  setJustEnabled(null);
+                  setShowUnenabled(false);
+                }}
               >
-                <span>{category.icon}</span>
-                <span>{category.label}</span>
+                <Icon className={`h-3.5 w-3.5 ${isActive ? 'text-primary' : ''}`} />
+                <span>{bucket.label}</span>
               </button>
             );
           })}
         </div>
       </div>
 
-      {/* Task Cards (horizontal scroll) - only show when no template selected */}
-      {!selectedTemplate && (
+      {/* Risk guard */}
+      {riskSkill && (
         <div className="p-4">
-          <div className="flex items-center gap-3 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-muted-foreground/20">
-            {templates.map((template) => {
-              const matchedSkill = matchMap.get(template.id) ?? null;
-              const shouldShowMatch = Boolean(
-                template.skillId || template.skillHint || template.skillTags?.length
-              );
-
-              return (
-                <div
-                  key={template.id}
-                  className="shrink-0 w-64 rounded-lg border border-border bg-card p-4 hover:border-primary/50 hover:shadow-md transition-all cursor-pointer group flex flex-col justify-between"
-                  onClick={() => handleSelectTemplate(template)}
-                >
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <div className="flex-1">
-                      <h3 className="font-medium text-sm line-clamp-1">{template.title}</h3>
-                      <p className="text-xs text-muted-foreground mt-1 line-clamp-2 min-h-[2.5rem]">
-                        {template.summary}
-                      </p>
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleSelectTemplate(template);
-                      }}
-                    >
-                      使用
-                    </Button>
-                  </div>
-                  {shouldShowMatch && (
-                    <div className="flex items-center gap-2">
-                      {isLoadingSkills && (
-                        <span className="text-xs text-muted-foreground">匹配中...</span>
-                      )}
-                      {!isLoadingSkills && matchedSkill && (
-                        <span className="text-xs text-primary">匹配技能：{matchedSkill.slug}</span>
-                      )}
-                      {!isLoadingSkills && !matchedSkill && (
-                        <span className="text-xs text-muted-foreground">未匹配技能</span>
-                      )}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-            {templates.length === 0 && (
-              <div className="text-sm text-muted-foreground px-2">该分类暂无任务模板</div>
-            )}
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+              <div className="flex-1">
+                <p className="font-medium text-sm">启用「{displayName(riskSkill)}」前请注意</p>
+                <p className="mt-1 text-muted-foreground text-xs">{riskSkill.riskNotesZh}</p>
+              </div>
+            </div>
+            <div className="mt-3 flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setRiskSkill(null)}>
+                取消
+              </Button>
+              <Button size="sm" onClick={() => void enableSkill(riskSkill)}>
+                仍要启用
+              </Button>
+            </div>
           </div>
         </div>
       )}
 
-      {/* Form Fields - show when template selected */}
-      {selectedTemplate && variables.length > 0 && (
-        <div className="p-4 space-y-4">
-          {/* Template info with back button */}
-          <div className="flex items-center gap-3 pb-3 border-b">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2"
-              onClick={() => setSelectedTemplateId(null)}
-            >
-              <ChevronDown className="h-4 w-4 rotate-90 mr-1" />
+      {/* Just-enabled cue (effective next conversation) */}
+      {!riskSkill && justEnabled && (
+        <div className="p-4">
+          <div className="rounded-md border border-primary/30 bg-accent p-4">
+            <p className="font-medium text-sm">
+              已加入「{displayName(justEnabled)}」—— 将在<strong className="text-primary">新对话</strong>生效
+            </p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              当前模型无法在运行中的会话热加载技能；开启新对话即可加载并使用。起手 prompt 已为你准备好。
+            </p>
+            <div className="mt-3 flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setJustEnabled(null)}>
+                知道了
+              </Button>
+              <Button size="sm" className="gap-1.5" onClick={() => handleOpenNewChat(justEnabled)}>
+                开启新对话并加载 <ArrowRight className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Variable form for a selected, enabled skill */}
+      {!riskSkill && !justEnabled && selectedSkill?.enabled && (
+        <div className="space-y-4 p-4">
+          <div className="flex items-center gap-3 border-b border-border pb-3">
+            <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setSelectedSlug(null)}>
+              <ChevronLeft className="mr-1 h-4 w-4" />
               返回
             </Button>
             <div className="flex-1">
-              <h3 className="font-medium">{selectedTemplate.title}</h3>
-              <p className="text-xs text-muted-foreground">{selectedTemplate.summary}</p>
+              <h3 className="font-medium text-sm">{displayName(selectedSkill)}</h3>
+              <p className="text-muted-foreground text-xs">{selectedSkill.summaryZh}</p>
             </div>
           </div>
-
-          {/* Form fields */}
-          <div className="space-y-4">
-            {variableFields.map(({ name, field }) => (
-              <div key={name} className="space-y-1.5">
-                <div className="flex items-center gap-2">
-                  <label className="text-sm font-medium">
-                    {field?.label ?? name}
-                  </label>
-                  {field?.required && (
-                    <span className="text-xs text-destructive">*</span>
-                  )}
-                  {field?.description && (
-                    <span className="text-xs text-muted-foreground">{field.description}</span>
-                  )}
+          {variables.length > 0 ? (
+            <div className="space-y-4">
+              {schemaInputs.map((field) => (
+                <div key={field.name} className="space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <label className="font-medium text-sm">{field.label ?? field.name}</label>
+                    {field.required && <span className="text-destructive text-xs">*</span>}
+                    {field.description && (
+                      <span className="text-muted-foreground text-xs">{field.description}</span>
+                    )}
+                  </div>
+                  {renderVariableControl(field.name, field)}
                 </div>
-                {renderVariableControl(name, field)}
-              </div>
-            ))}
-          </div>
-
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-muted-foreground text-sm">
+              起手 prompt 已填入，可直接编辑并发送。
+            </p>
+          )}
         </div>
       )}
 
-      {/* No variables case */}
-      {selectedTemplate && variables.length === 0 && (
-        <div className="p-4 text-center text-sm text-muted-foreground">
-          此任务模板无需填写字段，可直接发送。
+      {/* Skill cards (default view) */}
+      {!riskSkill && !justEnabled && !selectedSkill && (
+        <div className="space-y-3 p-4">
+          {enabledSkills.length > 0 ? (
+            <div className="scrollbar-thin scrollbar-thumb-muted-foreground/20 flex items-center gap-3 overflow-x-auto pb-2">
+              {enabledSkills.map((skill) => (
+                <SkillCard key={skill.slug} skill={skill} />
+              ))}
+            </div>
+          ) : (
+            <p className="px-1 text-muted-foreground text-sm">
+              该分类下还没有已启用的技能 —— 从下方启用一个（新对话生效）。
+            </p>
+          )}
+
+          {unenabledSkills.length > 0 && (
+            <div>
+              <button
+                type="button"
+                className="font-mono text-muted-foreground text-xs hover:text-foreground"
+                onClick={() => setShowUnenabled((v) => !v)}
+              >
+                {showUnenabled ? '收起' : `更多技能（未启用 · ${unenabledSkills.length}）`}
+              </button>
+              {showUnenabled && (
+                <div className="scrollbar-thin scrollbar-thumb-muted-foreground/20 mt-3 flex items-center gap-3 overflow-x-auto pb-2">
+                  {unenabledSkills.map((skill) => (
+                    <SkillCard key={skill.slug} skill={skill} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/claude-chat/a2composer-panel.tsx
+++ b/src/components/claude-chat/a2composer-panel.tsx
@@ -64,6 +64,7 @@ export function A2ComposerPanel({
   onSkillSelect,
   onOpenNewConversation,
 }: A2ComposerPanelProps) {
+  void composerText; // prop kept for API compatibility; no longer read internally
   const [isMinimized, setIsMinimized] = useState(true);
   const [activeBucketId, setActiveBucketId] = useState<BucketId>(A2_BUCKETS[0].id);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
@@ -75,7 +76,7 @@ export function A2ComposerPanel({
   const getCatalog = useServerFn(getComposerCatalogFn);
   const getSkillSchema = useServerFn(getCuratedSkillSchemaFn);
   const installSkill = useServerFn(installCuratedSkillFn);
-  const setPendingComposerText = useChatSessionStore((s) => s.setPendingComposerText);
+  const setPendingArmedSkill = useChatSessionStore((s) => s.setPendingArmedSkill);
 
   const { data: catalog = [], isLoading, refetch } = useQuery<ComposerSkill[]>({
     queryKey: ['a2composer-catalog'],
@@ -150,15 +151,16 @@ export function A2ComposerPanel({
   };
 
   const openEnabledSkill = (skill: ComposerSkill) => {
+    // Arm the skill (composer chip + skill marker on send). Composer text is set
+    // by the tier effect once the schema resolves: Tier 2 (has inputs) → form-fill
+    // prompt; Tier 1 (no inputs) → empty composer, firstTaskZh shown only as a hint.
     setSelectedSlug(skill.slug);
     setVariableValues({});
-    onSetComposerText(starterOf(skill));
     onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
   };
 
   const enableSkill = async (skill: ComposerSkill) => {
     setRiskSkill(null);
-    onSetComposerText(starterOf(skill));
     onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
     try {
       // Catalog install: materialize SKILL.md to disk + record in skill_enablement.
@@ -184,7 +186,8 @@ export function A2ComposerPanel({
   };
 
   const handleOpenNewChat = (skill: ComposerSkill) => {
-    setPendingComposerText(starterOf(skill));
+    // Arm the skill in the fresh session (it's enabled now, effective next convo).
+    setPendingArmedSkill({ slug: skill.slug, name: displayName(skill) });
     onOpenNewConversation?.();
     handleMinimize();
   };
@@ -197,13 +200,16 @@ export function A2ComposerPanel({
     });
   };
 
-  // Auto-collapse when the composer was cleared externally (e.g. after send).
+  // Two-tier: once an enabled skill is selected and its schema resolves, either
+  // seed the form-fill prompt (Tier 2 — has inputs) or keep the composer empty so
+  // firstTaskZh acts purely as a hint (Tier 1). Post-send reset is handled by the
+  // parent remount (a2ComposerKey), so no auto-collapse effect is needed here.
   useEffect(() => {
-    if (onReset && composerText === '' && (selectedSlug || justEnabled)) {
-      handleMinimize();
-    }
+    if (!selectedSkill?.enabled) return;
+    if (schemaData === undefined) return; // schema still loading
+    onSetComposerText(schemaInputs.length > 0 ? buildPrompt(selectedSkill, {}) : '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [composerText, onReset]);
+  }, [selectedSlug, schemaData]);
 
   // ── variable form controls (schema-driven) ─────────────────────────────
   const getOptionValue = (option: SkillOption, index: number) =>
@@ -381,8 +387,6 @@ export function A2ComposerPanel({
     );
   }
 
-  const variables = schemaInputs.map((f) => f.name);
-
   // ===== EXPANDED =====
   return (
     <div className="mx-auto w-full max-w-3xl rounded-lg border border-border bg-card shadow-sm">
@@ -474,7 +478,7 @@ export function A2ComposerPanel({
         </div>
       )}
 
-      {/* Variable form for a selected, enabled skill */}
+      {/* Selected enabled skill — Tier 2 (curated form) or Tier 1 (placeholder hint) */}
       {!riskSkill && !justEnabled && selectedSkill?.enabled && (
         <div className="space-y-4 p-4">
           <div className="flex items-center gap-3 border-b border-border pb-3">
@@ -487,7 +491,11 @@ export function A2ComposerPanel({
               <p className="text-muted-foreground text-xs">{selectedSkill.summaryZh}</p>
             </div>
           </div>
-          {variables.length > 0 ? (
+
+          {schemaData === undefined ? (
+            <p className="text-center text-muted-foreground text-sm">正在准备…</p>
+          ) : schemaInputs.length > 0 ? (
+            // Tier 2 — curated form: the fields compose the prompt.
             <div className="space-y-4">
               {schemaInputs.map((field) => (
                 <div key={field.name} className="space-y-1.5">
@@ -503,9 +511,16 @@ export function A2ComposerPanel({
               ))}
             </div>
           ) : (
-            <p className="text-center text-muted-foreground text-sm">
-              起手 prompt 已填入，可直接编辑并发送。
-            </p>
+            // Tier 1 — placeholder hint: skill is armed, composer stays empty.
+            <div className="rounded-md border border-primary/20 bg-accent/60 p-3">
+              <p className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+                提示 · how to use
+              </p>
+              <p className="mt-1.5 text-foreground text-sm">{starterOf(selectedSkill)}</p>
+              <p className="mt-2 text-muted-foreground text-xs">
+                「{displayName(selectedSkill)}」已就绪 —— 按提示在下方输入框输入 / 粘贴内容并发送即可。
+              </p>
+            </div>
           )}
         </div>
       )}

--- a/src/components/claude-chat/a2composer-panel.tsx
+++ b/src/components/claude-chat/a2composer-panel.tsx
@@ -29,7 +29,7 @@ import {
 import {
   getComposerCatalogFn,
   getCuratedSkillSchemaFn,
-  ensureUserSkillEnabledFn,
+  installCuratedSkillFn,
 } from '~/server/function/skills.server';
 import type { ComposerSkill } from '~/lib/a2composer/types';
 import type { SkillInputField } from '~/claude/skills';
@@ -74,11 +74,10 @@ export function A2ComposerPanel({
 
   const getCatalog = useServerFn(getComposerCatalogFn);
   const getSkillSchema = useServerFn(getCuratedSkillSchemaFn);
-  const ensureSkillEnabled = useServerFn(ensureUserSkillEnabledFn);
-  const addTemporarySkill = useChatSessionStore((s) => s.addTemporarySkill);
+  const installSkill = useServerFn(installCuratedSkillFn);
   const setPendingComposerText = useChatSessionStore((s) => s.setPendingComposerText);
 
-  const { data: catalog = [], isLoading } = useQuery<ComposerSkill[]>({
+  const { data: catalog = [], isLoading, refetch } = useQuery<ComposerSkill[]>({
     queryKey: ['a2composer-catalog'],
     queryFn: () => getCatalog(),
   });
@@ -162,10 +161,12 @@ export function A2ComposerPanel({
     onSetComposerText(starterOf(skill));
     onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
     try {
-      const res = await ensureSkillEnabled({ data: { skillName: skill.slug } });
-      if (res?.enabledNow) addTemporarySkill(res.skillName ?? skill.slug);
+      // Catalog install: materialize SKILL.md to disk + record in skill_enablement.
+      // Effective next conversation (SDK can't hot-reload — STATUS Skills S2).
+      await installSkill({ data: { slug: skill.slug } });
+      void refetch();
     } catch (error) {
-      console.error('[A2Composer] Failed to enable skill:', error);
+      console.error('[A2Composer] Failed to install skill:', error);
     }
     setJustEnabled(skill);
   };

--- a/src/components/claude-chat/a2composer-panel.tsx
+++ b/src/components/claude-chat/a2composer-panel.tsx
@@ -47,8 +47,8 @@ interface A2ComposerPanelProps {
   onReset?: () => void;
   /** Notify parent when panel open state changes (expanded vs minimized) */
   onOpenChange?: (open: boolean) => void;
-  /** Explicitly select a skill for this message */
-  onSkillSelect?: (skill: { slug: string; name: string }) => void;
+  /** Explicitly select a skill for this message (hint → composer placeholder) */
+  onSkillSelect?: (skill: { slug: string; name: string; hint?: string }) => void;
   /** Open a fresh conversation so a just-enabled skill loads (SDK can't hot-reload) */
   onOpenNewConversation?: () => void;
 }
@@ -156,12 +156,12 @@ export function A2ComposerPanel({
     // prompt; Tier 1 (no inputs) → empty composer, firstTaskZh shown only as a hint.
     setSelectedSlug(skill.slug);
     setVariableValues({});
-    onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
+    onSkillSelect?.({ slug: skill.slug, name: displayName(skill), hint: starterOf(skill) });
   };
 
   const enableSkill = async (skill: ComposerSkill) => {
     setRiskSkill(null);
-    onSkillSelect?.({ slug: skill.slug, name: displayName(skill) });
+    onSkillSelect?.({ slug: skill.slug, name: displayName(skill), hint: starterOf(skill) });
     try {
       // Catalog install: materialize SKILL.md to disk + record in skill_enablement.
       // Effective next conversation (SDK can't hot-reload — STATUS Skills S2).
@@ -187,7 +187,7 @@ export function A2ComposerPanel({
 
   const handleOpenNewChat = (skill: ComposerSkill) => {
     // Arm the skill in the fresh session (it's enabled now, effective next convo).
-    setPendingArmedSkill({ slug: skill.slug, name: displayName(skill) });
+    setPendingArmedSkill({ slug: skill.slug, name: displayName(skill), hint: starterOf(skill) });
     onOpenNewConversation?.();
     handleMinimize();
   };

--- a/src/components/claude-chat/chat-composer.tsx
+++ b/src/components/claude-chat/chat-composer.tsx
@@ -102,8 +102,8 @@ export interface ChatComposerProps {
   onTextChange?: (text: string) => void;
   /** Called when user sends a message */
   onSend?: () => void;
-  /** Selected skill for explicit use */
-  selectedSkill?: { slug: string; name?: string } | null;
+  /** Selected skill for explicit use (hint → composer placeholder when armed) */
+  selectedSkill?: { slug: string; name?: string; hint?: string } | null;
   /** Clear selected skill */
   onClearSelectedSkill?: () => void;
   /** Select a skill from composer UI */
@@ -431,7 +431,9 @@ export function ChatComposer({
         <div className="relative z-10">
           <div className="wrap-break-word max-h-96 w-full overflow-y-auto">
             <ComposerPrimitive.Input
-              placeholder={toLocalizedString(content.chatInput.placeholderGreeting)}
+              placeholder={
+                selectedSkill?.hint || toLocalizedString(content.chatInput.placeholderGreeting)
+              }
               className="block min-h-6 w-full resize-none bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
             />
           </div>

--- a/src/lib/a2composer/buckets.ts
+++ b/src/lib/a2composer/buckets.ts
@@ -1,0 +1,34 @@
+/**
+ * A2Composer task buckets — 5 面向任务的大类，映射自技能 `skill_catalog.category`
+ * 的 7 个值。展示层映射；不改技能底层 category。
+ * See docs/project/prd/2026-06-a2composer-prd.md §0.
+ */
+
+export type BucketId = 'writing' | 'design' | 'automation' | 'research' | 'ai_eng';
+
+export type A2Bucket = {
+  id: BucketId;
+  /** lucide icon name (resolved to a component in the panel) */
+  icon: string;
+  /** display label (zh) */
+  label: string;
+  /** skill_catalog.category values that fall into this bucket */
+  categories: string[];
+};
+
+export const A2_BUCKETS: A2Bucket[] = [
+  { id: 'writing', icon: 'PenLine', label: '写作与内容', categories: ['writing'] },
+  { id: 'design', icon: 'Shapes', label: '设计与前端', categories: ['design_frontend'] },
+  { id: 'automation', icon: 'Workflow', label: '自动化与集成', categories: ['automation', 'security'] },
+  { id: 'research', icon: 'Compass', label: '研究与策略', categories: ['research', 'learning'] },
+  { id: 'ai_eng', icon: 'Cpu', label: 'AI 工程', categories: ['ai_engineering'] },
+];
+
+/** category → bucketId */
+export const CATEGORY_TO_BUCKET: Record<string, BucketId> = A2_BUCKETS.reduce(
+  (acc, bucket) => {
+    for (const cat of bucket.categories) acc[cat] = bucket.id;
+    return acc;
+  },
+  {} as Record<string, BucketId>,
+);

--- a/src/lib/a2composer/types.ts
+++ b/src/lib/a2composer/types.ts
@@ -31,3 +31,22 @@ export type A2ComposerStore = {
   templates: A2Template[];
   updatedAt?: string;
 };
+
+/**
+ * Composer view of a curated skill (derived from skill_catalog + per-user
+ * enablement). This is the new single source for the composer shortcuts —
+ * see docs/project/prd/2026-06-a2composer-prd.md.
+ */
+export type ComposerSkill = {
+  slug: string;
+  name: string;
+  titleZh: string | null;
+  summaryZh: string | null;
+  category: string | null;
+  level: string | null;
+  suitableForZh: string | null;
+  firstTaskZh: string | null;
+  riskNotesZh: string | null;
+  sortWeight: number;
+  enabled: boolean;
+};

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -190,7 +190,7 @@ interface ChatSessionState {
   // Skill to arm once the NEXT (newly-created) session is ready. Used by the
   // A2Composer "open new chat & load" flow: the skill was just enabled (effective
   // next conversation per SDK constraint), so we arm it in the fresh session.
-  pendingArmedSkill?: { slug: string; name?: string };
+  pendingArmedSkill?: { slug: string; name?: string; hint?: string };
 
   // Actions
   setSessionId: (sessionId: string | null) => void;
@@ -220,7 +220,7 @@ interface ChatSessionState {
   clearTemporarySkills: () => void;
   setSelectedTier: (mode: InteractionMode | undefined) => void;
   setSelectedModelId: (id: string | undefined) => void;
-  setPendingArmedSkill: (skill: { slug: string; name?: string } | undefined) => void;
+  setPendingArmedSkill: (skill: { slug: string; name?: string; hint?: string } | undefined) => void;
 
   // Load historical messages from SDK format
   loadHistoricalMessages: (sdkMessages: SDKMessage[]) => void;

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -187,6 +187,11 @@ interface ChatSessionState {
   // localStorage (PR8) and restored on session switch/resume.
   selectedModelId?: string;
 
+  // Composer text to apply once the NEXT (newly-created) session is ready.
+  // Used by the A2Composer "open new chat & load" flow (skill enabled now,
+  // effective next conversation per SDK constraint).
+  pendingComposerText?: string;
+
   // Actions
   setSessionId: (sessionId: string | null) => void;
   setMessages: (messages: ThreadMessage[]) => void;
@@ -215,6 +220,7 @@ interface ChatSessionState {
   clearTemporarySkills: () => void;
   setSelectedTier: (mode: InteractionMode | undefined) => void;
   setSelectedModelId: (id: string | undefined) => void;
+  setPendingComposerText: (text: string | undefined) => void;
 
   // Load historical messages from SDK format
   loadHistoricalMessages: (sdkMessages: SDKMessage[]) => void;
@@ -458,9 +464,14 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
   temporarySkills: [],
   selectedTier: 'act' as const, // default: 执行(Act) — full capability, sandbox is the guard
   selectedModelId: undefined,
+  pendingComposerText: undefined,
 
   setSelectedTier: (selectedTier) => {
     set({ selectedTier });
+  },
+
+  setPendingComposerText: (pendingComposerText) => {
+    set({ pendingComposerText });
   },
 
   setSelectedModelId: (selectedModelId) => {

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -187,10 +187,10 @@ interface ChatSessionState {
   // localStorage (PR8) and restored on session switch/resume.
   selectedModelId?: string;
 
-  // Composer text to apply once the NEXT (newly-created) session is ready.
-  // Used by the A2Composer "open new chat & load" flow (skill enabled now,
-  // effective next conversation per SDK constraint).
-  pendingComposerText?: string;
+  // Skill to arm once the NEXT (newly-created) session is ready. Used by the
+  // A2Composer "open new chat & load" flow: the skill was just enabled (effective
+  // next conversation per SDK constraint), so we arm it in the fresh session.
+  pendingArmedSkill?: { slug: string; name?: string };
 
   // Actions
   setSessionId: (sessionId: string | null) => void;
@@ -220,7 +220,7 @@ interface ChatSessionState {
   clearTemporarySkills: () => void;
   setSelectedTier: (mode: InteractionMode | undefined) => void;
   setSelectedModelId: (id: string | undefined) => void;
-  setPendingComposerText: (text: string | undefined) => void;
+  setPendingArmedSkill: (skill: { slug: string; name?: string } | undefined) => void;
 
   // Load historical messages from SDK format
   loadHistoricalMessages: (sdkMessages: SDKMessage[]) => void;
@@ -464,14 +464,14 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
   temporarySkills: [],
   selectedTier: 'act' as const, // default: 执行(Act) — full capability, sandbox is the guard
   selectedModelId: undefined,
-  pendingComposerText: undefined,
+  pendingArmedSkill: undefined,
 
   setSelectedTier: (selectedTier) => {
     set({ selectedTier });
   },
 
-  setPendingComposerText: (pendingComposerText) => {
-    set({ pendingComposerText });
+  setPendingArmedSkill: (pendingArmedSkill) => {
+    set({ pendingArmedSkill });
   },
 
   setSelectedModelId: (selectedModelId) => {

--- a/src/routes/agents/capabilities/route.tsx
+++ b/src/routes/agents/capabilities/route.tsx
@@ -70,7 +70,11 @@ function CapabilityCenter() {
   };
 
   return (
-    <div className="container mx-auto max-w-6xl px-6 py-8">
+    // The /agents layout wraps the Outlet in an `overflow-hidden` flex shell
+    // (sized for the chat view's internal scroll). This page is a tall document,
+    // so it must own its own vertical scroll — otherwise it gets clipped.
+    <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="container mx-auto max-w-6xl px-6 py-8">
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
           <TabsTrigger value="skills">{content.nav.skillsStore}</TabsTrigger>
@@ -102,6 +106,7 @@ function CapabilityCenter() {
         onOpenChange={setIsUploadDialogOpen}
         onSuccess={handleSkillUploadSuccess}
       />
+      </div>
     </div>
   );
 }

--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -1385,7 +1385,7 @@ function ClaudeChatSurface({
   const [composerText, setComposerText] = useState('');
   const [isA2ComposerOpen, setIsA2ComposerOpen] = useState(false);
   const [isSkillsPanelOpen, setIsSkillsPanelOpen] = useState(false);
-  const [selectedSkill, setSelectedSkill] = useState<{ slug: string; name?: string } | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<{ slug: string; name?: string; hint?: string } | null>(null);
 
   // A2ComposerPanel reset handler
   const [a2ComposerKey, setA2ComposerKey] = useState(0);
@@ -1408,7 +1408,7 @@ function ClaudeChatSurface({
     }
   }, [currentSessionId, isInitializingSession, pendingArmedSkill, setPendingArmedSkill]);
 
-  const handleSelectSkill = useCallback((skill: { slug: string; name?: string }) => {
+  const handleSelectSkill = useCallback((skill: { slug: string; name?: string; hint?: string }) => {
     setSelectedSkill(skill);
   }, []);
 

--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -1102,8 +1102,8 @@ function ClaudeChatSurface({
   const [showWorkspace, setShowWorkspace] = useState(false);
   const [showSessionFiles, setShowSessionFiles] = useState(false);
   const currentSessionId = useChatSessionStore((state) => state.currentSessionId);
-  const pendingComposerText = useChatSessionStore((state) => state.pendingComposerText);
-  const setPendingComposerText = useChatSessionStore((state) => state.setPendingComposerText);
+  const pendingArmedSkill = useChatSessionStore((state) => state.pendingArmedSkill);
+  const setPendingArmedSkill = useChatSessionStore((state) => state.setPendingArmedSkill);
   const { loadSessionAttachments } = useMessageAttachments();
   const [attachmentsByMessage, setAttachmentsByMessage] = useState<Map<string, MessageAttachment[]>>(
     new Map()
@@ -1399,14 +1399,14 @@ function ClaudeChatSurface({
     composerRef.current?.focus();
   }, []);
 
-  // Apply the starter prompt stashed by A2Composer's "open new chat & load" once
-  // the freshly-created session is ready (the just-enabled skill is now loaded).
+  // Arm the skill stashed by A2Composer's "open new chat & load" once the freshly-
+  // created session is ready (the just-enabled skill is now loaded + active).
   useEffect(() => {
-    if (currentSessionId && !isInitializingSession && pendingComposerText) {
-      handleSetComposerText(pendingComposerText);
-      setPendingComposerText(undefined);
+    if (currentSessionId && !isInitializingSession && pendingArmedSkill) {
+      setSelectedSkill(pendingArmedSkill);
+      setPendingArmedSkill(undefined);
     }
-  }, [currentSessionId, isInitializingSession, pendingComposerText, handleSetComposerText, setPendingComposerText]);
+  }, [currentSessionId, isInitializingSession, pendingArmedSkill, setPendingArmedSkill]);
 
   const handleSelectSkill = useCallback((skill: { slug: string; name?: string }) => {
     setSelectedSkill(skill);

--- a/src/routes/agents/claude-chat/route.tsx
+++ b/src/routes/agents/claude-chat/route.tsx
@@ -1102,6 +1102,8 @@ function ClaudeChatSurface({
   const [showWorkspace, setShowWorkspace] = useState(false);
   const [showSessionFiles, setShowSessionFiles] = useState(false);
   const currentSessionId = useChatSessionStore((state) => state.currentSessionId);
+  const pendingComposerText = useChatSessionStore((state) => state.pendingComposerText);
+  const setPendingComposerText = useChatSessionStore((state) => state.setPendingComposerText);
   const { loadSessionAttachments } = useMessageAttachments();
   const [attachmentsByMessage, setAttachmentsByMessage] = useState<Map<string, MessageAttachment[]>>(
     new Map()
@@ -1397,6 +1399,15 @@ function ClaudeChatSurface({
     composerRef.current?.focus();
   }, []);
 
+  // Apply the starter prompt stashed by A2Composer's "open new chat & load" once
+  // the freshly-created session is ready (the just-enabled skill is now loaded).
+  useEffect(() => {
+    if (currentSessionId && !isInitializingSession && pendingComposerText) {
+      handleSetComposerText(pendingComposerText);
+      setPendingComposerText(undefined);
+    }
+  }, [currentSessionId, isInitializingSession, pendingComposerText, handleSetComposerText, setPendingComposerText]);
+
   const handleSelectSkill = useCallback((skill: { slug: string; name?: string }) => {
     setSelectedSkill(skill);
   }, []);
@@ -1539,6 +1550,7 @@ function ClaudeChatSurface({
                     onReset={handleA2ComposerReset}
                     onOpenChange={handleA2ComposerOpenChange}
                     onSkillSelect={handleSelectSkill}
+                    onOpenNewConversation={onStartSession}
                   />
                 </div>
 

--- a/src/server/function/skills.server.ts
+++ b/src/server/function/skills.server.ts
@@ -52,6 +52,7 @@ import {
 } from '~/claude/skills';
 import { validateGitHubUrl } from '~/claude/skills/command-parser';
 import type { CatalogSchemaResult } from '~/claude/skills/catalog-schema';
+import type { ComposerSkill } from '~/lib/a2composer/types';
 import type { SkillsApiListItem } from '~/claude/skills/skills-api-client';
 
 /**
@@ -632,6 +633,58 @@ export const getCuratedSkillSchemaFn = createServerFn({ method: 'POST' })
     if (!row) throw new Error(`Curated skill not found: ${data.slug}`);
     return await readCatalogSchema(row.id);
   });
+
+/**
+ * Composer catalog view (A2Composer redesign — see a2composer PRD).
+ *
+ * Returns curated skills (official + this user's own) with the editorial fields
+ * the composer shortcuts need + the user's per-skill `enabled` state. This is the
+ * single source for the in-conversation skill shortcuts (replaces the hand-written
+ * A2 category/template store). `enabled` skills are usable in the CURRENT session;
+ * un-enabled ones can be enabled on the spot but only load next conversation
+ * (SDK 0.2.112 can't hot-reload — STATUS Skills S2).
+ */
+export const getComposerCatalogFn = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<ComposerSkill[]> => {
+    const user = await requireUser();
+    const { db } = await import('~/db/db-config');
+    const { skillCatalog, skillEnablement } = await import('~/db/schema');
+    const { and, eq, or, isNotNull } = await import('drizzle-orm');
+
+    const rows = await db
+      .select({
+        slug: skillCatalog.slug,
+        name: skillCatalog.name,
+        titleZh: skillCatalog.titleZh,
+        summaryZh: skillCatalog.summaryZh,
+        category: skillCatalog.category,
+        level: skillCatalog.level,
+        suitableForZh: skillCatalog.suitableForZh,
+        firstTaskZh: skillCatalog.firstTaskZh,
+        riskNotesZh: skillCatalog.riskNotesZh,
+        sortWeight: skillCatalog.sortWeight,
+        enabled: skillEnablement.enabled,
+      })
+      .from(skillCatalog)
+      .leftJoin(
+        skillEnablement,
+        and(eq(skillEnablement.catalogId, skillCatalog.id), eq(skillEnablement.userId, user.id)),
+      )
+      .where(
+        and(
+          isNotNull(skillCatalog.category),
+          or(
+            eq(skillCatalog.scope, 'official'),
+            and(eq(skillCatalog.scope, 'user'), eq(skillCatalog.ownerUserId, user.id)),
+          ),
+        ),
+      );
+
+    return rows
+      .map((r) => ({ ...r, enabled: r.enabled === true }))
+      .sort((a, b) => b.sortWeight - a.sortWeight || a.name.localeCompare(b.name));
+  },
+);
 
 /**
  * Generate (or refresh) the fillable-variable schema for a curated skill.


### PR DESCRIPTION
> **Stacked on #141** (base = `feat/design-jumpx-homepage`) so the diff is a2composer-only. Retarget to `main` after #141 merges.

## Why
The composer skill shortcuts were a hand-written 4-category/8-template store that was **mismatched** (its categories ≠ the skills' own categories), **drifted** (2 `skillHint` slugs don't exist), and **unwired** (`skillId` never set → picking a shortcut inserted a prompt but **loaded no skill**). Full analysis + decision in **`docs/project/prd/2026-06-a2composer-prd.md`**.

## Decision (owner-approved)
Keep it, but **derive the shortcuts from the curated skill catalog** (single source) instead of a parallel hand-maintained store. Present skills under **5 task buckets** mapped from the 7 catalog categories.

## What
- **`getComposerCatalogFn`** — curated skills (official + own) with editorial fields (`titleZh/summaryZh/firstTaskZh/suitableForZh/riskNotesZh/category/level`) + per-user `enabled`, from `skill_catalog ⨝ skill_enablement`. No schema changes.
- **`A2_BUCKETS` / `CATEGORY_TO_BUCKET`** — 5 task buckets (display layer).
- **Panel rewrite**: bucket pills (lucide, **no emoji**) → skill cards (**enabled-first, un-enabled folded**).
  - **Enabled** skill → insert `firstTaskZh` + schema-driven variable form → send now.
  - **Un-enabled** skill → `riskNotesZh` guard → `ensureSkillEnabled` → cue **"新对话生效"** + **"开启新对话并加载"** one-click. (SDK 0.2.112 can't hot-reload a running session — STATUS Skills S2.)
  - Starter prompt carries into the new conversation via store `pendingComposerText`.
- `A2_TEMPLATES` / `getA2ComposerStoreFn` kept as a **dormant admin override layer** (backlog); the live UI no longer depends on them.

## Verify
`oxlint` clean (new files); `tsc` — new files clean, route.tsx error count unchanged (11, all pre-existing). Building the image for OrbStack now.

## Follow-ups (backlog)
P3 admin override editor + feature flag; smarter ranking (recommendationTags/recently-used/context-aware); prune the dormant `config.ts`/`marketing.content.ts` leftovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)