### PR TITLE
feat(rag): U0.5 — embedding 默认切换 doubao-vision@1024（真实语料 A/B 胜出，零迁移）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,7 +201,10 @@ services:
       MEILI_HOST: http://meilisearch:7700
       MEILI_API_KEY: ${MEILI_API_KEY:-${MEILI_MASTER_KEY}}
       SEARCH_REINDEX_ON_BOOT: ${SEARCH_REINDEX_ON_BOOT:-false}
-      # RAG ingest (R0): Zhipu embedding/rerank — the ingest pipeline embeds in this worker
+      # RAG ingest: embedding providers — doubao (default; ARK key) / zhipu fallback.
+      # The ingest pipeline embeds in this worker (see src/server/rag/embedding.ts).
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+      EMBED_PROVIDER: ${EMBED_PROVIDER:-}
       ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-}
     extra_hosts:

--- a/scripts/rag-embed-ab.ts
+++ b/scripts/rag-embed-ab.ts
@@ -1,0 +1,165 @@
+/**
+ * Embedding provider A/B — Zhipu embedding-3@1024 vs Doubao doubao-embedding-vision@2048.
+ * IN-MEMORY (brute-force cosine), touches NO tables — the two providers have different
+ * dims so a DB comparison would require schema churn before we even know the winner.
+ *
+ *   DATABASE_URL not needed.
+ *   ZHIPU_API_KEY=... ANTHROPIC_AUTH_TOKEN=<ark-key> npx tsx scripts/rag-embed-ab.ts
+ *
+ * Corpora:
+ *  A. synthetic golden set v1 (2 docs, 14 tagged cases — same as scripts/rag-eval.ts)
+ *  B. REAL prospectus subset (rag-test-docs/minimax.md, financial-info window) with 6
+ *     paraphrase needle questions judged by expectText-in-chunk
+ * Metrics: R@1 / R@4 / MRR per provider per corpus. Also reports embed throughput.
+ */
+import { readFileSync } from 'node:fs';
+import { chunkMarkdown } from '../src/server/rag/chunker';
+import { embedTexts as embedZhipu } from '../src/server/rag/zhipu';
+import { GOLDEN_DOCS, GOLDEN_CASES } from '../tests/golden/rag-golden-set';
+
+const ARK_BASE = process.env.ARK_EMBED_BASE_URL || 'https://ark.cn-beijing.volces.com/api/v3';
+const ARK_MODEL = 'doubao-embedding-vision-250615';
+
+function arkKey(): string {
+  const k = process.env.ANTHROPIC_AUTH_TOKEN;
+  if (!k) throw new Error('ANTHROPIC_AUTH_TOKEN (ARK key) not set');
+  return k;
+}
+
+/** doubao-embedding-vision has NO batching: input[] is ONE multimodal sample → 1 vector. */
+async function embedDoubao(texts: readonly string[], concurrency = 4, dimensions?: number): Promise<number[][]> {
+  const out: number[][] = new Array(texts.length);
+  let next = 0;
+  async function lane() {
+    while (next < texts.length) {
+      const i = next++;
+      const res = await fetch(`${ARK_BASE}/embeddings/multimodal`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${arkKey()}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: ARK_MODEL, input: [{ type: 'text', text: texts[i] }], ...(dimensions ? { dimensions } : {}) }),
+      });
+      if (!res.ok) throw new Error(`doubao ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      out[i] = (await res.json()).data.embedding as number[];
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, lane));
+  return out;
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+interface Corpus {
+  name: string;
+  chunks: Array<{ sectionPath: string; text: string }>;
+  cases: Array<{ query: string; isHit: (c: { sectionPath: string; text: string }) => boolean }>;
+}
+
+function buildSynthetic(): Corpus {
+  const chunks = GOLDEN_DOCS.flatMap((d) => {
+    const { parents } = chunkMarkdown(d.title, d.markdown);
+    return parents;
+  });
+  return {
+    name: 'synthetic-v1 (14 cases)',
+    chunks,
+    cases: GOLDEN_CASES.map((c) => ({
+      query: c.query,
+      isHit: (chunk) => chunk.sectionPath.startsWith(c.doc) && chunk.sectionPath.includes(c.expectSection),
+    })),
+  };
+}
+
+const REAL_CASES: Array<{ query: string; expectText: string }> = [
+  // 财务区
+  { query: '研发团队有多少人', expectText: '約300名成員' },
+  { query: '流动负债净额增长到了多少', expectText: '343.3' },
+  { query: '公司预计每个月要烧多少钱', expectText: '28.1' },
+  { query: '账上的现金结余还有多少', expectText: '1,046.2' },
+  { query: '毛利率是怎么改善的', expectText: '24.7%' },
+  { query: '2022年公司亏了多少钱', expectText: '73.7' },
+  // 业务区
+  { query: '产品覆盖了多少个国家的用户', expectText: '200個國家' },
+  { query: '月活跃用户增长情况如何', expectText: '19.1百萬' },
+  { query: '付费用户数量达到多少', expectText: '650,300' },
+  { query: '开放平台付费用户是怎么定义的', expectText: '50美元' },
+  { query: '视频生成用的是哪个模型', expectText: 'Hailuo-02' },
+  { query: '语音合成模型叫什么', expectText: 'Speech-02' },
+];
+
+function buildReal(): Corpus {
+  const md = readFileSync(new URL('../../rag-test-docs/minimax.md', import.meta.url), 'utf8');
+  // Two anchored windows (business overview + financial info) so every expectText is
+  // in-corpus, surrounded by plenty of distractor text (~real retrieval conditions).
+  const windows = ['19.1百萬', '343.3'].map((a) => {
+    const i = md.indexOf(a);
+    if (i < 0) throw new Error(`anchor not found: ${a}`);
+    return md.slice(Math.max(0, i - 60_000), i + 60_000);
+  });
+  const { parents } = chunkMarkdown('MiniMax招股书', windows.join('\n\n'));
+  for (const c of REAL_CASES) {
+    if (!parents.some((p) => p.text.includes(c.expectText))) {
+      throw new Error(`expectText not in corpus window: ${c.expectText}`);
+    }
+  }
+  return {
+    name: `minimax-real (${REAL_CASES.length} cases, ${parents.length} chunks)`,
+    chunks: parents,
+    cases: REAL_CASES.map((c) => ({ query: c.query, isHit: (chunk) => chunk.text.includes(c.expectText) })),
+  };
+}
+
+type Provider = { name: string; embed: (texts: readonly string[]) => Promise<number[][]> };
+
+async function evalProvider(p: Provider, corpus: Corpus) {
+  const inputs = corpus.chunks.map((c) => `${c.sectionPath}\n${c.text}`);
+  const t0 = Date.now();
+  const chunkVecs = await p.embed(inputs);
+  const embedMs = Date.now() - t0;
+  const queryVecs = await p.embed(corpus.cases.map((c) => c.query));
+
+  let r1 = 0, r4 = 0, mrr = 0;
+  const misses: string[] = [];
+  for (let qi = 0; qi < corpus.cases.length; qi++) {
+    const ranked = chunkVecs
+      .map((v, i) => ({ i, s: cosine(queryVecs[qi], v) }))
+      .sort((a, b) => b.s - a.s);
+    const rank = ranked.findIndex((r) => corpus.cases[qi].isHit(corpus.chunks[r.i])) + 1;
+    if (rank === 1) r1++;
+    if (rank >= 1 && rank <= 4) r4++;
+    if (rank >= 1) mrr += 1 / rank;
+    if (rank < 1 || rank > 4) misses.push(`${corpus.cases[qi].query} (rank=${rank || 'none'})`);
+  }
+  const n = corpus.cases.length;
+  return { r1: r1 / n, r4: r4 / n, mrr: mrr / n, embedMs, chunks: corpus.chunks.length, misses };
+}
+
+const pct = (x: number) => `${Math.round(x * 100)}%`.padStart(4);
+
+async function main() {
+  const providers: Provider[] = [
+    { name: 'zhipu-1024', embed: (t) => embedZhipu(t) },
+    { name: 'doubao-v-2048', embed: (t) => embedDoubao(t) },
+    { name: 'doubao-v-1024', embed: (t) => embedDoubao(t, 4, 1024) },
+  ];
+  for (const corpus of [buildSynthetic(), buildReal()]) {
+    console.log(`\n=== ${corpus.name} — ${corpus.chunks.length} chunks ===`);
+    console.log(`${'provider'.padEnd(15)} ${'R@1'.padStart(4)} ${'R@4'.padStart(4)}   MRR    embed`);
+    for (const p of providers) {
+      const m = await evalProvider(p, corpus);
+      console.log(
+        `${p.name.padEnd(15)} ${pct(m.r1)} ${pct(m.r4)}  ${m.mrr.toFixed(3)}  ${(m.embedMs / 1000).toFixed(1)}s/${m.chunks}ch`,
+      );
+      for (const miss of m.misses) console.log(`    ✗ ${miss}`);
+    }
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('❌ A/B failed:', err);
+  process.exit(1);
+});

--- a/scripts/rag-r0-smoke.ts
+++ b/scripts/rag-r0-smoke.ts
@@ -13,7 +13,7 @@ import { eq, cosineDistance } from 'drizzle-orm';
 import { db } from '~/db/db-config';
 import { files } from '~/db/schema/file.schema';
 import { documents, documentChunks } from '~/db/schema/document.schema';
-import { embedTexts, EMBED_DIM, EMBED_MODEL } from '~/server/rag/zhipu';
+import { embedTexts, EMBED_DIM, embedModel } from '~/server/rag/embedding';
 
 const SAMPLES = [
   { section: '§3 退款政策', text: '本合同约定退款费率为 4.5%，七日内可无理由退款。' },
@@ -24,7 +24,7 @@ const QUERY = '保修期有多久？';
 const EXPECTED_SECTION = '§5 保修条款';
 
 async function main() {
-  console.log(`[smoke] embedding ${SAMPLES.length} chunks via ${EMBED_MODEL}@${EMBED_DIM} …`);
+  console.log(`[smoke] embedding ${SAMPLES.length} chunks via ${embedModel()}@${EMBED_DIM} …`);
   const vectors = await embedTexts(SAMPLES.map((s) => `RAG冒烟文档 > ${s.section}\n${s.text}`));
 
   const [file] = await db
@@ -49,7 +49,7 @@ async function main() {
       fileId: file.id,
       ragTier: 'rag',
       ingestStatus: 'ready',
-      embedModel: EMBED_MODEL,
+      embedModel: embedModel(),
       embedDim: EMBED_DIM,
     })
     .returning();

--- a/scripts/rag-r1-smoke.ts
+++ b/scripts/rag-r1-smoke.ts
@@ -13,7 +13,7 @@ import { eq, cosineDistance, isNotNull, and } from 'drizzle-orm';
 import { db } from '~/db/db-config';
 import { files } from '~/db/schema/file.schema';
 import { documents, documentChunks } from '~/db/schema/document.schema';
-import { embedTexts } from '~/server/rag/zhipu';
+import { embedTexts } from '~/server/rag/embedding';
 import { ingestDocument } from '~/server/rag/ingest';
 import { estimateTokens, routeTier } from '~/server/rag/tier';
 

--- a/src/db/schema/document.schema.ts
+++ b/src/db/schema/document.schema.ts
@@ -77,8 +77,8 @@ export const documents = pgTable(
  *
  * NO access columns here (final spec D2 / keystone "零重嵌" rule): visibility resolves at
  * the documents level; chunks are document-scoped so sharing a document never re-embeds.
- * `embedding` is Zhipu embedding-3 @ 1024 dims (final spec D1; the previous 1536 column
- * was never written by any code, so the dim change is free).
+ * `embedding` is 1024-dim, provider-agnostic (doubao-vision via MRL dimensions / zhipu
+ * native — see src/server/rag/embedding.ts; provenance per doc in embed_model/embed_dim).
  */
 export const documentChunks = pgTable(
   'document_chunks',

--- a/src/server/rag/doubao.ts
+++ b/src/server/rag/doubao.ts
@@ -1,0 +1,106 @@
+/**
+ * Doubao (ARK) embedding client — doubao-embedding-vision via /embeddings/multimodal.
+ *
+ * Chosen as the DEFAULT embedding provider by real-corpus A/B (2026-06-11, minimax
+ * prospectus, 12 cases/117 chunks; scripts/rag-embed-ab.ts):
+ *   zhipu-1024 R@1 42% MRR 0.546 | doubao-2048 58%/0.684 | doubao-1024 67%/0.744 ← winner
+ *
+ * API quirk (probed live): `input[]` is ONE multimodal sample (text+image combined),
+ * NOT a batch — every text needs its own request. We run a small concurrency pool
+ * instead. Auth reuses the ARK key (ANTHROPIC_AUTH_TOKEN), same as the chat gateway.
+ * Bonus capability for later (U3/R3): image+text combined embeddings.
+ */
+
+const DEFAULT_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3';
+
+export const DOUBAO_EMBED_MODEL = process.env.ARK_EMBED_MODEL || 'doubao-embedding-vision-250615';
+/**
+ * 1024 via the (probed) MRL `dimensions` param — the A/B WINNER even over the model's
+ * native 2048 (minimax corpus: R@1 67%/MRR 0.744 vs 58%/0.684), and it reuses the
+ * existing vector(1024) column + HNSW untouched. NB: pgvector HNSW caps at 2000 dims,
+ * so the native 2048 couldn't be indexed anyway (halfvec would be the escape hatch).
+ */
+export const DOUBAO_EMBED_DIM = 1024;
+const CONCURRENCY = Number(process.env.ARK_EMBED_CONCURRENCY) || 4;
+
+function baseUrl(): string {
+  return (process.env.ARK_EMBED_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+}
+
+function apiKey(): string {
+  const key = process.env.ARK_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN;
+  if (!key) {
+    throw new Error(
+      'ARK key not set (ARK_API_KEY or ANTHROPIC_AUTH_TOKEN) — required for doubao embeddings.',
+    );
+  }
+  return key;
+}
+
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+interface EmbedOptions {
+  retries?: number;
+  backoffMs?: number;
+  signal?: AbortSignal;
+}
+
+async function embedOne(text: string, key: string, opts: EmbedOptions): Promise<number[]> {
+  const { retries = 3, backoffMs = 1000, signal } = opts;
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, backoffMs * 2 ** (attempt - 1)));
+    try {
+      const res = await fetch(`${baseUrl()}/embeddings/multimodal`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: DOUBAO_EMBED_MODEL, input: [{ type: 'text', text }], dimensions: DOUBAO_EMBED_DIM }),
+        signal,
+      });
+      if (res.ok) {
+        const embedding = (await res.json())?.data?.embedding as number[] | undefined;
+        if (!embedding || embedding.length !== DOUBAO_EMBED_DIM) {
+          throw new Error(
+            `doubao embeddings: expected ${DOUBAO_EMBED_DIM}-dim vector, got ${embedding?.length ?? 'none'}`,
+          );
+        }
+        return embedding;
+      }
+      const body = await res.text().catch(() => '');
+      const error = new Error(`doubao embeddings HTTP ${res.status}: ${body.slice(0, 200)}`);
+      if (!RETRYABLE_STATUS.has(res.status)) throw error;
+      lastError = error;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') throw err;
+      if (err instanceof Error && /expected \d+-dim|HTTP \d{3}/.test(err.message) && !isRetryable(err.message)) {
+        throw err;
+      }
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+  throw lastError ?? new Error('doubao embeddings: exhausted retries');
+}
+
+function isRetryable(message: string): boolean {
+  const m = message.match(/HTTP (\d{3})/);
+  return m ? RETRYABLE_STATUS.has(Number(m[1])) : true;
+}
+
+/** Embed texts via a fixed-size concurrency pool, preserving input order. */
+export async function embedTextsDoubao(
+  texts: readonly string[],
+  opts: EmbedOptions = {},
+): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  const key = apiKey(); // config errors surface before any lane starts
+  const out: number[][] = new Array(texts.length);
+  let next = 0;
+  async function lane() {
+    while (next < texts.length) {
+      const i = next++;
+      out[i] = await embedOne(texts[i], key, opts);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, texts.length) }, lane));
+  return out;
+}

--- a/src/server/rag/embedding.ts
+++ b/src/server/rag/embedding.ts
@@ -1,0 +1,49 @@
+/**
+ * Embedding provider facade — the ONE import for everything that embeds (ingest, search,
+ * eval, smokes). Provider switches via env, column stays vector(1024) for both:
+ *
+ *   EMBED_PROVIDER=doubao (default) — doubao-embedding-vision @1024 via MRL dimensions
+ *     (ARK key; per-text requests with a concurrency pool). Real-corpus A/B winner.
+ *   EMBED_PROVIDER=zhipu            — zhipu embedding-3 @1024 (documented native value),
+ *     so a fallback/switch never needs a schema change — only re-embed.
+ *
+ * documents.embed_model/embed_dim record provenance per doc; a provider/model change is
+ * detected there and forces re-embedding on next ingest (hash-skip is bypassed).
+ */
+import { embedTexts as embedTextsZhipu } from './zhipu';
+import { DOUBAO_EMBED_DIM, DOUBAO_EMBED_MODEL, embedTextsDoubao } from './doubao';
+
+export type EmbedProvider = 'doubao' | 'zhipu';
+
+export function embedProvider(): EmbedProvider {
+  return process.env.EMBED_PROVIDER === 'zhipu' ? 'zhipu' : 'doubao';
+}
+
+/** Unified column dimension — both providers emit 1024 (doubao via its MRL `dimensions`
+ * param, zhipu natively), matching the existing vector(1024) column + HNSW (≤2000 dims). */
+export const EMBED_DIM = 1024;
+
+export function embedModel(): string {
+  return embedProvider() === 'zhipu' ? 'embedding-3' : DOUBAO_EMBED_MODEL;
+}
+
+// Compile-time guard: the doubao constant must match the unified column dim.
+const _dimCheck: typeof EMBED_DIM = DOUBAO_EMBED_DIM;
+void _dimCheck;
+
+export interface EmbedOptions {
+  retries?: number;
+  backoffMs?: number;
+  signal?: AbortSignal;
+}
+
+/** Embed texts with the configured provider. Order-preserving; throws on config errors. */
+export async function embedTexts(
+  texts: readonly string[],
+  opts: EmbedOptions = {},
+): Promise<number[][]> {
+  if (embedProvider() === 'zhipu') {
+    return embedTextsZhipu(texts, { ...opts, dimensions: EMBED_DIM });
+  }
+  return embedTextsDoubao(texts, opts);
+}

--- a/src/server/rag/ingest.ts
+++ b/src/server/rag/ingest.ts
@@ -12,7 +12,8 @@ import { db } from '~/db/db-config';
 import { documents, documentChunks } from '~/db/schema/document.schema';
 import { chunkMarkdown } from './chunker';
 import { chunkStrategy, estimateTokens, type ChunkStrategy } from './tier';
-import { EMBED_DIM, EMBED_MODEL, embedTexts, splitBatches } from './zhipu';
+import { EMBED_DIM, embedModel, embedTexts } from './embedding';
+import { splitBatches } from './zhipu';
 import { indexChunks, removeChunksOfDocument } from '~/search/meilisearch';
 
 /** Flat chunk shape fed to the embed+insert loop (parentIndex -1 = a top-level/single chunk). */
@@ -86,7 +87,7 @@ export async function ingestDocument(documentId: string): Promise<IngestResult> 
       .select({ contentHash: documentChunks.contentHash })
       .from(documentChunks)
       .where(eq(documentChunks.documentId, documentId));
-    const sameModel = doc.embedModel === EMBED_MODEL && doc.embedDim === EMBED_DIM;
+    const sameModel = doc.embedModel === embedModel() && doc.embedDim === EMBED_DIM;
     if (
       sameModel &&
       existing.length === all.length &&
@@ -157,7 +158,7 @@ export async function ingestDocument(documentId: string): Promise<IngestResult> 
       ingestProgress: 100,
       toc,
       ragTier: strategy,
-      embedModel: EMBED_MODEL,
+      embedModel: embedModel(),
       embedDim: EMBED_DIM,
     });
     return { status: 'ready', chunks: all.length };

--- a/src/server/rag/search.ts
+++ b/src/server/rag/search.ts
@@ -13,7 +13,8 @@ import { kbDocuments } from '~/db/schema/kb-document.schema';
 import { ragSearchTrace } from '~/db/schema/rag-trace.schema';
 import { accessibleProjectIds, visibleDocumentsWhere } from '~/server/projects/access';
 import { searchChunks } from '~/search/meilisearch';
-import { embedTexts, rerankDocuments } from './zhipu';
+import { embedTexts } from './embedding';
+import { rerankDocuments } from './zhipu';
 import { rrfFuse } from './fuse';
 
 export interface KbSearchParams {

--- a/tests/unit/rag-doubao-client.test.ts
+++ b/tests/unit/rag-doubao-client.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+/**
+ * Unit tests for the Doubao embedding client (U0.5) — mocked fetch. Pins the contracts
+ * the ingest pipeline relies on: per-text requests (the API has NO batching) with order
+ * preserved under concurrency, MRL dimensions=1024 in every request, retry on 429/5xx
+ * but not 4xx, dim-drift guard, and clear config errors.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DOUBAO_EMBED_DIM, embedTextsDoubao } from '../../src/server/rag/doubao';
+
+function okOne(dim = DOUBAO_EMBED_DIM) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ data: { embedding: Array.from({ length: dim }, () => 0.1) } }),
+    text: async () => '',
+  } as unknown as Response;
+}
+
+function httpError(status: number) {
+  return { ok: false, status, json: async () => ({}), text: async () => `s${status}` } as unknown as Response;
+}
+
+describe('embedTextsDoubao', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-ark-key';
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.ARK_API_KEY;
+  });
+
+  it('sends ONE request per text with dimensions=1024, preserving order under concurrency', async () => {
+    fetchMock.mockResolvedValue(okOne());
+    const texts = Array.from({ length: 9 }, (_, i) => `t${i}`);
+    const vectors = await embedTextsDoubao(texts);
+
+    expect(fetchMock).toHaveBeenCalledTimes(9);
+    const bodies = fetchMock.mock.calls.map((c) => JSON.parse(c[1].body as string));
+    for (const b of bodies) {
+      expect(b.dimensions).toBe(1024);
+      expect(b.input).toHaveLength(1); // input[] is one multimodal sample, never a batch
+    }
+    // order preserved regardless of lane interleaving
+    const sent = bodies.map((b) => b.input[0].text).sort();
+    expect(sent).toEqual([...texts].sort());
+    expect(vectors).toHaveLength(9);
+    expect(vectors[0]).toHaveLength(DOUBAO_EMBED_DIM);
+  });
+
+  it('retries on 429 then succeeds; does NOT retry on 400', async () => {
+    fetchMock.mockResolvedValueOnce(httpError(429)).mockResolvedValueOnce(okOne());
+    await expect(embedTextsDoubao(['a'], { backoffMs: 1 })).resolves.toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(httpError(400));
+    await expect(embedTextsDoubao(['a'], { backoffMs: 1 })).rejects.toThrow('HTTP 400');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a wrong-dimension response (provider drift guard)', async () => {
+    fetchMock.mockResolvedValue(okOne(2048));
+    await expect(embedTextsDoubao(['a'], { backoffMs: 1 })).rejects.toThrow('1024-dim');
+  });
+
+  it('throws a clear error when no ARK key is set', async () => {
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    await expect(embedTextsDoubao(['a'])).rejects.toThrow('ARK key not set');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns [] for empty input without any request', async () => {
+    await expect(embedTextsDoubao([])).resolves.toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## U0.5 Embedding Provider 切换

Owner 要求平行测试 doubao-embedding-vision。真实招股书语料 A/B（12 题/117 chunks）：

| provider | R@1 | R@4 | MRR | 吞吐 |
|---|---|---|---|---|
| zhipu-1024 | 42% | 67% | 0.546 | 17.2s |
| doubao-v-2048 | 58% | 75% | 0.684 | 11.6s |
| **doubao-v-1024** | **67%** | 75% | **0.744** | **9.5s** ← 胜出 |

**关键发现**：①pgvector HNSW 上限 2000 维——豆包原生 2048 **进不了索引**（实测报错）；②豆包实测支持 MRL `dimensions:1024`，且质量**反超**自家 2048 → **零迁移**复用现有 vector(1024)+HNSW（已生成的 2048 迁移干净回滚，journal 完好）。

**实现**：doubao 客户端（无批量 API → 并发池）+ provider 门面（`EMBED_PROVIDER` env 切换，双方统一 1024 维，切换永不动 schema）+ compose worker 补 ARK key。

**验证**：unit 175/175；U0 冒烟在豆包真实路径 PASS（仅 ARK key，证明默认生效）；黄金集 v1 全模式 100% 零回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)