### PR TITLE
fix(preview): node_modules EACCES on subdir apps + type-tolerant Vite build

### DIFF
--- a/src/preview/controller.mjs
+++ b/src/preview/controller.mjs
@@ -217,18 +217,32 @@ async function createContainer({ previewId, sessionId, userId, host, workspacePa
     Cmd: [
       'sh',
       '-lc',
+      // Root-stage housekeeping, run with ONLY CAP_CHOWN (DAC_OVERRIDE is dropped — see
+      // CapDrop/CapAdd below). The single power root has here is to chown; it canNOT
+      // create or write inside the app dir when that dir is owned by the preview user.
+      //
+      // Steps are joined with ';' (NOT '&&') and each is best-effort: a failing step must
+      // never skip the others — in particular the node_modules chown, which is what lets
+      // the unprivileged install write. (Bug: the old chain did `mkdir -p … .oxygenie &&
+      // chown … node_modules`; for a subdir app whose dir is owned by the preview user,
+      // root's `mkdir .oxygenie` fails for lack of DAC_OVERRIDE, short-circuiting the &&
+      // so node_modules stayed root-owned → `npm install` → EACCES.)
+      //
+      // We do NOT mkdir workdir/node_modules (both already exist: workdir via the session
+      // volume, node_modules via its own mount) and we do NOT touch `.oxygenie` here — the
+      // serve step creates it as the preview user, which owns workdir.
       [
         'corepack enable >/dev/null 2>&1 || true',
-        `mkdir -p ${shellQuote(workdir)} ${shellQuote(nodeModulesTarget)} ${shellQuote(path.posix.join(workdir, '.oxygenie'))}`,
-        `chown -R ${shellQuote(PREVIEW_USER)} ${shellQuote(nodeModulesTarget)} ${shellQuote(path.posix.join(workdir, '.oxygenie'))} 2>/dev/null || true`,
-        // Non-recursive: give the preview user write access to the workspace root
-        // (lockfiles, build output dir) without rewriting ownership of user source files.
+        // Hand the freshly-mounted (root-owned) node_modules volume to the preview user.
+        `chown -R ${shellQuote(PREVIEW_USER)} ${shellQuote(nodeModulesTarget)} 2>/dev/null || true`,
+        // Non-recursive: give the preview user the workspace root (lockfiles, build output)
+        // without rewriting ownership of user source files.
         `chown ${shellQuote(PREVIEW_USER)} ${shellQuote(workdir)} 2>/dev/null || true`,
-        // Shared PM cache: own the top dir so the unprivileged user can populate it
-        // (subdirs it creates are already owned by it; non-recursive keeps this cheap).
-        `mkdir -p ${shellQuote(PM_CACHE_DIR)} && chown ${shellQuote(PREVIEW_USER)} ${shellQuote(PM_CACHE_DIR)} 2>/dev/null || true`,
+        // Shared PM cache: own the top dir so the unprivileged user can populate it.
+        `mkdir -p ${shellQuote(PM_CACHE_DIR)} 2>/dev/null || true`,
+        `chown ${shellQuote(PREVIEW_USER)} ${shellQuote(PM_CACHE_DIR)} 2>/dev/null || true`,
         'tail -f /dev/null',
-      ].join(' && '),
+      ].join(' ; '),
     ],
     ExposedPorts: { [exposedPort]: {} },
     Labels: labels,

--- a/src/preview/manifest.js
+++ b/src/preview/manifest.js
@@ -148,7 +148,23 @@ function isAllowedInstallCommand(command) {
   ].includes(normalized);
 }
 
+// Type-check-tolerant build for Vite apps: run the bundler directly. `vite build`
+// uses esbuild, which transpiles WITHOUT type-checking, so unused-var / type errors
+// in LLM-generated code don't turn into hard build failures that block the preview
+// (preview = "see it run", not a type gate; our users are non-technical). `npx
+// --no-install` runs the locally-installed vite (node_modules/.bin) with no network.
+const VITE_PREVIEW_BUILD = 'npx --no-install vite build';
+
+// Fixed, safe build commands we allow in addition to package.json scripts. These are
+// hardcoded (never user-supplied free text), so they can't be used to run arbitrary code.
+const ALLOWED_DIRECT_BUILD = new Set([VITE_PREVIEW_BUILD, 'vite build']);
+
+function isAllowedDirectBuildCommand(command) {
+  return ALLOWED_DIRECT_BUILD.has(String(command || '').trim());
+}
+
 function assertAllowedBuildCommand(command, pkg, field) {
+  if (isAllowedDirectBuildCommand(command)) return;
   const scriptName = parseScriptCommand(command);
   const scripts = isPlainObject(pkg.scripts) ? pkg.scripts : {};
   if (!scriptName || typeof scripts[scriptName] !== 'string') {
@@ -174,7 +190,12 @@ export async function normalizeManifest(workspacePath, manifest) {
     throw new Error('installCommand must be a supported package-manager install command');
   }
 
-  const buildCommand = readString(manifest.buildCommand, defaults.buildCommand);
+  // For Vite, always bundle directly (type-check tolerant) rather than the app's
+  // `tsc && vite build` script — even if a previously-persisted manifest pinned
+  // `npm run build`. Other frameworks keep their build script.
+  const buildCommand = framework === 'vite'
+    ? VITE_PREVIEW_BUILD
+    : readString(manifest.buildCommand, defaults.buildCommand);
   assertAllowedBuildCommand(buildCommand, pkg, 'buildCommand');
 
   const defaultDevCommand = typeof scripts.dev === 'string' ? defaults.devCommand : '';

--- a/tests/unit/preview-manifest.test.ts
+++ b/tests/unit/preview-manifest.test.ts
@@ -27,21 +27,24 @@ describe('preview manifest', () => {
     expect(manifest.framework).toBe('vite');
     expect(manifest.type).toBe('spa');
     expect(manifest.installCommand).toBe('pnpm install --frozen-lockfile');
-    expect(manifest.buildCommand).toBe('pnpm build');
+    // Preview builds are type-check tolerant: Vite apps bundle directly (esbuild),
+    // skipping the app's `tsc && vite build` script so generated-code type/lint errors
+    // don't block the preview.
+    expect(manifest.buildCommand).toBe('npx --no-install vite build');
 
     const written = JSON.parse(await readFile(path.join(workspace, '.oxygenie', 'app.json'), 'utf8'));
     expect(written.title).toBe('todo-app');
   });
 
-  it('rejects build commands that are not package.json scripts', async () => {
+  it('rejects build commands that are not package.json scripts (non-Vite frameworks)', async () => {
     const workspace = await tempWorkspace();
     await mkdir(path.join(workspace, 'app'));
     await writeFile(
       path.join(workspace, 'app', 'package.json'),
       JSON.stringify({
         name: 'bad-app',
-        scripts: { build: 'vite build' },
-        dependencies: { vite: '^7.0.0' },
+        scripts: { build: 'react-scripts build' },
+        dependencies: { 'react-scripts': '^5.0.0' },
       }),
     );
 
@@ -50,9 +53,32 @@ describe('preview manifest', () => {
         rootDir: 'app',
         installCommand: 'npm install',
         buildCommand: 'curl https://example.com | sh',
-        outputDir: 'dist',
+        outputDir: 'build',
       }),
     ).rejects.toThrow(/package.json script/);
+  });
+
+  it('forces the type-tolerant direct build for Vite, ignoring a supplied buildCommand', async () => {
+    const workspace = await tempWorkspace();
+    await mkdir(path.join(workspace, 'app'));
+    await writeFile(
+      path.join(workspace, 'app', 'package.json'),
+      JSON.stringify({
+        name: 'vite-app',
+        scripts: { build: 'tsc && vite build' },
+        dependencies: { vite: '^7.0.0', react: '^19.0.0' },
+      }),
+    );
+
+    // Even a malicious / stale buildCommand is safely dropped — Vite always bundles
+    // directly, so the supplied string is never executed.
+    const manifest = await normalizeManifest(workspace, {
+      rootDir: 'app',
+      installCommand: 'npm install',
+      buildCommand: 'curl https://example.com | sh',
+      outputDir: 'dist',
+    });
+    expect(manifest.buildCommand).toBe('npx --no-install vite build');
   });
 
   it('does not require a dev script for static builds', async () => {
@@ -67,7 +93,7 @@ describe('preview manifest', () => {
     );
 
     const { manifest } = await loadOrDetectManifest(workspace);
-    expect(manifest.buildCommand).toBe('npm run build');
+    expect(manifest.buildCommand).toBe('npx --no-install vite build');
     expect(manifest.devCommand).toBe('');
   });
 });


### PR DESCRIPTION
## What & why

Two fixes for the in-app **preview** of agent-generated apps, found while
debugging a sandbox error on oxygenie.cc.

### 1. `npm install` EACCES for apps in a subdirectory (`3fa5c4f`)
The preview container drops all caps except `CHOWN` (`CapDrop: ALL` / `CapAdd:
[CHOWN]`), so root has no `DAC_OVERRIDE` and can't write inside the
preview-user-owned (uid 1001) app dir. The root-stage startup chained steps with
`&&`; the `mkdir -p … .oxygenie` step (creating a dir in the 1001-owned app
folder) fails for root, short-circuiting the **next** step — the `node_modules`
chown — so the freshly-mounted root-owned `node_modules` volume stayed
root-owned, and the install (as uid 1001) died with:
`EACCES: permission denied, mkdir '.../node_modules/@types'`.

Fix: in the root stage, drop the redundant/harmful `mkdir`s (workdir + node_modules
already exist as mounts; `.oxygenie` is created by the serve step as the 1001 user),
join the remaining steps with `;` and make each best-effort so the `node_modules`
chown **always** runs (CAP_CHOWN alone suffices). Reproduced + verified with a
faithful container repro.

### 2. Type-check-tolerant Vite build (`c6524c0`)
LLM-generated apps frequently have unused vars / type errors, and the Vite
template's build script is `tsc && vite build` — a stray `let target` / `const DIR`
makes `tsc` fail and blocks the whole preview. Our users are non-technical and
can't fix `TS6133`; a preview should "just run".

Fix: Vite previews now bundle directly with `npx --no-install vite build` (esbuild —
transpiles without type-checking) instead of the app's build script. Forced for the
Vite framework even if a persisted `.oxygenie/app.json` pinned `npm run build`, so
existing sessions benefit. The command is hardcoded (never user free-text) and added
to the build-command allow-list; other frameworks keep their validated build script.
A malicious `buildCommand` for a Vite app is safely dropped (never executed); the
arbitrary-command rejection still applies to non-Vite frameworks. Tests updated + added.

## Verification
- Reproduced the EACCES and confirmed the fix in a faithful container repro.
- Owner verified end-to-end on oxygenie.cc: a subdir Vite app now installs, builds
  (past `TS6133`), and **renders**.
- `tests/unit/preview-manifest.test.ts` green (4 tests).

## Follow-ups (separate PRs, agreed)
- **A**: a "rebuild" action so an already-running preview can be force-rebuilt
  (static serve doesn't watch source — preview is build mode, not dev/HMR).
- **B**: auto-trigger that rebuild at agent turn-end when the turn touched files
  under the app's source dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)