### PR TITLE
docs(scope): align RAG + file-upload designs with the Projects scope model

### DIFF
--- a/docs/project/research/2026-06-advanced-rag-design.md
+++ b/docs/project/research/2026-06-advanced-rag-design.md
@@ -1,0 +1,195 @@
+# OxyGenie Advanced RAG 设计方案
+
+> 状态：**设计稿（未实现）** · 2026-06-07 · 对应博客设计篇 [D1](../../blog/zh/d1-advanced-rag.md)
+> 北极星对照：自托管 / 单组织 / 多用户（半可信同事）/ ARK 网关 + SDK 0.2.112 钉死 / 单机 16G·50 并发 / 可部署性优先。本方案不依赖任何 0.3.x-only 的 SDK 特性。
+>
+> **🔄 更新（2026-06-08，Projects PRD）**：隔离基元从 `user_id` 改为 **`scope(personal|project)` + 统一访问解析器**——所有检索 `WHERE user_id=?` 改为 **`WHERE kb_id IN accessibleKbIds(user)`**；`documents`/`knowledge_bases` 加 `scope + project_id`；`document.userId` 退化为"上传者/署名"；**chunks/embedding 不加 scope（零重嵌，一份嵌入多人可见）**。**scope 列必须在 R0 同一次迁移里落**，否则按 `user_id` 建好后加 Project 必返工。详见 [Projects PRD](../prd/2026-06-projects-collaboration-prd.md) + [Projects P1 ⊕ RAG R0 合并方案](./2026-06-projects-p1-rag-r0-data-model.md)。
+
+## 0. 一句话方针
+
+**RAG 不是默认项，是"放不下了"才触发的逃生通道。** OxyGenie 已有的 `Read`/`Grep`（per-session workspace）对小文档**本来就够、而且更好**；本方案只补**大文档 / 大语料 + 捞针**这一格，并把"走哪一格"做成**上传时分流 + 在线让 Agent 自己选工具**的路由，而不是把所有文档都 chunk+embed。
+
+---
+
+## 1. 背景：现状是"空架子"
+
+代码盘点（`main` @ 2026-06-07）：
+
+| 该有的 | 现状 | 证据 |
+|--------|------|------|
+| 向量列 | ✅ 有，**从未写入/查询** | `src/db/schema/document.schema.ts:33` `embedding: vector(1536)` |
+| chunk 仓库 | ✅ 定义，**死代码** | `src/db/repositories/document.repo.ts:6` `documentChunkRepo` |
+| 入库 | ❌ 纯文件拷贝，无切分/嵌入 | `src/routes/api/workspace/$sessionId.documents.ts` |
+| 解析 | ❌ 装了不用 | `src/mcp-store/markitdown-mcp` |
+| 检索 | ⚠️ 只有 BM25 | `src/search/meilisearch.ts` |
+| Embedding / 检索工具 / 评测 / tracing | ❌ 全无 | — |
+
+**缺的不是设计，是接线**：pgvector 列、BullMQ、Meili、markitdown、ARK 网关、S3 全在了，只是从没接到一起。
+
+---
+
+## 2. 核心原则：分档路由，不是默认 RAG
+
+### 2.1 三档阶梯（按"塞不塞得进上下文"切）
+
+| 档 | 触发条件 | 用什么 | 成本 |
+|----|----------|--------|------|
+| **① 装得进上下文** | 单文档 ≲ 预算的一小块（粗略 ~1–3 万 token / 十几页），单次/短会话 | **整篇丢进上下文，模型自己读** | 零额外基建；按 token 计费（有 cache 则更省） |
+| **② 放不下、字面可定位** | 单个大文件，查的是关键词能命中的东西 | **`Grep` + `Read`（Agent 自己翻）= 现状** | 几乎零成本、无损 |
+| **③ 放不下 + 语义对不上 / 多文档语料** | 200 页、一堆文档、或跨会话天天查的常备资料 | **chunk + embed + 混合检索（本方案）** | 入库有成本，换语义召回 + 跨文档 + 可复用 |
+
+> ①②是 OxyGenie 现状，**对它们这是正确答案，不是缺口**。本方案只造 ③。
+
+### 2.2 第二根轴：任务类型（捞针 vs 通读）
+
+RAG 只擅长**大海捞针（lookup）**，不擅长**通读全篇（holistic）**：
+
+- "退款费率是多少" → top-K 检索完美。
+- "总结这 200 页 / 对比第 3 章和第 9 章" → top-K **有害**（切碎全局结构）→ 走**全文 map-reduce / 分层摘要**，不是检索。
+
+**决策是二维的：`大小 ×（捞针 / 通读）`。** 200 页 + 捞针 → RAG；200 页 + 通读 → 分层摘要。
+
+### 2.3 路由落点
+
+- **上传时分流（关键省钱点）**：文件入库时按大小分类——小 → 留作 workspace 文件，走 Read/Grep，**不嵌**；大 → 才入 BullMQ 嵌入管线。**绝大多数上传是小的，全嵌纯属烧钱。**
+- **在线把工具都给 Agent**：同一会话里 Agent 同时有 `Read` / `Grep` / （大文档才有的）`kb_search` / 文档摘要+ToC——**用哪个交给 Loop**（Agentic 本质；第 03/06 篇）。RAG 是多给的一把工具，不是替换 Grep。
+- **门槛是预算不是页数**：真正决定档位的是 `(大小 × 复用次数 × 任务类型 × 有无 prompt cache)`。40 页查一次 → Grep；40 页天天查的常备件 → 嵌（摊薄成本）。阈值做成**可配置**（`RAG_INGEST_MIN_TOKENS` 之类），先给保守默认，按实测调。
+
+---
+
+## 3. 数据模型
+
+沿用 Skills 已验证的 **DB-as-truth** 模式（DB 为真相，不做 FS 复制）。
+
+**复用已存在的**：`document`、`documentChunks(embedding vector(1536))`、`knowledgeBases`、`kbDocuments`、`sessionDocument`、`messageAttachment`。
+
+**需要新增/补列**：
+
+```
+documents            + ingest_status (pending|processing|ready|failed)
+                     + ingest_progress (0-100)
+                     + token_estimate           -- 用于分档路由
+                     + rag_tier (inline|grep|rag)-- 分流结果
+                     + summary (text)           -- 文档级摘要
+                     + toc (jsonb)              -- 章节树，给 agentic 路由
+                     + embed_model / embed_dim  -- 记录嵌入模型与维度（换模型要重嵌）
+                     + scope (personal|project) + project_id (nullable)  -- 🔄 访问基元（取代 user_id 隔离）
+                     -- userId 退化为上传者/署名(attribution)，不再是访问基元
+
+knowledge_bases      + scope (personal|project) + project_id (nullable)  -- 🔄 accessibleKbIds 据此解析
+
+document_chunks      + section_path (text)      -- 如 "§7.2 退款条款"，用于引用 + 上下文增强
+                     + page_start / page_end    -- 引用页码
+                     + parent_chunk_id          -- parent-child / small-to-big
+                     + content_hash             -- 块级去重 + 增量重嵌
+                     + context_prefix (text)    -- contextual retrieval 前缀
+                     -- embedding 已存在
+```
+
+**索引**：Postgres 开 `pgvector` 扩展，给 `document_chunks.embedding` 建 **HNSW**；Meili 维持 `documents`/新增 chunk 级 BM25 索引。**所有检索 SQL 必带 🔄 `WHERE kb_id IN accessibleKbIds(user)`**（统一解析器，取代 `WHERE user_id`；隔离仍进 SQL、不事后过滤；第 11 篇 + Projects PRD §4）。
+
+---
+
+## 4. 入库管线（离线，BullMQ）
+
+上传后挂一个 BullMQ job（不是只拷文件）。各 stage 幂等、按 `content_hash` 增量、可报进度。**只对 ③ 档文档跑。**
+
+```
+upload(S3 + document 行, status=pending)
+   │  ① 路由：token_estimate < 阈值 → rag_tier=grep/inline，结束（不嵌）
+   ▼  大文档 → rag_tier=rag，入队
+② parse        markitdown-mcp → 结构化 Markdown（保留标题层级 + 页码锚点；扫描件/表格走 OCR 兜底）
+③ chunk        结构感知切分：按标题层级 章→节→小块（不是定长窗口）；建 parent-child
+④ contextualize 给每块前置上下文（见 4.1）
+⑤ embed        批量调 ARK/Zhipu embeddings（非 SDK）→ 写 document_chunks.embedding
+⑥ index        pgvector HNSW + Meili BM25
+⑦ digest       生成 document.summary + toc
+   ▼
+status=ready（全程 ingest_progress 反馈 UI "处理中 60%"）
+```
+
+### 4.1 上下文增强（大文档的胜负手）
+
+裸块"费率为 4.5%"检索不出来。在 embedding **之前**给每块前置上下文，两档：
+
+- **免费档（默认）**：`context_prefix = doc标题 + section_path`，零 LLM 成本，已拿大半收益。
+- **进阶档（Contextual Retrieval）**：用便宜的 haiku 档（`doubao-seed-2.0-lite`，第 14 篇）给每块生成一句"这段在讲什么"。Anthropic 实测它 + 混合 + rerank 能把检索失败率大幅下降。**成本评估**：N 块 × 1 次廉价调用；若 ARK 网关支持 prompt cache 可大幅摊薄，否则先用免费档、对高价值文档才开进阶档。
+
+### 4.2 200 页 worked example
+
+200 页 PDF ≈ 10–15 万 token ≈ 300–600 块。它**几乎能塞进 200K 窗口**，但每轮灌 15 万 token = 烧光 ARK 额度 + lost-in-the-middle 更不准 + 第二个文档放不下 → **必须走 ③ 档**。
+- parse：200 页含表格/扫描页，**解析质量是天花板**（烂解析 → 烂块 → 检索全错）。
+- chunk：按章节切 + parent-child；每块带 `page/section_path`。
+- contextualize → embed（后台批量，几分钟，显示进度）→ pgvector + Meili。
+- digest：摘要 + ToC，供 Agent 先看"地图"再钻具体节。
+
+---
+
+## 5. 在线检索（`kb_search` MCP 工具）
+
+把整套检索封进 `createSdkMcpServer({ name:'kb_search', ... })`，注册进 `ws-query-worker.mjs`（与 python/glm-image/bash 并列；第 06 篇）。**Agent 自己决定何时调、查什么、取几条、要不要按 ToC 再钻一层**。
+
+```
+kb_search(query, k?, doc_id?/kb_id?) →
+  ① （可选）查询改写/拆解（haiku 档）
+  ② 混合召回（并行）：
+       pgvector 向量召回（语义）  ∥  Meili BM25（精确词/专名）
+       两路都带 WHERE kb_id IN accessibleKbIds(user)   ← 🔄 解析器隔离（个人 KB ∪ 可见 project KB）
+  ③ RRF 融合
+  ④ rerank 精排（ARK/Zhipu rerank 端点）
+  ⑤ small-to-big：小块命中 → 返回其 parent 小节（给够上下文）
+  ⑥ 返回 top-K（默认 ~8）+ 页码/小节引用
+```
+
+- **向量管"意思像"、BM25 管"词对得上"、rerank 管"真相关"、引用管"可信"**——四段各补一段。
+- **通读类任务不走这里**：检测到 holistic 意图（总结/全局对比）→ 走 map-reduce 摘要（基于 summary/ToC + 分节读），而非 top-K。
+
+---
+
+## 6. 横切关注点
+
+| 关注 | 做法 | 关联 |
+|------|------|------|
+| **访问隔离（🔄 scope）** | 统一解析器 `accessibleKbIds(user)`（个人 KB ∪ 可见 project KB）进 SQL `WHERE`，**绝不在各处散写 `WHERE user_id`**；`content_hash` 跨用户去重嵌入在**共享模型下恰是想要的**（一份嵌入多人可见），**前提是解析器铁实** | 第 11 篇 / D5 / Projects PRD §4 |
+| **上下文协同** | 检索结果是工具返回，按需进上下文；大结果卸载到 `message_attachment`、留引用指针，不塞满窗口 | D3 |
+| **检索内容护栏** | 检索回来的文档 = **间接提示注入面**；结构上分离"文档内容 / 指令"，低置信召回不当事实用 | D5 |
+| **评测** | 每个 KB 维护黄金集（Q→相关块/期望答）；分层指标（Recall@K/MRR/NDCG + faithfulness/带正确引用）；改切分/换嵌入/调 rerank 都用它证伪 | D4 |
+| **可观测** | `kb_search` 每次记 query/召回块/混合+rerank 前后排名/延迟 → 导成 span（复用 seq 流）；线上算 recall、调 K | D6 / 第 04 篇 |
+
+---
+
+## 7. 模型选型（必须先拍的决定）
+
+- **Embedding 维度**：schema 写死 **1536**（OpenAI 系维度）。ARK/Zhipu 的 embedding 维度未必是 1536 → **要么选一个 1536 维兼容模型，要么改列维度**。**入库前必须先定，且换模型 = 重嵌全库。**
+- **入口**：embedding/rerank **不走 SDK `query()`**（那是聊天，且钉死 0.2.112）；单开一个 OpenAI 兼容客户端打 ARK/Zhipu 的 `/embeddings`、`/rerank`，鉴权同 `ANTHROPIC_AUTH_TOKEN`/对应 key（第 14 篇坑一）。
+- **不引入第二套 Agent SDK**（北极星红线）；embedding 客户端是纯 HTTP，不是 Agent 运行时。
+
+---
+
+## 8. 落地：分阶段 PR 拆解
+
+| 阶段 | 内容 | Exit |
+|------|------|------|
+| **R0 · 地基** | pgvector 扩展 + HNSW 迁移；补 `documents`/`document_chunks` 列；**定 embedding 模型与维度**；嵌入/rerank HTTP 客户端 | 迁移就绪、能写入一条带 embedding 的 chunk、向量近邻查询能跑 |
+| **R1 · 分流 + 最小入库** | 上传时 `token_estimate` 分流（小→不嵌）；BullMQ job：parse→结构切分→embed→pgvector+Meili；进度反馈 | 一个大文档能 ingest 到 ready，小文档保持 Read/Grep 不变 |
+| **R2 · kb_search 工具** | `kb_search` MCP（混合召回 + RRF + rerank + small-to-big + 引用 + SQL 隔离），注册进 worker | Agent 能对已 ingest 文档检索、带页码引用、跨租户隔离有回归测试 |
+| **R3 · 进阶召回** | 上下文增强（免费档→LLM 档）+ parent-child + 文档 summary/ToC + holistic 路由（通读走摘要） | 200 页 case 端到端：捞针走检索、通读走摘要 |
+| **R4 · 护栏 + 评测 + 观测** | 检索内容注入护栏（D5）；黄金集 + 分层指标进 CI（D4）；kb_search→span（D6） | 改动可证伪、可回归、可观测 |
+
+依赖：R0→R1→R2 串行；R3/R4 可在 R2 后并行。**R4 的评测建议尽早起最小版**（哪怕几十条黄金集），否则 R3 的调参无法判断好坏。
+
+---
+
+## 9. 风险与未决
+
+- **解析是天花板**：扫描件/复杂表格不 OCR/不抽表 → 垃圾块 → 检索全错。R1 先验证解析质量。
+- **入库成本/时延在离线侧**：必须后台、批量、限速（ARK 速率限制）；`content_hash` 让小改只重嵌变化块。
+- **多租户去重 vs 隔离**：`content_hash` 共享嵌入省钱，但 `WHERE` 必须铁实，否则泄漏。
+- **引用全程透传**：页码/小节从解析一路带到返回，否则可信度归零。
+- **未决**：① embedding 模型 + 维度（阻塞 R0）；② ARK 网关是否支持 prompt cache（决定上下文增强成本）；③ 分档阈值默认值（需实测校准）；④ pgvector HNSW 在多文档×多用户下的索引规模/recall 调参。
+
+---
+
+## 10. 一句话收口
+
+**OxyGenie 的 Advanced RAG = 只在"大文档/大语料 + 捞针"这一格触发的逃生通道：上传时按大小分流（小的不嵌）、离线把解析+结构切分+上下文增强做扎实、在线把 `kb_search` 和 `Read`/`Grep` 一起摊给 Agent 由 Loop 决定——目标是让 Agent 永远只看到 8 段带引用的精排结果，而不是那 200 页。** 基建几乎都在，工作量主要是把零件接起来 + 先拍 embedding 选型。

--- a/docs/project/research/2026-06-file-upload-foundation-design.md
+++ b/docs/project/research/2026-06-file-upload-foundation-design.md
@@ -3,6 +3,8 @@
 > 状态：**设计稿 + 实施计划** · 2026-06-07 · 与 [Advanced RAG 方案](./2026-06-advanced-rag-design.md) **分离**。
 > 关系：本文是 RAG 的**前置地基（R0.5）**——RAG 是"大文档捞针"的逃生通道，但今天连"单个文件被 Agent 读到"都没闭环。本文只做到"文件可靠地、以文本形式、被 Agent 用上"，**不做 chunk/embed/检索**（那是 RAG 文档）。
 > 北极星对照：自托管 / 单组织 / 多用户（半可信同事）/ ARK + SDK 0.2.112 / 可部署性优先。
+>
+> **🔄 更新（2026-06-08，Projects PRD）**：`document.userId` 退化为"上传者/署名"，**不再是访问基元**；访问一律走 **`scope(personal|project)` + 统一解析器**；F5"提升到 KB"改为"提升到 **project / personal KB**（改 scope + 关联，不复制、零重嵌）"。详见 [Projects PRD](../prd/2026-06-projects-collaboration-prd.md) + [Projects P1 ⊕ RAG R0 合并方案](./2026-06-projects-p1-rag-r0-data-model.md)。
 
 ## 0. 目标 / 非目标
 
@@ -41,13 +43,13 @@
 - **解析**：用**已装的 markitdown** 当 loader，pdf/docx/xlsx/pptx → markdown 文本；txt/md/csv/json/代码直接用。
 - **分档（对齐三档）**：
   - **聊天上传** = 解析 → **把解析文本物化进本会话 workspace**（Agent `Read`/`Grep` 直接读）+ 小文件可 inline 摘要；**不 embed**。
-  - **提升到文档库/KB** = 给**同一个 `document`** 建 `kb_document` 关联；**这时才**异步 chunk+embed（交给 RAG R1+）。
+  - **提升到文档库/KB** = 给**同一个 `document`** 改 `scope=project`（或 personal）+ 建 `kb_document` 关联（🔄 关联不复制、零重嵌）；**这时才**异步 chunk+embed（交给 RAG R1+）。
 - **oxygenie 专属适配**：references 是 chat-completion 只能 inline；**oxygenie 是带 Read/Grep 的文件系统 Agent**，所以"物化解析文本到 workspace"比 inline 更稳、还能 Grep——这是本地化的关键差异。
 
 ## 4. 安全 / 效率
 
 - **解析在不可信输入上运行**：markitdown 跑用户文件，**经沙箱/受控子进程**执行（复用 ExecutionRuntime/python 沙箱思路，第 05/10 篇），限时限内存；解析失败优雅降级（存错误元数据，不崩）。
-- **隔离**：文件路径含 `userId/sessionId`；`validateRelativePath` 已在用；提升到 KB 的关联查询带 `userId` 过滤（第 11 篇）。
+- **隔离**：workspace 文件路径含 `userId/sessionId`（per-session 文件系统层，不变）；**DB 层访问 🔄 走 `scope(personal|project)` 统一解析器**（`accessibleKbIds`/`canSeeSession`，取代 `userId` 过滤；Projects PRD §4）；`validateRelativePath` 已在用。
 - **去重（可选，后置）**：LobeChat 式 hash 去重（`globalFiles`）省存储，但**前提是访问过滤铁实**；地基阶段可先不做，先把单文件闭环。
 - **大小/类型闸**：上传大小上限 + 类型白名单；超大文件走 RAG 分档（本文不处理，标记 `rag_tier`）。
 
@@ -62,7 +64,7 @@
 | **F2** | **解析落盘**：上传富文本时，markitdown → 把 `<name>.md` 物化进 workspace（原文件保留）；解析文本写 `document.content` | 上传 pdf，workspace 出现可读 `.md`，Agent `Read` 到文本 | 后端 upload 路由，contained |
 | **F3** | **把文件路径可靠递给 Agent**：composer 附件 + 文档页两条路径都注入"附件信息（用 Read 读）" | 文档页加的文件，Agent 也知道在哪 | prompt 注入，低 |
 | **F4** | **文件实体规范化**（可选）：原始字节进 MinIO 为规范家、workspace 为投影；hash 去重 | 重复上传不重复存 | 较大，可后置 |
-| **F5** | **会话文件→文档库"提升"**：一键给 `document` 建 `kb_document` 关联（**不复制**），为 RAG 接力 | 会话文件出现在 `agents/documents`，仍是同一实体 | 中，接 RAG 边界 |
+| **F5** | **会话文件→文档库"提升"**：一键给 `document` 改 `scope=project/personal` + 建 `kb_document` 关联（🔄 不复制、零重嵌），为 RAG 接力 | 会话文件出现在 project/个人文档库，仍是同一实体 | 中，接 RAG + Projects 边界 |
 
 **与 RAG 边界**：本文止于 F5 的"关联提升"；F5 之后的 chunk/embed/检索 = RAG 方案 R1+。
 

--- a/docs/project/research/2026-06-projects-p1-rag-r0-data-model.md
+++ b/docs/project/research/2026-06-projects-p1-rag-r0-data-model.md
@@ -1,0 +1,85 @@
+# Projects P1 ⊕ RAG R0 —— 合并数据模型 · 访问解析器 · 迁移 · 排期
+
+> 日期：2026-06-08 ｜ 状态：草案待评审
+> 关联（本文是这三者的**公共地基**，必须一次对齐，避免返工）：
+> - [Projects 协作 PRD](../prd/2026-06-projects-collaboration-prd.md)（决策来源：Model A + `scope` + 单一解析器）
+> - [Advanced RAG 方案](./2026-06-advanced-rag-design.md)（R0 数据模型 / `kb_search` 检索）
+> - [文件上传地基](./2026-06-file-upload-foundation-design.md)（`document` 实体 / 提升到 KB）
+
+## 0. 为什么合并
+
+三件事——**Projects 共享 / RAG 检索 / 文件上传提升**——都要回答同一个问题：**"谁能看哪份文档/会话/KB？"** PRD 已拍板把答案从 `user_id` 隔离换成 **`scope(personal|project)` + 单一访问解析器**。
+
+**关键时序**：scope 列若不在 RAG R0 的**同一次迁移**里落，等 RAG 按 `user_id` 建好、再加 Project 时**必返工**（PRD §6/§7）。所以本文把 **Projects P1 地基** 和 **RAG R0 数据模型** 合成**一次迁移 + 一个解析器**。
+
+> **已发的不受影响**：刚上线的文件上传修复（F2/F3/Read 护栏/F4）全在 **per-session workspace（文件系统）**层，不碰 scope 治理的 DB 访问层。scope 在我们建文档实体 + RAG 时采纳即可。
+
+## 1. 统一数据模型（一次迁移）
+
+```
+-- Projects 地基（PRD §3）
+project            id, org_id?, owner_user_id, name, description, instructions, created_at
+project_member     project_id, user_id, role(owner|member), PK(project_id, user_id)
+
+-- scope 化既有资源（访问基元从 user_id → scope）
+agent_session    + project_id (nullable; null = personal)
+                 + branched_from_session_id (nullable) + created_by_user_id   -- 续聊即分支（PRD §5 场景1）
+knowledge_bases  + scope(personal|project) + project_id (nullable)
+documents        + scope(personal|project) + project_id (nullable)            -- userId 退化为上传者/署名
+                 + (RAG R0 列：ingest_status/progress/token_estimate/rag_tier/summary/toc/embed_model/embed_dim)
+
+-- RAG R0 检索基础（与 scope 无关，零重嵌）
+document_chunks  + section_path/page_start/page_end/parent_chunk_id/content_hash/context_prefix
+                 -- embedding 已存在；★ chunks/embedding 不加 scope 列 ★
+pgvector 扩展 + document_chunks.embedding 上的 HNSW 索引
+```
+
+**铁律**：`chunks/embedding/HNSW/Meili` **不带 scope**——它们是**文档级**，访问在 `KB/文档` 这层解析。这保住 **零重嵌**：加 Project 只改"谁能访问"，不重算向量；`content_hash` 跨用户去重在共享模型下**恰是想要的**（一份嵌入多人可见）。
+
+## 2. 单一访问解析器（唯一入口）
+
+**严禁在各处散写 `WHERE user_id`。** 所有"谁能看什么"收敛到一处（PRD §4）：
+
+```
+accessibleProjectIds(user) = project_member 里该 user 的 project 集
+canSeeSession(user, s)     = s.project_id == null ? s.user_id == user
+                                                  : s.project_id ∈ accessibleProjectIds(user)
+accessibleKbIds(user)      = (个人KB: scope=personal AND owner=user)
+                           ∪ (项目KB: scope=project AND project_id ∈ accessibleProjectIds(user))
+```
+
+落点：
+- **RAG 检索**（`kb_search`）：`WHERE kb_id IN accessibleKbIds(user)`（隔离进 SQL，不事后过滤）。
+- **会话/文档列表**：`canSeeSession` / `accessibleKbIds`。
+- **owner-only**：邀请/移除成员、删 project。
+- **隔离（ChatGPT 式）**：project 会话只引用同 project 的会话/文档；个人与 project 互不串。
+
+## 3. 迁移（无损、向后兼容）
+
+- 现有 `userId`-scoped 的 `agent_session`/`documents`/`knowledge_bases` → 一律迁为 **`scope=personal`**（owner = 原 `userId`）。不进任何 project = 个人私有，**行为同今天**（PRD §8）。
+- `document.userId` 列保留，但语义改为**上传者/署名**（attribution），不再参与访问判定。
+- 用户事后自行把会话/文档"提升"进 project（改 `scope` + 关联，零重嵌）。
+
+## 4. 排期（依赖关系）
+
+| 阶段 | 内容 | 与原计划的对应 |
+|------|------|----------------|
+| **P1+R0（合做，keystone）** | `project` + `project_member` + scope 列；pgvector + HNSW；**`accessibleProjectIds/KbIds`、`canSeeSession` 解析器**；embedding/rerank 选型 + HTTP 客户端；列表按解析器 | Projects P1（PRD §7）⊕ RAG R0（rag §8） |
+| **P2（= RAG R1/R2）** | 入库管线（parse→切分→embed）+ `kb_search` MCP（混合+rerank+引用）**按 `accessibleKbIds` 检索**；文件上传 F5"提升到 project/personal KB" | RAG R1+R2 ⊕ Projects 场景3 |
+| **P3** | 续聊即分支（branch 会话 + 署名 + 隔离上下文） | Projects 场景1 |
+| **暂缓** | 实时同对话(1b)、Model B（逐组/逐文档授权/is_public）、跨组织、角色细化 | PRD 非目标 |
+
+**依赖**：P1+R0 是地基；P2 与之共用同一次数据模型迁移；P3 在 P1 后可并行。
+
+## 5. 最大风险 + 纪律
+
+- **最大工程量 = 把全站 `user_id` 查询改成解析器**（PRD §9）——面广，**漏一处 = 越权可见**。纪律：
+  1. **先建解析器**（`accessibleProjectIds/KbIds`、`canSeeSession`）为唯一入口；
+  2. **集中改写**所有列表/检索调用点（grep `WHERE.*user_id` / `eq(*.userId, ...)`）；
+  3. **每个列表/检索一条"非成员看不到"回归用例**（呼应 RAG D4 + 第 11 篇跨租户回归）。
+- **共享会话写权限**：member 可**分支**（场景1）；删除/重命名限 owner 或发起人（PRD §9 未决）。
+- **org ↔ project**：better-auth `organization`/`member` 当外层实例边界，`project_member` 当内层；P1 厘清 `member of org ⊇ member of project`。
+
+## 6. 一句话收口
+
+**scope 是 Projects / RAG / 上传 的公共地基——一次迁移落 `scope + project_id` + 一个访问解析器，取代全站 `user_id` 隔离；chunks/embedding 不带 scope 以保零重嵌。P1 地基 + RAG R0 合做，避免 RAG 按 user_id 建好后返工。**


### PR DESCRIPTION
Follows the Projects PRD (#145): the access primitive moves from `user_id` isolation → **`scope(personal|project)` + a single access resolver**. This keeps the RAG and file-upload designs from being built on `user_id` and then needing rework when Projects lands.

**Changes**
- `advanced-rag-design.md`: all retrieval `WHERE user_id=?` → `WHERE kb_id IN accessibleKbIds(user)`; add `scope + project_id` to `documents`/`knowledge_bases`; **chunks/embedding stay scope-free (zero re-embed)**. (Also lands this design doc — it was previously untracked.)
- `file-upload-foundation-design.md`: `document.userId` → uploader/attribution (not an access primitive); F5 "promote to KB" → "promote to **project/personal KB** (re-scope + associate, no copy)".
- **NEW** `projects-p1-rag-r0-data-model.md`: the keystone — unified schema (`project`/`project_member` + scope columns), the single resolver (`accessibleProjectIds`/`accessibleKbIds`/`canSeeSession`), lossless `userId → scope=personal` migration, and sequencing (**Projects P1 ⊕ RAG R0 in one migration**).

**Why now:** scope must land in the RAG R0 migration, or building RAG on `user_id` forces a rework when Projects ships. Already-shipped file-upload fixes (#143) are unaffected (per-session workspace = filesystem, not the scope-governed DB layer).

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)