### PR TITLE
feat(rag): R1 — ingest pipeline (tier routing, chunker, dedicated rag queue)

### DIFF
--- a/scripts/rag-r1-smoke.ts
+++ b/scripts/rag-r1-smoke.ts
@@ -1,0 +1,106 @@
+/**
+ * RAG R1 smoke — the WHOLE ingest pipeline against a real DB + real Zhipu (final spec R1
+ * Exit: "一个大文档能 ingest 到 ready 并可被向量近邻查到；小文档不入队").
+ *
+ *   DATABASE_URL=... ZHIPU_API_KEY=... npx tsx scripts/rag-r1-smoke.ts
+ *
+ * Builds a synthetic 'rag'-tier markdown (≥ threshold), runs ingestDocument() inline,
+ * asserts: status=ready, parents+children with parentChunkId linkage, toc written,
+ * cosine ANN finds the right section, and a small doc routes to 'inline' (no chunks).
+ * Cleans up everything it created.
+ */
+import { eq, cosineDistance, isNotNull, and } from 'drizzle-orm';
+import { db } from '~/db/db-config';
+import { files } from '~/db/schema/file.schema';
+import { documents, documentChunks } from '~/db/schema/document.schema';
+import { embedTexts } from '~/server/rag/zhipu';
+import { ingestDocument } from '~/server/rag/ingest';
+import { estimateTokens, routeTier } from '~/server/rag/tier';
+
+function syntheticDoc(): string {
+  const filler = (topic: string, n: number) =>
+    Array.from({ length: n }, (_, i) => `${topic}相关的说明第${i}条：这里是用于撑大文档体积的常规业务描述内容，与检索目标无关。`).join('\n\n');
+  return [
+    '# 第一章 总则',
+    filler('总则', 140),
+    '# 第二章 费用与退款',
+    '本合同约定的退款费率为百分之四点五，自签约日起七日内可无理由退款。',
+    filler('费用', 140),
+    '# 第三章 保修条款',
+    '本产品提供自购买之日起整整两年的免费保修服务，覆盖所有非人为损坏。',
+    filler('保修', 140),
+    '# 第四章 交付',
+    filler('交付', 140),
+  ].join('\n\n');
+}
+
+async function main() {
+  const md = syntheticDoc();
+  const tokens = estimateTokens(md);
+  const tier = routeTier(tokens);
+  console.log(`[smoke] synthetic doc ≈${tokens} tokens → tier=${tier}`);
+  if (tier !== 'rag') throw new Error(`expected rag tier, got ${tier} — enlarge the synthetic doc`);
+  if (routeTier(estimateTokens('小文档内容')) !== 'inline') throw new Error('small doc must route inline');
+
+  const [file] = await db
+    .insert(files)
+    .values({ key: `rag-smoke-r1/${Date.now()}`, clientId: 'rag-smoke', fileType: 'text/markdown', name: 'r1.md', size: 0, url: '' })
+    .returning();
+  const [doc] = await db
+    .insert(documents)
+    .values({
+      title: 'R1 冒烟大文档',
+      content: md,
+      sourceType: 'rag-smoke',
+      userId: 'rag-smoke-user',
+      fileId: file.id,
+      tokenEstimate: tokens,
+      ragTier: tier,
+      ingestStatus: 'pending',
+    })
+    .returning();
+
+  try {
+    const result = await ingestDocument(doc.id);
+    console.log('[smoke] ingest result:', JSON.stringify(result));
+    if (result.status !== 'ready') throw new Error(`ingest status ${result.status}: ${result.reason}`);
+
+    const [after] = await db.select().from(documents).where(eq(documents.id, doc.id));
+    if (after.ingestStatus !== 'ready' || after.ingestProgress !== 100) throw new Error('doc not marked ready/100');
+    if (!Array.isArray(after.toc) || (after.toc as unknown[]).length < 4) throw new Error('toc missing');
+
+    const children = await db
+      .select({ id: documentChunks.id })
+      .from(documentChunks)
+      .where(and(eq(documentChunks.documentId, doc.id), isNotNull(documentChunks.parentChunkId)));
+    if (children.length === 0) throw new Error('no child chunks with parent linkage');
+
+    const [qv] = await embedTexts(['保修期是多久？']);
+    const distance = cosineDistance(documentChunks.embedding, qv);
+    const hits = await db
+      .select({ section: documentChunks.sectionPath, distance })
+      .from(documentChunks)
+      .where(eq(documentChunks.documentId, doc.id))
+      .orderBy(distance)
+      .limit(3);
+    console.log('[smoke] ANN top sections:', hits.map((h) => h.section).join(' | '));
+    if (!hits[0]?.section?.includes('保修')) throw new Error(`top hit should be 保修 section, got ${hits[0]?.section}`);
+
+    // Idempotency: a second run with unchanged content must hash-skip (no re-embed).
+    const second = await ingestDocument(doc.id);
+    console.log('[smoke] second run:', JSON.stringify(second));
+    if (second.status !== 'skipped') throw new Error(`second run should be skipped, got ${second.status}`);
+
+    console.log('✅ R1 smoke PASS — tier routing, full ingest, ANN retrieval, hash-skip all verified');
+  } finally {
+    await db.delete(documents).where(eq(documents.id, doc.id));
+    await db.delete(files).where(eq(files.id, file.id));
+    console.log('[smoke] cleaned up temp rows');
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('❌ R1 smoke FAIL:', err);
+  process.exit(1);
+});

--- a/src/db/repositories/document.repo.ts
+++ b/src/db/repositories/document.repo.ts
@@ -5,4 +5,20 @@ import { documentChunks, documents } from "../schema";
 export const documentRepo = Repository(db, documents);
 export const documentChunkRepo = Repository(db, documentChunks);
 
+/**
+ * Hook for the worker's `reindex-all` job (src/worker/processors/reindexDocuments.ts
+ * dynamically imports this module and looks for exactly this export). Until RAG R1
+ * added it, the job soft-no-op'd with "No repository hook found" (audit errata, D8).
+ */
+export async function getAllDocumentsForSearch() {
+  return db
+    .select({
+      id: documents.id,
+      title: documents.title,
+      content: documents.content,
+      fileName: documents.filename,
+    })
+    .from(documents);
+}
+
 export default documentRepo;

--- a/src/search/meilisearch.ts
+++ b/src/search/meilisearch.ts
@@ -23,9 +23,55 @@ export async function ensureIndexes() {
   } catch {
     // index likely exists
   }
+  // RAG R1 (final spec D7/D8): chunk-level BM25 index — the keyword leg of kb_search's
+  // hybrid retrieval. documentId is filterable so deletion and access scoping can filter.
+  try {
+    await meili.createIndex(CHUNKS_INDEX, { primaryKey: 'id' })
+  } catch {
+    // index likely exists
+  }
+  try {
+    await meili.index(CHUNKS_INDEX).updateFilterableAttributes(['documentId'])
+  } catch {
+    // best-effort: settings update failing must not block boot
+  }
 }
 
 export async function indexDocuments(docs: SearchDoc[]) {
   const index = meili.index<SearchDoc>('documents')
   await index.addDocuments(docs)
+}
+
+// ── RAG chunks (final spec D7: BM25 leg of hybrid retrieval) ──────────────────
+
+export const CHUNKS_INDEX = 'document_chunks'
+
+export type SearchChunk = {
+  /** documentChunks.id — joins BM25 hits back to pgvector rows for RRF fusion. */
+  id: string
+  documentId: string
+  sectionPath?: string | null
+  text: string
+}
+
+export async function indexChunks(chunks: SearchChunk[]) {
+  if (chunks.length === 0) return
+  await ensureIndexes()
+  await meili.index<SearchChunk>(CHUNKS_INDEX).addDocuments(chunks)
+}
+
+export async function removeChunksOfDocument(documentId: string) {
+  try {
+    await meili.index(CHUNKS_INDEX).deleteDocuments({ filter: `documentId = "${documentId}"` })
+  } catch {
+    // index may not exist yet — nothing to remove
+  }
+}
+
+/** BM25 search over chunks, scoped to the given (already access-filtered) document ids. */
+export async function searchChunks(query: string, documentIds: string[], limit = 20) {
+  if (documentIds.length === 0) return []
+  const filter = `documentId IN [${documentIds.map((id) => `"${id}"`).join(', ')}]`
+  const res = await meili.index<SearchChunk>(CHUNKS_INDEX).search(query, { filter, limit })
+  return res.hits
 }

--- a/src/server/function/documents.server.ts
+++ b/src/server/function/documents.server.ts
@@ -11,6 +11,9 @@ import { documents } from '~/db/schema/document.schema';
 import { auth } from '~/server/auth.server';
 import { S3StaticFileImpl } from '~/server/s3/s3';
 import { and, desc, eq, inArray } from 'drizzle-orm';
+import { estimateTokens, routeTier } from '~/server/rag/tier';
+import { scheduleRagIngest } from '~/server/rag/queue';
+import { canAccessDocument } from '~/server/projects/access';
 
 const fileService = new S3StaticFileImpl();
 
@@ -244,7 +247,13 @@ export const initDocumentUpload = createServerFn({ method: 'POST' })
     const shouldCreateDocument =
       !!input.addToKnowledgeBase || Boolean(input.content?.trim().length);
 
-    const fileRecord = await db.transaction(async (tx) => {
+    // RAG R1 (final spec D5): tier the document at creation — only 'rag'-tier content
+    // enters the embed pipeline; small docs stay on the free Read/Grep path.
+    const content = input.content ?? '';
+    const tokenEstimate = content ? estimateTokens(content) : 0;
+    const ragTier = content ? routeTier(tokenEstimate) : null;
+
+    const { fileRecord, ragDocumentId } = await db.transaction(async (tx) => {
       const [createdFile] = await tx
         .insert(files)
         .values({
@@ -262,30 +271,78 @@ export const initDocumentUpload = createServerFn({ method: 'POST' })
         throw new Error('Failed to create file record');
       }
 
+      let createdRagDocId: string | null = null;
       if (shouldCreateDocument) {
-        await tx.insert(documents).values({
-          title: input.title?.trim() || originalName,
-          content: input.content ?? '',
-          fileType: mimeType,
-          filename: originalName,
-          totalCharCount: input.content?.length ?? null,
-          totalLineCount: input.content ? input.content.split(/\r?\n/).length : null,
-          sourceType: input.addToKnowledgeBase ? 'knowledge-base' : 'upload',
-          source: key,
-          fileId: createdFile.id,
-          userId: user.id,
-          clientId: user.id,
-        });
+        const [createdDoc] = await tx
+          .insert(documents)
+          .values({
+            title: input.title?.trim() || originalName,
+            content,
+            fileType: mimeType,
+            filename: originalName,
+            totalCharCount: input.content?.length ?? null,
+            totalLineCount: input.content ? input.content.split(/\r?\n/).length : null,
+            sourceType: input.addToKnowledgeBase ? 'knowledge-base' : 'upload',
+            source: key,
+            fileId: createdFile.id,
+            userId: user.id,
+            clientId: user.id,
+            tokenEstimate: tokenEstimate || null,
+            ragTier,
+            ingestStatus: ragTier === 'rag' ? 'pending' : 'none',
+          })
+          .returning({ id: documents.id });
+        if (ragTier === 'rag') createdRagDocId = createdDoc?.id ?? null;
       }
 
-      return createdFile;
+      return { fileRecord: createdFile, ragDocumentId: createdRagDocId };
     });
+
+    // After the tx so a queue/inline failure can never roll back the upload itself.
+    if (ragDocumentId) {
+      await scheduleRagIngest(ragDocumentId);
+    }
 
     const uploadUrl = fileService.isPresignedEnabled()
       ? await fileService.createUploadPreSignedUrl(key)
       : null;
 
     return { id: fileRecord.id, key, uploadUrl };
+  });
+
+/**
+ * Manually (re)ingest a document into the RAG pipeline — used by the documents UI and
+ * for backfilling docs created before R1. Forces tier re-routing from current content.
+ */
+export const reingestDocument = createServerFn({ method: 'POST' })
+  .inputValidator((input: unknown) => {
+    const data = (input && typeof input === 'object' && 'data' in (input as Record<string, unknown>))
+      ? (input as { data: unknown }).data
+      : input;
+    return z.object({ documentId: z.string().min(1) }).parse(data);
+  })
+  .handler(async ({ data }) => {
+    const user = await requireUser();
+    const [doc] = await db
+      .select({ id: documents.id, userId: documents.userId, projectId: documents.projectId, content: documents.content })
+      .from(documents)
+      .where(eq(documents.id, data.documentId))
+      .limit(1);
+    if (!doc) throw new Error('Document not found');
+    if (!(await canAccessDocument(user.id, doc))) throw new Error('FORBIDDEN');
+
+    const tokenEstimate = estimateTokens(doc.content ?? '');
+    const ragTier = routeTier(tokenEstimate);
+    await db
+      .update(documents)
+      .set({ tokenEstimate, ragTier, ingestStatus: ragTier === 'rag' ? 'pending' : 'none' })
+      .where(eq(documents.id, doc.id));
+
+    if (ragTier !== 'rag') {
+      return { scheduled: false as const, ragTier, tokenEstimate };
+    }
+    const mode = await scheduleRagIngest(doc.id);
+    return { scheduled: true as const, ragTier, tokenEstimate, mode };
   });
 
 export const completeDocumentUpload = createServerFn({ method: 'POST' })

--- a/src/server/rag/chunker.ts
+++ b/src/server/rag/chunker.ts
@@ -1,0 +1,126 @@
+/**
+ * Structure-aware Markdown chunker (final spec D10) — pure, unit-tested.
+ *
+ * Parents = heading-delimited sections (small-to-big retrieval returns these).
+ * Children = paragraph-packed slices of a parent, ≤ CHILD_MAX_TOKENS each (safety margin
+ * under Zhipu's 3072-token per-text hard limit).
+ * Every chunk carries its `sectionPath` ("§ 标题 > 子标题") for citations and for the
+ * free-tier contextual prefix (final spec D9).
+ */
+import { estimateTokens } from './tier';
+
+export const CHILD_MAX_TOKENS = 1_024;
+export const PARENT_MAX_TOKENS = 2_500;
+
+export interface ParentChunk {
+  sectionPath: string;
+  text: string;
+}
+
+export interface ChildChunk {
+  /** Index into the parents array (resolved to parentChunkId at insert time). */
+  parentIndex: number;
+  sectionPath: string;
+  text: string;
+}
+
+export interface TocEntry {
+  path: string;
+  level: number;
+}
+
+export interface ChunkResult {
+  parents: ParentChunk[];
+  children: ChildChunk[];
+  toc: TocEntry[];
+}
+
+interface Section {
+  path: string[];
+  level: number;
+  lines: string[];
+}
+
+/** Split markdown into heading-scoped sections; preamble before any heading keeps the doc title. */
+function splitSections(markdown: string, docTitle: string): Section[] {
+  const sections: Section[] = [];
+  let current: Section = { path: [docTitle], level: 0, lines: [] };
+  const stack: Array<{ level: number; title: string }> = [];
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const m = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (m) {
+      if (current.lines.some((l) => l.trim() !== '')) sections.push(current);
+      const level = m[1].length;
+      const title = m[2].trim();
+      while (stack.length > 0 && stack[stack.length - 1].level >= level) stack.pop();
+      stack.push({ level, title });
+      current = { path: [docTitle, ...stack.map((s) => s.title)], level, lines: [] };
+    } else {
+      current.lines.push(line);
+    }
+  }
+  if (current.lines.some((l) => l.trim() !== '')) sections.push(current);
+  return sections;
+}
+
+/** Pack paragraphs into pieces of ≤ maxTokens, hard-splitting any oversized paragraph. */
+function packParagraphs(text: string, maxTokens: number): string[] {
+  const paragraphs = text.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean);
+  const pieces: string[] = [];
+  let buf = '';
+
+  const flush = () => {
+    if (buf.trim()) pieces.push(buf.trim());
+    buf = '';
+  };
+
+  for (let p of paragraphs) {
+    // A single paragraph beyond the limit (e.g. a giant table) gets hard-split by lines.
+    if (estimateTokens(p) > maxTokens) {
+      flush();
+      let part = '';
+      for (const line of p.split('\n')) {
+        if (estimateTokens(part) + estimateTokens(line) > maxTokens && part) {
+          pieces.push(part.trim());
+          part = '';
+        }
+        part += line + '\n';
+      }
+      if (part.trim()) pieces.push(part.trim());
+      continue;
+    }
+    if (buf && estimateTokens(buf) + estimateTokens(p) > maxTokens) flush();
+    buf += (buf ? '\n\n' : '') + p;
+  }
+  flush();
+  return pieces;
+}
+
+/**
+ * Chunk a markdown document. `docTitle` roots every sectionPath (it is also the
+ * context prefix root, so "费率为4.5%" embeds as "合同X > §3 退款政策\n费率为4.5%").
+ */
+export function chunkMarkdown(docTitle: string, markdown: string): ChunkResult {
+  const sections = splitSections(markdown, docTitle);
+  const parents: ParentChunk[] = [];
+  const children: ChildChunk[] = [];
+  const toc: TocEntry[] = [];
+
+  for (const section of sections) {
+    const body = section.lines.join('\n').trim();
+    if (!body) continue;
+    const sectionPath = section.path.join(' > ');
+    if (section.level > 0) toc.push({ path: sectionPath, level: section.level });
+
+    // Parent = the section, capped so small-to-big expansion stays context-friendly.
+    for (const parentText of packParagraphs(body, PARENT_MAX_TOKENS)) {
+      const parentIndex = parents.length;
+      parents.push({ sectionPath, text: parentText });
+      for (const childText of packParagraphs(parentText, CHILD_MAX_TOKENS)) {
+        children.push({ parentIndex, sectionPath, text: childText });
+      }
+    }
+  }
+  return { parents, children, toc };
+}

--- a/src/server/rag/ingest.ts
+++ b/src/server/rag/ingest.ts
@@ -1,0 +1,144 @@
+/**
+ * RAG ingest pipeline (final spec R1, D4/D9/D10) — ONE idempotent pure-ish function.
+ *
+ * `ingestDocument(documentId)` runs identically inline (local dev, RAG_INGEST_INLINE)
+ * and inside the BullMQ 'rag' worker. Stages: load → chunk → contextualize (free tier:
+ * title + sectionPath prefix) → hash-skip if unchanged → embed (batched) → replace
+ * chunks transactionally → Meili chunks index (best-effort) → toc/status/progress.
+ */
+import { createHash } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { db } from '~/db/db-config';
+import { documents, documentChunks } from '~/db/schema/document.schema';
+import { chunkMarkdown } from './chunker';
+import { EMBED_DIM, EMBED_MODEL, embedTexts, splitBatches } from './zhipu';
+import { indexChunks, removeChunksOfDocument } from '~/search/meilisearch';
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
+
+/** Embedding input = context prefix + text (final spec D9 free tier). */
+const embedInput = (sectionPath: string, text: string) => `${sectionPath}\n${text}`;
+
+async function setProgress(documentId: string, patch: Partial<typeof documents.$inferInsert>) {
+  // updatedAt explicit: the shared `timestamps` helper's $onUpdate returns a sql fragment,
+  // which drizzle's date-mode driver mapping crashes on ("value.toISOString is not a
+  // function") whenever an update does NOT set the column explicitly. Latent repo-wide
+  // bug — flagged separately; do not remove this without fixing _shared.ts first.
+  await db.update(documents).set({ ...patch, updatedAt: new Date() }).where(eq(documents.id, documentId));
+}
+
+export interface IngestResult {
+  status: 'ready' | 'failed' | 'skipped';
+  chunks?: number;
+  reason?: string;
+}
+
+export async function ingestDocument(documentId: string): Promise<IngestResult> {
+  const [doc] = await db.select().from(documents).where(eq(documents.id, documentId)).limit(1);
+  if (!doc) return { status: 'failed', reason: `document ${documentId} not found` };
+  if (!doc.content?.trim()) {
+    await setProgress(documentId, { ingestStatus: 'failed' });
+    return { status: 'failed', reason: 'empty content' };
+  }
+
+  try {
+    await setProgress(documentId, { ingestStatus: 'processing', ingestProgress: 5 });
+
+    const { parents, children, toc } = chunkMarkdown(doc.title || doc.filename || '文档', doc.content);
+    if (parents.length === 0) {
+      await setProgress(documentId, { ingestStatus: 'failed' });
+      return { status: 'failed', reason: 'no chunks produced' };
+    }
+
+    // One flat list: parents first (children reference them), order stable.
+    const all = [
+      ...parents.map((p) => ({ ...p, parentIndex: -1 })),
+      ...children.map((c) => ({ sectionPath: c.sectionPath, text: c.text, parentIndex: c.parentIndex })),
+    ];
+    const hashes = all.map((c) => sha256(embedInput(c.sectionPath, c.text)));
+
+    // Incremental skip (final spec D10): same model+dim and identical hash set → no re-embed.
+    const existing = await db
+      .select({ contentHash: documentChunks.contentHash })
+      .from(documentChunks)
+      .where(eq(documentChunks.documentId, documentId));
+    const sameModel = doc.embedModel === EMBED_MODEL && doc.embedDim === EMBED_DIM;
+    if (
+      sameModel &&
+      existing.length === all.length &&
+      existing.every((e) => e.contentHash != null) &&
+      new Set(existing.map((e) => e.contentHash)).size === new Set(hashes).size &&
+      hashes.every((h, _, set) => set.includes(h) || true) && // order-insensitive compare below
+      [...new Set(hashes)].every((h) => existing.some((e) => e.contentHash === h))
+    ) {
+      await setProgress(documentId, { ingestStatus: 'ready', ingestProgress: 100 });
+      return { status: 'skipped', chunks: existing.length };
+    }
+
+    await setProgress(documentId, { ingestProgress: 15 });
+
+    // Embed in explicit batches so progress moves 15 → 80 as batches complete.
+    const inputs = all.map((c) => embedInput(c.sectionPath, c.text));
+    const batches = splitBatches(inputs);
+    const vectors: number[][] = [];
+    for (let i = 0; i < batches.length; i++) {
+      vectors.push(...(await embedTexts(batches[i])));
+      await setProgress(documentId, {
+        ingestProgress: 15 + Math.round(((i + 1) / batches.length) * 65),
+      });
+    }
+
+    // Replace chunks transactionally: parents first (capture ids), then children.
+    const insertedIds = await db.transaction(async (tx) => {
+      await tx.delete(documentChunks).where(eq(documentChunks.documentId, documentId));
+      const ids: string[] = [];
+      for (let i = 0; i < all.length; i++) {
+        const chunk = all[i];
+        const [row] = await tx
+          .insert(documentChunks)
+          .values({
+            documentId,
+            fileId: doc.fileId!,
+            chunkIndex: i,
+            text: chunk.text,
+            embedding: vectors[i],
+            sectionPath: chunk.sectionPath,
+            parentChunkId: chunk.parentIndex >= 0 ? ids[chunk.parentIndex] : null,
+            contentHash: hashes[i],
+            contextPrefix: chunk.sectionPath,
+          })
+          .returning({ id: documentChunks.id });
+        ids.push(row.id);
+      }
+      return ids;
+    });
+
+    // BM25 leg (final spec D7) — best-effort: Meili down must not fail the ingest.
+    try {
+      await removeChunksOfDocument(documentId);
+      await indexChunks(
+        all.map((c, i) => ({
+          id: insertedIds[i],
+          documentId,
+          sectionPath: c.sectionPath,
+          text: c.text,
+        })),
+      );
+    } catch (err) {
+      console.warn('[rag-ingest] Meili chunk indexing failed (non-fatal):', err);
+    }
+
+    await setProgress(documentId, {
+      ingestStatus: 'ready',
+      ingestProgress: 100,
+      toc,
+      embedModel: EMBED_MODEL,
+      embedDim: EMBED_DIM,
+    });
+    return { status: 'ready', chunks: all.length };
+  } catch (err) {
+    console.error('[rag-ingest] failed:', documentId, err);
+    await setProgress(documentId, { ingestStatus: 'failed' }).catch(() => {});
+    return { status: 'failed', reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/server/rag/queue.ts
+++ b/src/server/rag/queue.ts
@@ -1,0 +1,60 @@
+/**
+ * RAG ingest scheduling (final spec D4).
+ *
+ * DELIBERATELY a separate BullMQ queue named 'rag' — the deployed worker container may
+ * run an older image whose Worker subscribes only to the 'system' queue; jobs on a queue
+ * nobody subscribes to simply wait, whereas jobs on 'system' would be consumed by the old
+ * worker's default branch and silently completed ("Unknown job - ignoring").
+ *
+ * Local dev (scripts/local-* run NO worker): RAG_INGEST_INLINE=true executes the pipeline
+ * in-process, fire-and-forget. Inline is also the automatic fallback when REDIS_URL is
+ * unset.
+ */
+import { ingestDocument } from './ingest';
+
+export const RAG_QUEUE = 'rag';
+export const RAG_INGEST_JOB = 'rag-ingest';
+
+let queuePromise: Promise<import('bullmq').Queue> | null = null;
+
+async function getQueue() {
+  if (!queuePromise) {
+    queuePromise = (async () => {
+      const [{ Queue }, { default: IORedis }] = await Promise.all([
+        import('bullmq'),
+        import('ioredis'),
+      ]);
+      const connection = new IORedis(process.env.REDIS_URL!, { maxRetriesPerRequest: null });
+      const prefix = process.env.BULLMQ_PREFIX ?? 'constructa';
+      return new Queue(RAG_QUEUE, { connection, prefix });
+    })();
+  }
+  return queuePromise;
+}
+
+function inlineMode(): boolean {
+  if (process.env.RAG_INGEST_INLINE === 'true') return true;
+  return !process.env.REDIS_URL;
+}
+
+/**
+ * Schedule (or inline-run) ingest for a document. Never throws — ingest failure surfaces
+ * via documents.ingest_status, not by breaking the upload request that triggered it.
+ */
+export async function scheduleRagIngest(documentId: string): Promise<'queued' | 'inline' | 'error'> {
+  try {
+    if (inlineMode()) {
+      void ingestDocument(documentId).catch((err) =>
+        console.error('[rag-queue] inline ingest failed:', documentId, err),
+      );
+      return 'inline';
+    }
+    const queue = await getQueue();
+    // jobId dedups re-triggers of the same document while one is still queued.
+    await queue.add(RAG_INGEST_JOB, { documentId }, { jobId: `${RAG_INGEST_JOB}-${documentId}` });
+    return 'queued';
+  } catch (err) {
+    console.error('[rag-queue] schedule failed:', documentId, err);
+    return 'error';
+  }
+}

--- a/src/server/rag/tier.ts
+++ b/src/server/rag/tier.ts
@@ -1,0 +1,51 @@
+/**
+ * RAG tier routing (final spec D5) — pure, unit-tested.
+ *
+ * The whole point of tiering: most uploads are small and must NOT be embedded
+ * (workspace Read/Grep already serves them better and for free). Only 'rag'-tier
+ * documents enter the chunk+embed pipeline.
+ */
+
+export type RagTier = 'inline' | 'grep' | 'rag';
+
+/** inline-tier ceiling: comfortably fits a context window slice. */
+export const INLINE_MAX_TOKENS = 8_000;
+/** rag-tier floor (default; override via RAG_TIER_RAG_MIN_TOKENS). */
+export const DEFAULT_RAG_MIN_TOKENS = 20_000;
+
+/**
+ * Cheap token estimate good enough for routing (NOT for billing): CJK chars count
+ * ~1 token each; everything else ~4 chars/token.
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  let cjk = 0;
+  let other = 0;
+  for (const ch of text) {
+    const code = ch.codePointAt(0)!;
+    // CJK unified + extensions, kana, hangul — the ranges that tokenize ~1:1.
+    if (
+      (code >= 0x4e00 && code <= 0x9fff) ||
+      (code >= 0x3400 && code <= 0x4dbf) ||
+      (code >= 0x3040 && code <= 0x30ff) ||
+      (code >= 0xac00 && code <= 0xd7af)
+    ) {
+      cjk++;
+    } else {
+      other++;
+    }
+  }
+  return cjk + Math.ceil(other / 4);
+}
+
+export function ragMinTokens(): number {
+  const raw = Number(process.env.RAG_TIER_RAG_MIN_TOKENS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_RAG_MIN_TOKENS;
+}
+
+/** Route a document by its estimated tokens. */
+export function routeTier(tokenEstimate: number, ragMin: number = ragMinTokens()): RagTier {
+  if (tokenEstimate >= ragMin) return 'rag';
+  if (tokenEstimate > INLINE_MAX_TOKENS) return 'grep';
+  return 'inline';
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,6 +6,8 @@ import { logger } from '~/lib/logger'
 import { runDailyCreditRefill } from './processors/dailyCreditRefill.ts'
 import { reindexDocuments } from './processors/reindexDocuments.ts'
 import { probeModels } from './processors/probeModels.ts'
+import { ingestDocument } from '~/server/rag/ingest'
+import { RAG_QUEUE, RAG_INGEST_JOB } from '~/server/rag/queue'
 
 const connection = new IORedis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
   maxRetriesPerRequest: null,
@@ -38,6 +40,28 @@ const worker = new Worker(
 
 worker.on('ready', () => logger.info('[worker] ready'))
 worker.on('error', (err) => logger.error('[worker] error', { error: err }))
+
+// RAG ingest worker — its own queue (final spec D4): an older deployed image, which
+// doesn't know this queue, leaves its jobs untouched instead of swallowing them via the
+// 'system' default branch above. Concurrency 1: ingest is batch-embedding heavy and the
+// Zhipu client already parallelizes nothing it shouldn't.
+const ragWorker = new Worker(
+  RAG_QUEUE,
+  async (job) => {
+    if (job.name !== RAG_INGEST_JOB) {
+      logger.warn(`[worker:rag] Unknown job "${job.name}" - ignoring`)
+      return
+    }
+    const { documentId } = job.data as { documentId: string }
+    logger.info('[worker:rag] ingesting document', { documentId })
+    const result = await ingestDocument(documentId)
+    logger.info('[worker:rag] ingest finished', { documentId, ...result })
+    return result
+  },
+  { connection, prefix, concurrency: 1 }
+)
+ragWorker.on('ready', () => logger.info('[worker:rag] ready'))
+ragWorker.on('error', (err) => logger.error('[worker:rag] error', { error: err }))
 
 // Events
 const events = new QueueEvents(queueName, { connection, prefix })

--- a/tests/unit/rag-tier-chunker.test.ts
+++ b/tests/unit/rag-tier-chunker.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+/**
+ * Unit tests for RAG tier routing + the structure-aware chunker (final spec D5/D10).
+ * These pin the routing boundaries (only 'rag' documents get embedded — the cost valve)
+ * and the chunker contracts the ingest pipeline relies on.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_RAG_MIN_TOKENS,
+  INLINE_MAX_TOKENS,
+  estimateTokens,
+  routeTier,
+} from '../../src/server/rag/tier';
+import { CHILD_MAX_TOKENS, chunkMarkdown } from '../../src/server/rag/chunker';
+
+describe('estimateTokens', () => {
+  it('counts CJK ~1:1 and latin ~4 chars/token', () => {
+    expect(estimateTokens('中文十个字符的估算测试')).toBe(11);
+    expect(estimateTokens('abcdefgh')).toBe(2);
+    expect(estimateTokens('')).toBe(0);
+  });
+});
+
+describe('routeTier — the cost valve', () => {
+  it('small docs are inline (never embedded)', () => {
+    expect(routeTier(500, DEFAULT_RAG_MIN_TOKENS)).toBe('inline');
+    expect(routeTier(INLINE_MAX_TOKENS, DEFAULT_RAG_MIN_TOKENS)).toBe('inline');
+  });
+
+  it('mid-size docs are grep (workspace Read/Grep, not embedded)', () => {
+    expect(routeTier(INLINE_MAX_TOKENS + 1, DEFAULT_RAG_MIN_TOKENS)).toBe('grep');
+    expect(routeTier(DEFAULT_RAG_MIN_TOKENS - 1, DEFAULT_RAG_MIN_TOKENS)).toBe('grep');
+  });
+
+  it('only ≥ threshold goes to rag', () => {
+    expect(routeTier(DEFAULT_RAG_MIN_TOKENS, DEFAULT_RAG_MIN_TOKENS)).toBe('rag');
+  });
+});
+
+const MD = `前言段落，介绍这份文档。
+
+# 第一章 总则
+
+本合同约定退款费率为 4.5%。
+
+## 1.1 适用范围
+
+适用于全部订单。
+
+# 第二章 保修
+
+保修期为两年。`;
+
+describe('chunkMarkdown', () => {
+  it('builds heading-scoped sections with full sectionPath and toc', () => {
+    const r = chunkMarkdown('测试合同', MD);
+    const paths = r.parents.map((p) => p.sectionPath);
+    expect(paths).toContain('测试合同'); // preamble
+    expect(paths).toContain('测试合同 > 第一章 总则');
+    expect(paths).toContain('测试合同 > 第一章 总则 > 1.1 适用范围');
+    expect(paths).toContain('测试合同 > 第二章 保修'); // sibling heading pops the stack
+    expect(r.toc.map((t) => t.path)).toEqual([
+      '测试合同 > 第一章 总则',
+      '测试合同 > 第一章 总则 > 1.1 适用范围',
+      '测试合同 > 第二章 保修',
+    ]);
+  });
+
+  it('every child stays under CHILD_MAX_TOKENS and points at a valid parent', () => {
+    const bigSection = `# 大章节\n\n${Array.from({ length: 80 }, (_, i) => `这是第${i}段，包含一些用于撑大体积的中文内容，重复重复重复重复重复重复重复重复重复重复。`).join('\n\n')}`;
+    const r = chunkMarkdown('大文档', bigSection);
+    expect(r.children.length).toBeGreaterThan(1);
+    for (const c of r.children) {
+      expect(estimateTokens(c.text)).toBeLessThanOrEqual(CHILD_MAX_TOKENS);
+      expect(r.parents[c.parentIndex]).toBeDefined();
+      expect(c.sectionPath).toBe(r.parents[c.parentIndex].sectionPath);
+    }
+  });
+
+  it('hard-splits a single oversized paragraph instead of dropping it', () => {
+    const giant = `# 表格\n\n${Array.from({ length: 200 }, (_, i) => `行${i}：很长的一行中文内容用来模拟巨型表格的单元格数据`).join('\n')}`;
+    const r = chunkMarkdown('表格文档', giant);
+    expect(r.children.length).toBeGreaterThan(1);
+    for (const c of r.children) expect(estimateTokens(c.text)).toBeLessThanOrEqual(CHILD_MAX_TOKENS);
+  });
+
+  it('empty/whitespace markdown produces no chunks', () => {
+    const r = chunkMarkdown('空', '\n\n  \n');
+    expect(r.parents).toHaveLength(0);
+    expect(r.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## RAG 复工 R1（入库管线）

Per final spec D4/D5/D8/D9/D10. Backend-complete; UI badge/promote lands with R2 (one panel pass).

- **Tier routing** (`tier.ts`): only ≥20k-token docs embed ('rag'); small docs stay on free Read/Grep. The cost valve.
- **Chunker** (`chunker.ts`): heading-scoped parents (≤2500 tok) + paragraph-packed children (≤1024 tok), sectionPath + toc.
- **Pipeline** (`ingest.ts`): idempotent — contextual prefix, sha256 hash-skip, batched embed w/ progress 15→80%, transactional replace w/ parent linkage, best-effort Meili chunks index.
- **Dedicated 'rag' BullMQ queue** (`queue.ts` + worker): old deployed worker images only subscribe 'system' and would swallow jobs there; inline fallback for local dev (no worker).
- **Wiring**: docs tiered at creation, auto-schedule on 'rag'; `reingestDocument` server fn (access-checked) for manual/backfill. `getAllDocumentsForSearch` hook turns worker `reindex-all` real (audit errata).

### Verified
- Unit **166/166** (incl. 8 new tier/chunker contracts)
- E2E smoke `scripts/rag-r1-smoke.ts` vs real DB + Zhipu: 21k-token doc → 40 chunks `ready`, ANN top-1 hits 「第三章 保修条款」 for 「保修期是多久？」, second run **hash-skipped**; Meili leg degrades gracefully
- typecheck baseline 179, zero new

Known latent repo bug worked around (shared timestamps $onUpdate) — flagged separately.

Next: R2 — `/api/rag/search` (hybrid+RRF+rerank) + `kb_search` MCP tool + isolation regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)