### PR TITLE
feat(preview): force-rebuild action for a running preview (PR A)

### DIFF
--- a/src/claude/adapters/ws-adapter.ts
+++ b/src/claude/adapters/ws-adapter.ts
@@ -112,7 +112,7 @@ type InboundMessage =
   | { type: 'chat'; content: string; sessionId?: string; skillSlug?: string; permissionTier?: string; model?: string }
   | { type: 'resume'; sessionId: string }
   | { type: 'abort' }
-  | { type: 'start_preview'; sessionId?: string; mode?: 'static' | 'live' }
+  | { type: 'start_preview'; sessionId?: string; mode?: 'static' | 'live'; force?: boolean }
   | { type: 'stop_preview'; sessionId?: string }
   | { type: 'share_preview'; previewId: string; sessionId?: string }
   | { type: 'approval_response'; toolUseID: string; decision: 'allow' | 'deny' }
@@ -612,8 +612,17 @@ async function send(message: InboundMessage): Promise<void> {
 export async function startPreview(
   sessionId?: string,
   mode: 'static' | 'live' = 'static',
+  opts?: { force?: boolean },
 ): Promise<void> {
-  await send({ type: 'start_preview', sessionId: sessionId ?? currentSessionId, mode });
+  // `force: true` rebuilds an already-running preview in place (re-install + re-build
+  // + restart serve) instead of reusing the cached "ready" instance — preview is build
+  // mode (static serve, no HMR), so code edits only show after a rebuild.
+  await send({
+    type: 'start_preview',
+    sessionId: sessionId ?? currentSessionId,
+    mode,
+    ...(opts?.force ? { force: true } : {}),
+  });
 }
 
 export async function stopPreview(sessionId?: string): Promise<void> {

--- a/src/components/claude-chat/artifact-html.tsx
+++ b/src/components/claude-chat/artifact-html.tsx
@@ -86,9 +86,12 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
   const failed = status === 'error'
   const liveUrl = status === 'ready' ? preview?.url : undefined
 
-  const runPreview = () => {
+  // `force` rebuilds an already-running preview (re-install + re-build + restart serve).
+  // Preview is build mode (static serve, no HMR), so edits only show after a rebuild —
+  // a plain start would reuse the cached "ready" instance and show stale output.
+  const runPreview = (force = false) => {
     setStarting(true)
-    void startPreview().catch(() => setStarting(false))
+    void startPreview(undefined, 'static', { force }).catch(() => setStarting(false))
   }
 
   // Bare, token-free origin of the running preview — the link safe to share.
@@ -139,12 +142,12 @@ export const HTMLArtifact: FC<HTMLArtifactProps> = ({ content, title, iframeRef 
             </span>
             <button
               type="button"
-              onClick={runPreview}
+              onClick={() => runPreview(Boolean(liveUrl))}
               disabled={busy}
               className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-300 bg-amber-100 px-2 py-1 font-medium text-amber-900 transition hover:bg-amber-200 disabled:opacity-60 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60"
             >
               {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-              {busy ? '运行中…' : liveUrl ? '重新运行' : '运行预览'}
+              {busy ? '运行中…' : liveUrl ? '重新构建' : '运行预览'}
             </button>
             {liveUrl && (
               <button

--- a/src/preview/runtime.js
+++ b/src/preview/runtime.js
@@ -194,7 +194,7 @@ export class PreviewRuntime {
     return stopped;
   }
 
-  async startStaticPreview({ userId, sessionId, workspacePath, sendState }) {
+  async startStaticPreview({ userId, sessionId, workspacePath, force = false, sendState }) {
     if (!userId || !sessionId || !workspacePath) {
       throw new Error('Missing preview start context');
     }
@@ -202,13 +202,13 @@ export class PreviewRuntime {
       return this.inFlight.get(sessionId);
     }
 
-    const task = this.#startStaticPreview({ userId, sessionId, workspacePath, sendState })
+    const task = this.#startStaticPreview({ userId, sessionId, workspacePath, force, sendState })
       .finally(() => this.inFlight.delete(sessionId));
     this.inFlight.set(sessionId, task);
     return task;
   }
 
-  async #startStaticPreview({ userId, sessionId, workspacePath, sendState }) {
+  async #startStaticPreview({ userId, sessionId, workspacePath, force = false, sendState }) {
     const status = (state) => {
       sendState?.(state);
       return state;
@@ -243,7 +243,17 @@ export class PreviewRuntime {
         });
       }
 
-      if (this.active.has(previewId)) {
+      // Force rebuild: the preview is build mode (static serve of `dist`, no HMR), so
+      // code edits only become visible after a fresh build. Tear the running preview
+      // down first — this releases its semaphore slot and removes the container but
+      // KEEPS the persisted per-preview node_modules volume (controller stop uses
+      // v=false) — then fall through to the normal install→build→serve below (install
+      // is fast against the warm cache + existing node_modules).
+      if (force && this.active.has(previewId)) {
+        await this.stopPreview(previewId).catch(() => {});
+      }
+
+      if (!force && this.active.has(previewId)) {
         const existing = this.active.get(previewId);
         existing.lastAccessAt = Date.now();
         if (existing.status !== 'ready') {

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -951,6 +951,7 @@ async function handleStartPreview(ws, message) {
       userId: ws.userId,
       sessionId,
       workspacePath,
+      force: message.force === true,
       sendState: (state) => sendPreviewState(ws, state),
     });
   } catch (error) {


### PR DESCRIPTION
## What & why
Preview is **build mode** (static serve of `dist`, no HMR/file-watch), and a running
preview is keyed by a stable `previewId` — so clicking "run" again returns the cached
"ready" instance and shows **stale** output after code edits.

This adds a `force` flag end-to-end so an already-running preview can be rebuilt.

## How
- `force` threads: client `startPreview(…, { force })` → `start_preview` WS message →
  `ws-server` → `runtime.startStaticPreview`.
- When `force`, the runtime **stops then starts**: `stopPreview` releases the semaphore
  slot and removes the container but **keeps the persisted per-preview node_modules
  volume** (controller stop uses `v=false`), then the normal `install→build→serve` runs.
  Install is fast against the warm package cache + existing node_modules. Leak-free
  (stop releases, start re-acquires the slot).
- The existing preview button now reads **"重新构建"** when a preview is running and
  triggers the force rebuild.

This is the shared primitive PR B (auto-rebuild on turn end) calls.

## Notes
- Roadmap alternative (not here): dev-mode/HMR preview — bigger (long-lived dev server +
  WS HMR through the tunnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)