### PR TITLE
feat(rag): R2 — kb_search MCP tool + hybrid retrieval (vector∥BM25→RRF→rerank) with SQL isolation

### DIFF
--- a/scripts/rag-r2-smoke.ts
+++ b/scripts/rag-r2-smoke.ts
@@ -1,0 +1,100 @@
+/**
+ * RAG R2 smoke — kb_search retrieval + THE isolation regression (final spec R2 Exit:
+ * "非成员检索不到他人项目文档"), against a real DB + real Zhipu.
+ *
+ *   DATABASE_URL=... ZHIPU_API_KEY=... npx tsx scripts/rag-r2-smoke.ts
+ *
+ * Fixtures (cleaned up at the end): users = the two seeded test accounts; a project
+ * owned by USER_A with USER_A as its only member; three small docs force-ingested:
+ *   docPersonalA (personal, A) / docProject (in project) / docPersonalB (personal, B).
+ * Asserts: A retrieves from docPersonalA + docProject but never docPersonalB;
+ * B retrieves ONLY from docPersonalB — neither A's personal doc nor the project doc.
+ */
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '~/db/db-config';
+import { user } from '~/db/schema/auth.schema';
+import { files } from '~/db/schema/file.schema';
+import { documents } from '~/db/schema/document.schema';
+import { project, projectMember } from '~/db/schema/project.schema';
+import { ingestDocument } from '~/server/rag/ingest';
+import { searchKb } from '~/server/rag/search';
+
+async function makeDoc(title: string, marker: string, userId: string, projectId: string | null) {
+  const [file] = await db
+    .insert(files)
+    .values({ key: `rag-smoke-r2/${title}-${Date.now()}`, clientId: userId, fileType: 'text/markdown', name: `${title}.md`, size: 0, url: '' })
+    .returning();
+  const [doc] = await db
+    .insert(documents)
+    .values({
+      title,
+      content: `# ${title}\n\n${marker}是本文档的核心机密内容，编号${title}。\n\n其余为常规说明文字。`,
+      sourceType: 'rag-smoke',
+      userId,
+      projectId,
+      fileId: file.id,
+      ragTier: 'rag',
+      ingestStatus: 'pending',
+    })
+    .returning();
+  const r = await ingestDocument(doc.id);
+  if (r.status !== 'ready') throw new Error(`ingest ${title} failed: ${r.reason}`);
+  return { doc, file };
+}
+
+async function main() {
+  const testUsers = await db
+    .select({ id: user.id, email: user.email })
+    .from(user)
+    .where(inArray(user.email, ['alice@oxy.local', 'bob@oxy.local']));
+  const userA = testUsers.find((u) => u.email === 'alice@oxy.local');
+  const userB = testUsers.find((u) => u.email === 'bob@oxy.local');
+  if (!userA || !userB) throw new Error('seeded test users alice/bob@oxy.local not found');
+
+  const [proj] = await db
+    .insert(project)
+    .values({ ownerUserId: userA.id, name: 'RAG-R2-冒烟项目' })
+    .returning();
+  await db.insert(projectMember).values({ projectId: proj.id, userId: userA.id, role: 'owner' });
+
+  const made: Array<{ doc: { id: string }; file: { id: string } }> = [];
+  try {
+    made.push(await makeDoc('个人A文档', '蓝色凤凰', userA.id, null));
+    made.push(await makeDoc('项目共享文档', '银色山脉', userA.id, proj.id));
+    made.push(await makeDoc('个人B文档', '红色峡谷', userB.id, null));
+    console.log('[smoke] 3 docs ingested');
+
+    // A sees own personal + project doc
+    const aProject = await searchKb(userA.id, { query: '银色山脉的机密内容', k: 5 });
+    if (!aProject.some((h) => h.documentTitle === '项目共享文档')) throw new Error('A should retrieve the project doc');
+    const aOwn = await searchKb(userA.id, { query: '蓝色凤凰的机密内容', k: 5 });
+    if (!aOwn.some((h) => h.documentTitle === '个人A文档')) throw new Error('A should retrieve own personal doc');
+    // A must NOT see B's personal doc even when querying its exact marker
+    const aLeak = await searchKb(userA.id, { query: '红色峡谷的机密内容', k: 5 });
+    if (aLeak.some((h) => h.documentTitle === '个人B文档')) throw new Error('LEAK: A retrieved B\'s personal doc');
+
+    // B (NOT a project member) must see neither the project doc nor A's personal doc
+    const bProj = await searchKb(userB.id, { query: '银色山脉的机密内容', k: 5 });
+    if (bProj.some((h) => h.documentTitle === '项目共享文档')) throw new Error('LEAK: non-member B retrieved the project doc');
+    const bPersonalA = await searchKb(userB.id, { query: '蓝色凤凰的机密内容', k: 5 });
+    if (bPersonalA.some((h) => h.documentTitle === '个人A文档')) throw new Error('LEAK: B retrieved A\'s personal doc');
+    const bOwn = await searchKb(userB.id, { query: '红色峡谷的机密内容', k: 5 });
+    if (!bOwn.some((h) => h.documentTitle === '个人B文档')) throw new Error('B should retrieve own personal doc');
+
+    console.log('[smoke] sample hit:', JSON.stringify({ ...aProject[0], text: aProject[0]?.text.slice(0, 40) }));
+    console.log('✅ R2 smoke PASS — hybrid retrieval works and isolation holds (非成员看不到)');
+  } finally {
+    for (const m of made) {
+      await db.delete(documents).where(eq(documents.id, m.doc.id));
+      await db.delete(files).where(eq(files.id, m.file.id));
+    }
+    await db.delete(project).where(eq(project.id, proj.id)); // member rows cascade
+    console.log('[smoke] cleaned up fixtures');
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('❌ R2 smoke FAIL:', err);
+  process.exit(1);
+});

--- a/src/routes/api/rag/search.ts
+++ b/src/routes/api/rag/search.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/rag/search — the kb_search retrieval endpoint (final spec D6/D7).
+ *
+ * Plain HTTP route (not a server-fn) ON PURPOSE: the per-session SDK worker is plain
+ * node (no TS imports, no DB, by design) and calls back into the app with the user's
+ * cookie — the same worker→app pattern as persistSession (/api/agent-sessions). The
+ * cookie travels via the worker's stdin request, NOT its env, so agent-spawned Bash
+ * children can't read it. Browser callers (DocsUI later) use the same endpoint.
+ *
+ * Isolation: requireUser → searchKb scopes BOTH recall legs through the access
+ * resolver. No raw user_id filters here.
+ */
+import { createFileRoute } from '@tanstack/react-router';
+import { requireUser } from '~/server/require-user';
+import { searchKb } from '~/server/rag/search';
+
+export const Route = createFileRoute('/api/rag/search')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const user = await requireUser(request);
+
+        let body: unknown;
+        try {
+          body = await request.json();
+        } catch {
+          return Response.json({ error: 'invalid JSON body' }, { status: 400 });
+        }
+        const { query, k, documentId, kbId } = (body ?? {}) as Record<string, unknown>;
+        if (typeof query !== 'string' || !query.trim()) {
+          return Response.json({ error: 'query is required' }, { status: 400 });
+        }
+
+        const hits = await searchKb(user.id, {
+          query,
+          k: typeof k === 'number' ? k : undefined,
+          documentId: typeof documentId === 'string' ? documentId : undefined,
+          kbId: typeof kbId === 'string' ? kbId : undefined,
+        });
+        return Response.json({ hits });
+      },
+    },
+  },
+});

--- a/src/server/rag/fuse.ts
+++ b/src/server/rag/fuse.ts
@@ -1,0 +1,15 @@
+/**
+ * Reciprocal-rank fusion (final spec D7) — pure, unit-tested, no imports.
+ * Merges the vector and BM25 recall legs: score(id) = Σ_legs 1/(k + rank + 1).
+ */
+export const RRF_K = 60;
+
+export function rrfFuse(rankings: string[][], k: number = RRF_K): Map<string, number> {
+  const scores = new Map<string, number>();
+  for (const ranking of rankings) {
+    ranking.forEach((id, rank) => {
+      scores.set(id, (scores.get(id) ?? 0) + 1 / (k + rank + 1));
+    });
+  }
+  return scores;
+}

--- a/src/server/rag/search.ts
+++ b/src/server/rag/search.ts
@@ -1,0 +1,147 @@
+/**
+ * kb_search retrieval pipeline (final spec D7) — hybrid recall → RRF → rerank →
+ * small-to-big → cited results.
+ *
+ * ISOLATION INVARIANT: both legs are scoped to the caller's visible documents via the
+ * access resolver (visibleDocumentsWhere) — in SQL / in the Meili filter, never a
+ * post-filter. The 非成员看不到 regression lives in scripts/rag-r2-smoke.ts.
+ */
+import { and, cosineDistance, eq, inArray } from 'drizzle-orm';
+import { db } from '~/db/db-config';
+import { documents, documentChunks } from '~/db/schema/document.schema';
+import { kbDocuments } from '~/db/schema/kb-document.schema';
+import { accessibleProjectIds, visibleDocumentsWhere } from '~/server/projects/access';
+import { searchChunks } from '~/search/meilisearch';
+import { embedTexts, rerankDocuments } from './zhipu';
+import { rrfFuse } from './fuse';
+
+export interface KbSearchParams {
+  query: string;
+  /** Results to return (default 8). */
+  k?: number;
+  /** Optional narrowing: a single document, or a knowledge base (via kb_documents). */
+  documentId?: string;
+  kbId?: string;
+}
+
+export interface KbSearchHit {
+  documentId: string;
+  documentTitle: string;
+  sectionPath: string | null;
+  text: string;
+  pageStart: number | null;
+  pageEnd: number | null;
+  score: number;
+}
+
+const VECTOR_RECALL = 20;
+const BM25_RECALL = 20;
+const RERANK_POOL = 12;
+
+/** Resolve the searchable document-id universe for this user (+ optional narrowing). */
+async function visibleDocIds(userId: string, params: KbSearchParams): Promise<string[]> {
+  const projectIds = await accessibleProjectIds(userId);
+  const rows = await db
+    .select({ id: documents.id, fileId: documents.fileId })
+    .from(documents)
+    .where(and(visibleDocumentsWhere(userId, projectIds), eq(documents.ingestStatus, 'ready')));
+
+  let ids = rows;
+  if (params.documentId) {
+    ids = ids.filter((r) => r.id === params.documentId);
+  } else if (params.kbId) {
+    // kb_documents links a KB to FILES; documents hang off the same fileId.
+    const kbFiles = await db
+      .select({ fileId: kbDocuments.fileId })
+      .from(kbDocuments)
+      .where(eq(kbDocuments.kbId, params.kbId));
+    const fileSet = new Set(kbFiles.map((f) => f.fileId));
+    ids = ids.filter((r) => r.fileId && fileSet.has(r.fileId));
+  }
+  return ids.map((r) => r.id);
+}
+
+export async function searchKb(userId: string, params: KbSearchParams): Promise<KbSearchHit[]> {
+  const k = Math.min(Math.max(params.k ?? 8, 1), 20);
+  const query = params.query?.trim();
+  if (!query) return [];
+
+  const docIds = await visibleDocIds(userId, params);
+  if (docIds.length === 0) return [];
+
+  // ── Hybrid recall (both legs scoped to the SAME visible-doc universe) ─────────
+  const [queryVec] = await embedTexts([query]);
+  const distance = cosineDistance(documentChunks.embedding, queryVec);
+  const vectorLegPromise = db
+    .select({ id: documentChunks.id })
+    .from(documentChunks)
+    .where(inArray(documentChunks.documentId, docIds))
+    .orderBy(distance)
+    .limit(VECTOR_RECALL);
+  const bm25LegPromise = searchChunks(query, docIds, BM25_RECALL).catch((err) => {
+    // Meili down → degrade to vector-only rather than failing the search.
+    console.warn('[rag-search] BM25 leg failed (degrading to vector-only):', err);
+    return [] as Array<{ id: string }>;
+  });
+  const [vectorLeg, bm25Leg] = await Promise.all([vectorLegPromise, bm25LegPromise]);
+
+  // ── RRF fuse → load candidate rows ────────────────────────────────────────────
+  const fused = rrfFuse([vectorLeg.map((r) => r.id), bm25Leg.map((h) => h.id)]);
+  const candidateIds = [...fused.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, RERANK_POOL)
+    .map(([id]) => id);
+  if (candidateIds.length === 0) return [];
+
+  const candidates = await db
+    .select()
+    .from(documentChunks)
+    .where(inArray(documentChunks.id, candidateIds));
+  const byId = new Map(candidates.map((c) => [c.id, c]));
+  const ordered = candidateIds.map((id) => byId.get(id)).filter((c) => c != null);
+
+  // ── Rerank (precision stage; degrade to RRF order if the endpoint fails) ──────
+  let rankedChunks = ordered;
+  try {
+    const reranked = await rerankDocuments(
+      query,
+      ordered.map((c) => `${c.sectionPath ?? ''}\n${c.text}`),
+    );
+    rankedChunks = reranked.map((r) => ordered[r.index]);
+  } catch (err) {
+    console.warn('[rag-search] rerank failed (keeping RRF order):', err);
+  }
+
+  // ── small-to-big: child hit → return its parent section; dedup by surface id ──
+  const parentIds = rankedChunks.map((c) => c.parentChunkId).filter((p): p is string => !!p);
+  const parents = parentIds.length
+    ? await db.select().from(documentChunks).where(inArray(documentChunks.id, parentIds))
+    : [];
+  const parentById = new Map(parents.map((p) => [p.id, p]));
+
+  const docTitles = new Map(
+    (await db
+      .select({ id: documents.id, title: documents.title })
+      .from(documents)
+      .where(inArray(documents.id, docIds))).map((d) => [d.id, d.title]),
+  );
+
+  const seen = new Set<string>();
+  const hits: KbSearchHit[] = [];
+  for (let i = 0; i < rankedChunks.length && hits.length < k; i++) {
+    const chunk = rankedChunks[i];
+    const surface = (chunk.parentChunkId && parentById.get(chunk.parentChunkId)) || chunk;
+    if (seen.has(surface.id)) continue;
+    seen.add(surface.id);
+    hits.push({
+      documentId: surface.documentId!,
+      documentTitle: docTitles.get(surface.documentId!) ?? '',
+      sectionPath: surface.sectionPath,
+      text: surface.text,
+      pageStart: surface.pageStart,
+      pageEnd: surface.pageEnd,
+      score: 1 - i / rankedChunks.length,
+    });
+  }
+  return hits;
+}

--- a/tests/unit/rag-tier-chunker.test.ts
+++ b/tests/unit/rag-tier-chunker.test.ts
@@ -12,6 +12,7 @@ import {
   routeTier,
 } from '../../src/server/rag/tier';
 import { CHILD_MAX_TOKENS, chunkMarkdown } from '../../src/server/rag/chunker';
+import { rrfFuse } from '../../src/server/rag/fuse';
 
 describe('estimateTokens', () => {
   it('counts CJK ~1:1 and latin ~4 chars/token', () => {
@@ -88,5 +89,22 @@ describe('chunkMarkdown', () => {
     const r = chunkMarkdown('空', '\n\n  \n');
     expect(r.parents).toHaveLength(0);
     expect(r.children).toHaveLength(0);
+  });
+});
+
+describe('rrfFuse — reciprocal-rank fusion (final spec D7)', () => {
+
+  it('an id ranked top in both legs beats single-leg ids', () => {
+    const scores = rrfFuse([
+      ['a', 'b', 'c'],
+      ['a', 'c', 'd'],
+    ]);
+    const sorted = [...scores.entries()].sort((x, y) => y[1] - x[1]).map(([id]) => id);
+    expect(sorted[0]).toBe('a');
+    expect(scores.get('d')).toBeLessThan(scores.get('c')!);
+  });
+
+  it('handles empty legs', () => {
+    expect(rrfFuse([[], []]).size).toBe(0);
   });
 });

--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -251,6 +251,8 @@ async function startRun(request) {
       disallowedTools: requestedDisallowedTools,
       allowBash: requestedAllowBash = false,
       userId,
+      // RAG R2: user auth for the kb_search app callback (stdin-only — never env).
+      cookie: userCookie = null,
     } = request;
     const permissionMode = resolvePermissionMode(requestedPermissionMode, userId);
     const disallowedTools = resolveDisallowedTools(
@@ -513,6 +515,58 @@ async function startRun(request) {
       tools: [glmImageGenerateTool],
     });
 
+    // RAG R2 (final spec D6/D7): kb_search — semantic retrieval over the user's
+    // ingested ('rag'-tier) documents. The worker stays unprivileged: the tool calls
+    // back into the app (/api/rag/search) with the user's cookie from the STDIN
+    // request; the app does embed → hybrid recall → RRF → rerank, with isolation
+    // resolved in SQL. Registered only when we actually hold the auth to call back.
+    const appUrl = process.env.APP_URL || 'http://localhost:5000';
+    const kbSearchTool = tool(
+      'kb_search',
+      'Search the user\'s ingested knowledge documents semantically (large docs only — small files are in the workspace, use Read/Grep for those). Returns top passages with section paths for citation. Use for needle-in-haystack questions over big/ingested documents; NOT for summarizing a whole document.',
+      {
+        query: z.string().min(1).describe('What to look for (natural language; keep it specific)'),
+        k: z.number().int().min(1).max(20).optional().describe('How many passages to return (default 8)'),
+        documentId: z.string().optional().describe('Restrict to one document id'),
+        kbId: z.string().optional().describe('Restrict to one knowledge base id'),
+      },
+      async (args) => {
+        try {
+          const response = await fetch(`${appUrl}/api/rag/search`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', cookie: userCookie || '' },
+            body: JSON.stringify(args),
+          });
+          if (!response.ok) {
+            const text = await response.text().catch(() => '');
+            throw new Error(`kb_search HTTP ${response.status}: ${text.slice(0, 200)}`);
+          }
+          const { hits } = await response.json();
+          if (!hits?.length) {
+            return { content: [{ type: 'text', text: 'No matching passages found in the ingested documents.' }] };
+          }
+          const formatted = hits
+            .map((h, i) => `[${i + 1}] ${h.documentTitle}${h.sectionPath ? ` — ${h.sectionPath}` : ''}${h.pageStart ? ` (p.${h.pageStart}${h.pageEnd && h.pageEnd !== h.pageStart ? `-${h.pageEnd}` : ''})` : ''}\n${h.text}`)
+            .join('\n\n---\n\n');
+          return { content: [{ type: 'text', text: formatted }] };
+        } catch (error) {
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({ error: error instanceof Error ? error.message : String(error) }),
+              isError: true,
+            }],
+          };
+        }
+      }
+    );
+    const kbSearchMcpServer = createSdkMcpServer({
+      name: 'kb-search',
+      tools: [kbSearchTool],
+    });
+    const kbSdkServers = userCookie ? { 'kb-search': kbSearchMcpServer } : {};
+    if (!userCookie) console.error('[Worker] kb_search tool: NOT registered (no user cookie in request)');
+
     // PR-C: Sandboxed Bash tool — only registered when a sandbox backend is confirmed.
     // Two valid sandboxes:
     //   1. srt (bubblewrap) — Linux + seccomp=unconfined; sandboxStatus().state === 'active'
@@ -600,6 +654,7 @@ async function startRun(request) {
       sdkServers: {
         python: pythonMcpServer,
         'glm-image': glmImageMcpServer,
+        ...kbSdkServers,
         ...bashSdkServers,
       },
     });

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -1392,6 +1392,10 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
       disallowedTools,
       allowBash,  // Pass allowBash flag so worker can trust org-based bypass mode
       userId: ws.userId,
+      // RAG R2 (final spec D6): the kb_search MCP tool calls back into the app
+      // (/api/rag/search) with the user's own auth — via STDIN on purpose, never the
+      // worker env, so agent-spawned Bash children can't read the cookie.
+      cookie: ws.cookie,
     });
     // Newline-delimited + keep stdin OPEN so Ask-mode HITL can stream
     // approval_response lines to the worker mid-run. The worker exits on its own


### PR DESCRIPTION
## RAG 复工 R2（检索工具）

Per final spec D6/D7. The agent now has `kb_search` for needle-in-haystack questions over ingested ('rag'-tier) documents.

**Pipeline**: embed query → pgvector cosine ∥ Meili BM25 (both legs access-scoped in SQL/filter) → RRF → Zhipu rerank → small-to-big parent expansion → top-k with sectionPath/page citations.

**Architecture**: worker stays unprivileged — `kb_search` (sdk-MCP, registered next to python/glm-image/bash) calls back into `POST /api/rag/search` with the user's cookie, passed via the worker's **stdin request, never env** (Bash children can't read it). Same worker→app pattern as persistSession.

**Verified**: unit 168/168; isolation smoke on real DB+Zhipu with seeded alice/bob + a real project — six 非成员看不到 assertions hold, run in both vector-only (Meili down) and full-hybrid modes; prod build passes; typecheck baseline unchanged.

Deferred to follow-ups: docs UI badges/promote-to-KB, R3 (LLM contextual enrichment, holistic routing), R4 (golden set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)