### PR TITLE
fix(rag): kb_search must register as built-in (catalog resolver drops unknown sdk servers)

### DIFF
--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -564,8 +564,6 @@ async function startRun(request) {
       name: 'kb-search',
       tools: [kbSearchTool],
     });
-    const kbSdkServers = userCookie ? { 'kb-search': kbSearchMcpServer } : {};
-    if (!userCookie) console.error('[Worker] kb_search tool: NOT registered (no user cookie in request)');
 
     // PR-C: Sandboxed Bash tool — only registered when a sandbox backend is confirmed.
     // Two valid sandboxes:
@@ -654,10 +652,19 @@ async function startRun(request) {
       sdkServers: {
         python: pythonMcpServer,
         'glm-image': glmImageMcpServer,
-        ...kbSdkServers,
         ...bashSdkServers,
       },
     });
+
+    // kb_search is a BUILT-IN capability (like Read/Grep), not a curated-catalog MCP —
+    // resolveMcpServerConfigs only passes through catalog-enabled sdk servers, so it is
+    // merged here AFTER resolution. Registered only when the run carries user auth.
+    if (userCookie) {
+      mcpServers['kb-search'] = kbSearchMcpServer;
+      allowedTools.push('mcp__kb-search__*');
+    } else {
+      console.error('[Worker] kb_search tool: NOT registered (no user cookie in request)');
+    }
 
     console.error(`[Worker] MCP Servers: ${Object.keys(mcpServers).join(', ') || '(none)'}`);
     console.error(`[Worker] Allowed Tools: ${allowedTools.length} entries`);


### PR DESCRIPTION
Follow-up to #156: `resolveMcpServerConfigs` only passes through **catalog-enabled** sdk servers, so kb-search (no catalog entry) was silently dropped — the agent never saw the tool.

Fix: merge kb-search into `mcpServers` + `allowedTools` **after** catalog resolution (built-in capability like Read/Grep), still gated on user auth.

**Live E2E proof** (full stack, real agent turn): asked 「量子加密密钥的轮换周期是多久？」 over a 12-chunk ingested fixture — agent invoked kb_search and answered **13 天** with citation 「《星尘协议运维手册》 > 安全章」. Worker log: `MCP Servers: …, kb-search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)