### PR TITLE
feat(rag): U1 — parser sidecar（opendataloader 容器化）+ ingest 前置解析

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ infra/tunnel/config.yml
 infra/prod/dynamic/origin.crt
 infra/prod/dynamic/origin.key
 infra/prod/dynamic/origin-ca.yml
+parser-sidecar/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,15 @@ services:
     profiles: ['tunnel']
     restart: unless-stopped
 
+  # PDF parser sidecar — owns the Java dependency (ingest-UX spec §7, U1).
+  # The future OCR engine plugs in here as another route; app/worker images stay slim.
+  parser:
+    build:
+      context: ./parser-sidecar
+    container_name: ex0-parser
+    restart: unless-stopped
+    profiles: ['dev', 'selfhost', 'prod']
+
   # Background workers for BullMQ (cron + indexing, etc.)
   # pull_policy: never — use locally built image; do not pull from registry
   worker:
@@ -205,6 +214,7 @@ services:
       # The ingest pipeline embeds in this worker (see src/server/rag/embedding.ts).
       ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
       EMBED_PROVIDER: ${EMBED_PROVIDER:-}
+      PARSER_SIDECAR_URL: ${PARSER_SIDECAR_URL:-http://parser:7800}
       ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
       EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-}
     extra_hosts:
@@ -262,6 +272,7 @@ services:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?}
       # Zhipu key — GLM image tool + Zhipu MCP servers + RAG embedding/rerank (R0)
       ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
+      PARSER_SIDECAR_URL: ${PARSER_SIDECAR_URL:-http://parser:7800}
       # Claude Agent SDK configuration
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?}
       ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}

--- a/parser-sidecar/Dockerfile
+++ b/parser-sidecar/Dockerfile
@@ -1,0 +1,13 @@
+# Parser sidecar — owns the Java dependency so app/worker images stay slim
+# (ingest-UX spec §7; future OCR engine plugs in here as another route).
+FROM node:20-slim
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openjdk-17-jre-headless \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /srv/parser
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+COPY server.mjs ./
+EXPOSE 7800
+USER node
+CMD ["node", "server.mjs"]

--- a/parser-sidecar/package-lock.json
+++ b/parser-sidecar/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "oxygenie-parser-sidecar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oxygenie-parser-sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opendataloader/pdf": "^2.4.7"
+      }
+    },
+    "node_modules/@opendataloader/pdf": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@opendataloader/pdf/-/pdf-2.4.7.tgz",
+      "integrity": "sha512-gVkweTbNKKWGHxOWzDmCuWfwvU+ierBrRIDi5ux8MLG0JOeYnzXOt1gojuEbVsQvSIUhE0QIkTshp/iru3cX0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "commander": "^14.0.3"
+      },
+      "bin": {
+        "opendataloader-pdf": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/parser-sidecar/package.json
+++ b/parser-sidecar/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "oxygenie-parser-sidecar",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "description": "PDF→Markdown parser sidecar (opendataloader-pdf; owns the Java dependency)",
+  "scripts": { "start": "node server.mjs" },
+  "dependencies": { "@opendataloader/pdf": "^2.4.7" }
+}

--- a/parser-sidecar/server.mjs
+++ b/parser-sidecar/server.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Parser sidecar — PDF → Markdown over HTTP (ingest-UX spec §7, U1).
+ *
+ * Owns the Java dependency (opendataloader-pdf) so the app/worker images stay slim
+ * (Owner decision 2026-06-11: dedicated sidecar; the future OCR engine plugs in here
+ * too as another route). Zero npm deps besides the engine; plain node http.
+ *
+ *   GET  /health                   → { ok, engine }
+ *   POST /parse?mode=structured    → body: raw PDF bytes
+ *        mode=structured : full layout analysis (headings/tables/reading order)
+ *        mode=simple     : fast text-layer extraction (--reading-order off)
+ *        mode=probe      : like simple but returns stats only (no markdown) — feeds
+ *                          the "system recommends an engine" UX (spec §3)
+ *        → { ok, engine, mode, pages, chars, ms, markdown? , recommend? }
+ *
+ * Run locally:  JAVA_HOME=/opt/homebrew/opt/openjdk node parser-sidecar/server.mjs
+ * Container:    see parser-sidecar/Dockerfile (bundles a headless JRE).
+ */
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PORT = Number(process.env.PARSER_PORT) || 7800;
+const MAX_BODY = Number(process.env.PARSER_MAX_BYTES) || 200 * 1024 * 1024; // 200MB
+const TIMEOUT_MS = Number(process.env.PARSER_TIMEOUT_MS) || 10 * 60_000; // 10min
+const CLI = join(dirname(fileURLToPath(import.meta.url)), 'node_modules', '.bin', 'opendataloader-pdf');
+
+/** Per-page marker so ingest can map chunks → page ranges later. */
+export const PAGE_MARK = (n) => `<!-- odl-page ${n} -->`;
+
+function run(args) {
+  return new Promise((resolve, reject) => {
+    execFile(CLI, args, { timeout: TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024 }, (err, stdout, stderr) =>
+      err ? reject(new Error(`${err.message}\n${String(stderr).slice(0, 500)}`)) : resolve(String(stdout)),
+    );
+  });
+}
+
+async function parsePdf(bytes, mode) {
+  const dir = await mkdtemp(join(tmpdir(), 'odl-'));
+  try {
+    const input = join(dir, 'input.pdf');
+    await writeFile(input, bytes);
+    const args = [
+      '-o', dir, '-f', 'markdown', '--image-output', 'off', '-q',
+      '--markdown-page-separator', '<!-- odl-page %page-number% -->',
+    ];
+    if (mode !== 'structured') args.push('--reading-order', 'off');
+    const t0 = Date.now();
+    await run([...args, input]);
+    const md = (await readdir(dir)).find((f) => f.endsWith('.md'));
+    const markdown = md ? await readFile(join(dir, md), 'utf8') : '';
+    const pages = (markdown.match(/<!-- odl-page \d+ -->/g) || []).length;
+    const chars = markdown.replace(/<!-- odl-page \d+ -->/g, '').replace(/\s+/g, '').length;
+    return { markdown, pages, chars, ms: Date.now() - t0 };
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/** Engine recommendation heuristic (spec §3): near-zero text per page → scanned. */
+function recommend(pages, chars, markdown) {
+  if (pages > 0 && chars / pages < 30) return { method: 'ocr', reason: '每页文字极少，疑似扫描件/图片型 PDF' };
+  const headings = (markdown.match(/^#{1,6} /gm) || []).length;
+  if (headings >= Math.max(3, pages / 10) || /\n\|.+\|\n/.test(markdown)) {
+    return { method: 'structured', reason: '检测到标题层级/表格，建议结构化解析' };
+  }
+  return { method: 'simple', reason: '纯文本为主，快速解析即可' };
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const parts = [];
+    let size = 0;
+    req.on('data', (c) => {
+      size += c.length;
+      if (size > MAX_BODY) { reject(new Error('body too large')); req.destroy(); return; }
+      parts.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(parts)));
+    req.on('error', reject);
+  });
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, 'http://x');
+  const send = (code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)); };
+  try {
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return send(200, { ok: true, engine: 'opendataloader-pdf' });
+    }
+    if (req.method === 'POST' && url.pathname === '/parse') {
+      const mode = url.searchParams.get('mode') || 'structured';
+      if (!['structured', 'simple', 'probe'].includes(mode)) return send(400, { ok: false, error: `bad mode ${mode}` });
+      const bytes = await readBody(req);
+      if (bytes.length === 0) return send(400, { ok: false, error: 'empty body' });
+      const r = await parsePdf(bytes, mode === 'probe' ? 'simple' : mode);
+      const base = { ok: true, engine: 'opendataloader-pdf', mode, pages: r.pages, chars: r.chars, ms: r.ms };
+      if (mode === 'probe') return send(200, { ...base, recommend: recommend(r.pages, r.chars, r.markdown) });
+      return send(200, { ...base, markdown: r.markdown });
+    }
+    send(404, { ok: false, error: 'not found' });
+  } catch (err) {
+    send(500, { ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+});
+
+server.listen(PORT, () => console.log(`[parser-sidecar] listening on :${PORT} (engine: opendataloader-pdf)`));

--- a/scripts/rag-u1-smoke.ts
+++ b/scripts/rag-u1-smoke.ts
@@ -1,0 +1,99 @@
+/**
+ * RAG U1 smoke — parser sidecar end to end with the REAL 716-page MiniMax prospectus
+ * (ingest-UX spec §7/§4 Exit): spawn the sidecar → probe (engine recommendation) →
+ * structured parse → ingest a real subset → kb_search hits a real financial needle.
+ *
+ *   DATABASE_URL=... ANTHROPIC_AUTH_TOKEN=<ark> JAVA_HOME=<jdk> npx tsx scripts/rag-u1-smoke.ts
+ *
+ * Notes: ingests a ~120k-char financial/business window (not all 716 pages) to keep the
+ * smoke under ~2min of embedding; the S3-fetch branch of the parse pre-stage is not
+ * exercised here (no MinIO bridge on host) — covered in compose. Cleans up after itself.
+ */
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { eq } from 'drizzle-orm';
+import { db } from '~/db/db-config';
+import { files } from '~/db/schema/file.schema';
+import { documents } from '~/db/schema/document.schema';
+import { ingestDocument } from '~/server/rag/ingest';
+import { searchKb } from '~/server/rag/search';
+import { parsePdfViaSidecar, probePdfViaSidecar, stripPageMarkers } from '~/server/rag/parser-client';
+
+const PDF = '/Users/peng/Dev/Projects/active/ClaudeAgentChat/rag-test-docs/minimax.pdf';
+
+async function waitHealthy(url: string, timeoutMs = 30_000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    try {
+      const r = await fetch(`${url}/health`);
+      if (r.ok) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error('sidecar did not become healthy');
+}
+
+async function main() {
+  process.env.PARSER_SIDECAR_URL = 'http://127.0.0.1:7800';
+  const sidecar = spawn('node', ['parser-sidecar/server.mjs'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    env: { ...process.env, JAVA_HOME: process.env.JAVA_HOME || '/opt/homebrew/opt/openjdk', PATH: `${process.env.JAVA_HOME || '/opt/homebrew/opt/openjdk'}/bin:${process.env.PATH}` },
+  });
+  try {
+    await waitHealthy('http://127.0.0.1:7800');
+    console.log('[smoke] sidecar healthy');
+
+    const bytes = readFileSync(PDF);
+
+    // ① probe → engine recommendation (text-layer PDF must NOT recommend ocr)
+    const probe = await probePdfViaSidecar(bytes);
+    if (!probe.ok || !probe.recommend) throw new Error(`probe failed: ${probe.error}`);
+    console.log(`[smoke] probe: ${probe.pages}p ${probe.chars}chars → recommend=${probe.recommend.method} (${probe.recommend.reason})`);
+    if (probe.recommend.method === 'ocr') throw new Error('text-layer PDF misclassified as scanned');
+
+    // ② structured parse of the full prospectus
+    const parsed = await parsePdfViaSidecar(bytes, 'structured');
+    if (!parsed.ok || !parsed.markdown) throw new Error(`parse failed: ${parsed.error}`);
+    const md = stripPageMarkers(parsed.markdown);
+    const headings = (md.match(/^#{1,6} /gm) || []).length;
+    console.log(`[smoke] structured parse: ${parsed.pages}p, ${Math.round(md.length / 1024)}KB md, ${headings} headings, ${(parsed.ms / 1000).toFixed(1)}s`);
+    if (parsed.pages < 700 || md.length < 500_000 || headings < 300) throw new Error('parse output below expectations');
+
+    // ③ ingest a real subset (financial + business windows) and retrieve a real needle
+    const windows = ['19.1百萬', '343.3'].map((a) => {
+      const i = md.indexOf(a);
+      if (i < 0) throw new Error(`anchor missing in parsed md: ${a}`);
+      return md.slice(Math.max(0, i - 60_000), i + 60_000);
+    });
+    const [file] = await db.insert(files).values({ key: `rag-u1/${Date.now()}`, clientId: 'rag-smoke', fileType: 'text/markdown', name: 'minimax-subset.md', size: 0, url: '' }).returning();
+    const [doc] = await db.insert(documents).values({
+      title: 'MiniMax招股书(U1冒烟子集)', content: windows.join('\n\n'), sourceType: 'rag-smoke',
+      userId: 'rag-u1-user', fileId: file.id, parseMethod: 'structured', parseStatus: 'ready', ingestStatus: 'pending',
+    }).returning();
+    try {
+      const r = await ingestDocument(doc.id);
+      if (r.status !== 'ready') throw new Error(`ingest: ${r.status} ${r.reason}`);
+      console.log(`[smoke] ingested subset: ${r.chunks} chunks`);
+      // Pipeline smoke, not a quality eval (that's golden-set v2): vector-only here
+      // (no Meili on host, rerank off), so assert a high-signal needle lands in top-8.
+      const hits = await searchKb('rag-u1-user', { query: '付费用户数量达到多少', k: 8, trace: false });
+      console.log('[smoke] top hit:', hits[0]?.sectionPath, '|', hits[0]?.text.slice(0, 60));
+      if (!hits.some((h) => h.text.includes('650,300') || h.text.includes('19.1百萬'))) {
+        throw new Error('real needle not retrieved in top-8 (650,300 / 19.1百萬)');
+      }
+      console.log('✅ U1 smoke PASS — sidecar probe/parse + real-corpus ingest + retrieval verified');
+    } finally {
+      await db.delete(documents).where(eq(documents.id, doc.id));
+      await db.delete(files).where(eq(files.id, file.id));
+      console.log('[smoke] cleaned up');
+    }
+  } finally {
+    sidecar.kill('SIGTERM');
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('❌ U1 smoke FAIL:', err);
+  process.exit(1);
+});

--- a/src/server/rag/ingest.ts
+++ b/src/server/rag/ingest.ts
@@ -10,10 +10,12 @@ import { createHash } from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { db } from '~/db/db-config';
 import { documents, documentChunks } from '~/db/schema/document.schema';
+import { files } from '~/db/schema/file.schema';
 import { chunkMarkdown } from './chunker';
 import { chunkStrategy, estimateTokens, type ChunkStrategy } from './tier';
 import { EMBED_DIM, embedModel, embedTexts } from './embedding';
 import { splitBatches } from './zhipu';
+import { parsePdfViaSidecar, stripPageMarkers } from './parser-client';
 import { indexChunks, removeChunksOfDocument } from '~/search/meilisearch';
 
 /** Flat chunk shape fed to the embed+insert loop (parentIndex -1 = a top-level/single chunk). */
@@ -64,12 +66,62 @@ export interface IngestResult {
   reason?: string;
 }
 
+/**
+ * Parse pre-stage (U1, ingest-UX spec §4): a KB document created from a binary upload has
+ * no content yet — fetch the file and run it through the parser sidecar, honoring the
+ * user-chosen/recommended engine (documents.parse_method; default structured). Parse and
+ * embed are SEPARATE state machines: a parse failure marks parse_status='failed'
+ * (visible + retryable with another engine, spec DR-7) without touching chunk state.
+ */
+async function parseStage(doc: typeof documents.$inferSelect): Promise<string | null> {
+  if (!doc.fileId) return null;
+  const [file] = await db.select().from(files).where(eq(files.id, doc.fileId)).limit(1);
+  const name = (file?.name || doc.filename || '').toLowerCase();
+  if (!file || !name.endsWith('.pdf')) return null; // non-PDF rich types stay on markitdown (U1 scope)
+
+  await setProgress(doc.id, { parseStatus: 'processing' });
+  try {
+    // Lazy import: ~/server/s3 pulls in ~/conf/file whose env validation requires S3_*
+    // vars — only environments that actually parse uploads (worker/app in compose) have
+    // them; importing eagerly would crash host-local tools that never touch S3.
+    const { S3StaticFileImpl } = await import('~/server/s3/s3');
+    const url = await new S3StaticFileImpl().getFullFileUrl(file.key);
+    const blob = await fetch(url);
+    if (!blob.ok) throw new Error(`file fetch HTTP ${blob.status}`);
+    const bytes = Buffer.from(await blob.arrayBuffer());
+
+    const mode = doc.parseMethod === 'simple' ? 'simple' : 'structured';
+    const parsed = await parsePdfViaSidecar(bytes, mode);
+    if (!parsed.ok || !parsed.markdown?.trim()) {
+      throw new Error(parsed.error || 'parser produced no text (scanned PDF? try OCR when available)');
+    }
+    const markdown = stripPageMarkers(parsed.markdown);
+    await setProgress(doc.id, {
+      content: markdown,
+      parseStatus: 'ready',
+      parseMethod: mode,
+      tokenEstimate: estimateTokens(markdown),
+      totalCharCount: markdown.length,
+      totalLineCount: markdown.split(/\r?\n/).length,
+    });
+    return markdown;
+  } catch (err) {
+    console.error('[rag-ingest] parse stage failed:', doc.id, err);
+    await setProgress(doc.id, { parseStatus: 'failed' }).catch(() => {});
+    return null;
+  }
+}
+
 export async function ingestDocument(documentId: string): Promise<IngestResult> {
   const [doc] = await db.select().from(documents).where(eq(documents.id, documentId)).limit(1);
   if (!doc) return { status: 'failed', reason: `document ${documentId} not found` };
   if (!doc.content?.trim()) {
-    await setProgress(documentId, { ingestStatus: 'failed' });
-    return { status: 'failed', reason: 'empty content' };
+    const parsed = await parseStage(doc);
+    if (!parsed) {
+      await setProgress(documentId, { ingestStatus: 'failed' });
+      return { status: 'failed', reason: 'empty content (parse pre-stage unavailable or failed)' };
+    }
+    doc.content = parsed;
   }
 
   try {

--- a/src/server/rag/parser-client.ts
+++ b/src/server/rag/parser-client.ts
@@ -1,0 +1,81 @@
+/**
+ * Parser sidecar client (U1, ingest-UX spec §7) — PDF → Markdown via the dedicated
+ * sidecar container (which owns the Java/opendataloader dependency).
+ *
+ * PARSER_SIDECAR_URL: http://parser:7800 in compose; http://127.0.0.1:7800 local dev
+ * (run: JAVA_HOME=/opt/homebrew/opt/openjdk node parser-sidecar/server.mjs).
+ */
+
+export type ParseMode = 'structured' | 'simple' | 'probe';
+
+export interface SidecarParseResult {
+  ok: boolean;
+  mode: ParseMode;
+  pages: number;
+  chars: number;
+  ms: number;
+  markdown?: string;
+  recommend?: { method: 'structured' | 'simple' | 'ocr'; reason: string };
+  error?: string;
+}
+
+function sidecarUrl(): string {
+  return (process.env.PARSER_SIDECAR_URL || 'http://127.0.0.1:7800').replace(/\/$/, '');
+}
+
+export function sidecarConfigured(): boolean {
+  return Boolean(process.env.PARSER_SIDECAR_URL);
+}
+
+/** Strip the sidecar's page markers for clean chunking (page-range mapping = follow-up). */
+export function stripPageMarkers(markdown: string): string {
+  return markdown.replace(/<!-- odl-page \d+ -->\n?/g, '');
+}
+
+export async function parsePdfViaSidecar(
+  bytes: Uint8Array | Buffer,
+  mode: Exclude<ParseMode, 'probe'> = 'structured',
+  opts: { timeoutMs?: number } = {},
+): Promise<SidecarParseResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 10 * 60_000);
+  try {
+    const res = await fetch(`${sidecarUrl()}/parse?mode=${mode}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/pdf' },
+      body: bytes as BodyInit,
+      signal: controller.signal,
+    });
+    const json = (await res.json()) as SidecarParseResult;
+    if (!res.ok || !json.ok) {
+      return { ok: false, mode, pages: 0, chars: 0, ms: 0, error: json.error ?? `HTTP ${res.status}` };
+    }
+    return json;
+  } catch (err) {
+    return {
+      ok: false, mode, pages: 0, chars: 0, ms: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Fast text-layer probe → engine recommendation (spec §3 "system recommends"). */
+export async function probePdfViaSidecar(bytes: Uint8Array | Buffer): Promise<SidecarParseResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 60_000);
+  try {
+    const res = await fetch(`${sidecarUrl()}/parse?mode=probe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/pdf' },
+      body: bytes as BodyInit,
+      signal: controller.signal,
+    });
+    return (await res.json()) as SidecarParseResult;
+  } catch (err) {
+    return { ok: false, mode: 'probe', pages: 0, chars: 0, ms: 0, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## U1：大 PDF 解析路径打通

**Owner 已拍板的 sidecar 方案落地**：Java 依赖（opendataloader）独立容器，app/worker 镜像不动；将来 OCR 引擎（模型未锁定，可能用多模态 VLM）作为另一路由插进同一个 sidecar。

- **parser-sidecar/**：零依赖 node http 包装 @opendataloader/pdf；`probe` 模式返回文本层统计 + **引擎推荐**（每页近零字→ocr / 有标题表格→structured / 否则 simple），直接喂 §3 的「系统推荐+可改」交互
- **ingest 前置解析**：无 content 的 PDF 文档 → 取文件 → 按 `parse_method` 走 sidecar → 落 Markdown → 照常嵌入；解析/嵌入两状态机独立（解析失败可见、可换引擎重试）
- compose 新增 `parser` 服务

**实测（716 页 MiniMax 招股书）**：probe 正确推荐 structured → 解析 716p/585KB/591 标题/6.6s → 真实子集 324 chunks 入库 → kb_search 真实针题 top-1 命中；**容器镜像内复测 6.5s**。Unit 175/175。

已知边界：chunk→页码映射为后续小任务；S3 取件分支本地无 MinIO 桥未冒烟（compose 路径覆盖）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)