### PR TITLE
fix(db): $onUpdate returns Date instead of sql fragment (latent updatedAt crash)

### DIFF
--- a/src/db/schema/_shared.ts
+++ b/src/db/schema/_shared.ts
@@ -1,10 +1,12 @@
 import { timestamp, pgEnum, text } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
 
 export const timestamptz = (name: string) => timestamp(name, { withTimezone: true });
 
 export const createdAt = () => timestamptz('created_at').notNull().defaultNow();
-export const updatedAt = () => timestamptz('updated_at').notNull().defaultNow().$onUpdate(() => sql`CURRENT_TIMESTAMP`);
+// $onUpdate must return a Date here: drizzle's date-mode driver mapping calls
+// .toISOString() on the returned value, so a sql`` fragment crashes every
+// db.update() that doesn't set updated_at explicitly.
+export const updatedAt = () => timestamptz('updated_at').notNull().defaultNow().$onUpdate(() => new Date());
 export const accessedAt = () => timestamptz('accessed_at').notNull().defaultNow();
 
 export const timestamps = {

--- a/src/server/rag/ingest.ts
+++ b/src/server/rag/ingest.ts
@@ -20,11 +20,7 @@ const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
 const embedInput = (sectionPath: string, text: string) => `${sectionPath}\n${text}`;
 
 async function setProgress(documentId: string, patch: Partial<typeof documents.$inferInsert>) {
-  // updatedAt explicit: the shared `timestamps` helper's $onUpdate returns a sql fragment,
-  // which drizzle's date-mode driver mapping crashes on ("value.toISOString is not a
-  // function") whenever an update does NOT set the column explicitly. Latent repo-wide
-  // bug — flagged separately; do not remove this without fixing _shared.ts first.
-  await db.update(documents).set({ ...patch, updatedAt: new Date() }).where(eq(documents.id, documentId));
+  await db.update(documents).set(patch).where(eq(documents.id, documentId));
 }
 
 export interface IngestResult {


### PR DESCRIPTION
## 问题

`src/db/schema/_shared.ts` 的共享 `updatedAt` helper 在 `$onUpdate` 里返回 sql\`CURRENT_TIMESTAMP\` 片段。drizzle-orm 0.44.x 对 `timestamp(mode: date)` 列的驱动映射会对 `$onUpdate` 返回值调用 `.toISOString()`，sql 片段没有该方法 → 任何对使用 `...timestamps` 的表的 `db.update()`，只要没显式传 `updatedAt`，就会抛 `value.toISOString is not a function`。

现有调用点恰好都显式传了 `updatedAt` 所以从未触发；RAG R1 的 `ingest.ts setProgress` 是第一个踩中的，当时用显式 `updatedAt: new Date()` 绕开并留了注释。

## 改动

- `_shared.ts`：`$onUpdate(() => sql\`CURRENT_TIMESTAMP\`)` → `$onUpdate(() => new Date())`（与 better-auth 生成 schema 的写法一致），移除不再使用的 `sql` import
- `ingest.ts`：移除 `setProgress` 里的显式 `updatedAt` 绕开及注释

## 验证

- 全仓 grep `CURRENT_TIMESTAMP`：唯一其他用点是 `seed-curated-skills.ts` 的显式 `.set({ updatedAt: sql\`CURRENT_TIMESTAMP\` })`，不经过 `$onUpdate` 映射，不受影响；没有调用点依赖 DB 端时钟语义
- `pnpm test:unit`：24 files / 168 tests 全过
- `pnpm vitest run`：12 failed / 186 passed，与 main 基线完全一致（失败全是需要 :3000 活服务的 auth 集成测试，预存）
- `pnpm lint`：0 errors
- `pnpm typecheck`：179 个预存错误（cli/ 等），改动前后数量一致，本改动未引入新错误

语义差异说明：时间戳从 DB 端 `CURRENT_TIMESTAMP` 变为应用端 `new Date()`，与 `createdAt` 的 `defaultNow()`（DB 端）存在毫秒级时钟偏差的可能，但仓内没有依赖两者严格同源的逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)