### PR TITLE
feat(rag): 黄金集 v2 — 716 页真实招股书全量过生产管线（基线落定）

### DIFF
--- a/scripts/rag-eval-v2.ts
+++ b/scripts/rag-eval-v2.ts
@@ -1,0 +1,105 @@
+/**
+ * RAG golden-set eval v2 — REAL corpus: the FULL 716-page MiniMax prospectus through the
+ * production pipeline (ingest → pgvector+Meili → searchKb), 3 ablation modes.
+ *
+ *   DATABASE_URL=... ANTHROPIC_AUTH_TOKEN=<ark> [MEILI_HOST/MEILI_API_KEY] \
+ *     npx tsx scripts/rag-eval-v2.ts [--cleanup]
+ *
+ * The golden document PERSISTS between runs (sourceType 'rag-golden'): the first run
+ * embeds the whole book (~minutes); later runs hit ingest's hash-skip and only query.
+ * --cleanup deletes it. Eval queries run with trace:false.
+ */
+import { readFileSync } from 'node:fs';
+import { and, eq } from 'drizzle-orm';
+import { db } from '~/db/db-config';
+import { files } from '~/db/schema/file.schema';
+import { documents } from '~/db/schema/document.schema';
+import { ingestDocument } from '~/server/rag/ingest';
+import { searchKb, type KbSearchParams } from '~/server/rag/search';
+import { REAL_GOLDEN_CASES, REAL_GOLDEN_DOC_TITLE } from '../tests/golden/rag-golden-set';
+
+const MD_PATH = '/Users/peng/Dev/Projects/active/ClaudeAgentChat/rag-test-docs/minimax.md';
+const EVAL_USER = 'rag-golden-user';
+const K = 8;
+
+type Mode = 'vector' | 'hybrid' | '+rerank';
+const MODES: Record<Mode, Partial<KbSearchParams>> = {
+  vector: { skipBm25: true, skipRerank: true },
+  hybrid: { skipRerank: true },
+  '+rerank': { skipRerank: false },
+};
+
+async function ensureGoldenDoc(): Promise<string> {
+  const [existing] = await db
+    .select()
+    .from(documents)
+    .where(and(eq(documents.sourceType, 'rag-golden'), eq(documents.title, REAL_GOLDEN_DOC_TITLE)))
+    .limit(1);
+  if (existing) {
+    console.log(`[eval-v2] reusing golden doc ${existing.id} (ingest=${existing.ingestStatus})`);
+    if (existing.ingestStatus !== 'ready') {
+      const r = await ingestDocument(existing.id);
+      if (r.status === 'failed') throw new Error(`re-ingest failed: ${r.reason}`);
+    }
+    return existing.id;
+  }
+  const md = readFileSync(MD_PATH, 'utf8').replace(/<!-- page \d+ -->\n?/g, '');
+  const [f] = await db
+    .insert(files)
+    .values({ key: `rag-golden/minimax-${Date.now()}`, clientId: EVAL_USER, fileType: 'text/markdown', name: 'minimax.md', size: 0, url: '' })
+    .returning();
+  const [d] = await db
+    .insert(documents)
+    .values({ title: REAL_GOLDEN_DOC_TITLE, content: md, sourceType: 'rag-golden', userId: EVAL_USER, fileId: f.id, parseMethod: 'structured', parseStatus: 'ready', ingestStatus: 'pending' })
+    .returning();
+  console.log('[eval-v2] embedding the FULL prospectus (first run only — minutes) …');
+  const t0 = Date.now();
+  const r = await ingestDocument(d.id);
+  if (r.status !== 'ready') throw new Error(`ingest failed: ${r.reason}`);
+  console.log(`[eval-v2] ingested ${r.chunks} chunks in ${Math.round((Date.now() - t0) / 1000)}s`);
+  return d.id;
+}
+
+async function cleanup() {
+  const rows = await db.select().from(documents).where(eq(documents.sourceType, 'rag-golden'));
+  for (const d of rows) {
+    await db.delete(documents).where(eq(documents.id, d.id));
+    if (d.fileId) await db.delete(files).where(eq(files.id, d.fileId));
+  }
+  console.log(`[eval-v2] cleaned up ${rows.length} golden doc(s)`);
+}
+
+const pct = (x: number) => `${Math.round(x * 100)}%`.padStart(4);
+
+async function main() {
+  if (process.argv.includes('--cleanup')) { await cleanup(); process.exit(0); }
+
+  await ensureGoldenDoc();
+
+  let bm25Available = true;
+  try { const { meili } = await import('~/search/meilisearch'); await meili.health(); } catch { bm25Available = false; }
+
+  console.log(`\n=== golden v2 — FULL minimax, ${REAL_GOLDEN_CASES.length} cases, k=${K} ===`);
+  if (!bm25Available) console.log('⚠️  Meili unreachable: hybrid/+rerank degenerate to vector-only');
+  console.log(`${'mode'.padEnd(9)} ${'R@1'.padStart(4)} ${'R@4'.padStart(4)} ${'R@8'.padStart(4)}   MRR`);
+
+  for (const mode of Object.keys(MODES) as Mode[]) {
+    let r1 = 0, r4 = 0, r8 = 0, mrr = 0;
+    const misses: string[] = [];
+    for (const c of REAL_GOLDEN_CASES) {
+      const hits = await searchKb(EVAL_USER, { query: c.query, k: K, ...MODES[mode], trace: false });
+      const rank = hits.findIndex((h) => h.text.includes(c.expectText)) + 1;
+      if (rank === 1) r1++;
+      if (rank >= 1 && rank <= 4) r4++;
+      if (rank >= 1) { r8++; mrr += 1 / rank; }
+      if (rank < 1 || rank > 4) misses.push(`[${c.type}] ${c.query} (rank=${rank || 'none'})`);
+    }
+    const n = REAL_GOLDEN_CASES.length;
+    console.log(`${mode.padEnd(9)} ${pct(r1 / n)} ${pct(r4 / n)} ${pct(r8 / n)}  ${(mrr / n).toFixed(3)}`);
+    for (const m of misses) console.log(`    ✗ ${m}`);
+  }
+  console.log('\n(golden doc kept for re-runs — `--cleanup` to remove)');
+  process.exit(0);
+}
+
+main().catch((err) => { console.error('❌ eval-v2 failed:', err); process.exit(1); });

--- a/tests/golden/rag-golden-set.ts
+++ b/tests/golden/rag-golden-set.ts
@@ -72,3 +72,31 @@ export const GOLDEN_CASES: GoldenCase[] = [
   { doc: '北辰数据中心运维规范', query: '灾备演练多久一次', expectSection: '灾备演练', type: 'keyword' },
   { doc: '北辰数据中心运维规范', query: '故障恢复的时间目标', expectSection: '灾备演练', type: 'paraphrase' },
 ];
+
+// ── Golden set v2: REAL corpus (rag-test-docs/minimax.md, 716-page prospectus) ────────
+// Judged by expectText-in-chunk (no section labels in real docs). Queries are
+// paraphrases mined from real facts — none contain the expected literal.
+
+export interface RealGoldenCase {
+  query: string;
+  expectText: string;
+  type: 'keyword' | 'paraphrase' | 'entity';
+}
+
+/** Title used for the persistent golden document row (sourceType 'rag-golden'). */
+export const REAL_GOLDEN_DOC_TITLE = 'MiniMax招股书(golden-v2)';
+
+export const REAL_GOLDEN_CASES: RealGoldenCase[] = [
+  { query: '研发团队有多少人', expectText: '約300名成員', type: 'paraphrase' },
+  { query: '流动负债净额增长到了多少', expectText: '343.3', type: 'paraphrase' },
+  { query: '公司预计每个月要烧多少钱', expectText: '28.1', type: 'paraphrase' },
+  { query: '账上的现金结余还有多少', expectText: '1,046.2', type: 'paraphrase' },
+  { query: '毛利率是怎么改善的', expectText: '24.7%', type: 'paraphrase' },
+  { query: '2022年公司亏了多少钱', expectText: '73.7', type: 'paraphrase' },
+  { query: '产品覆盖了多少个国家的用户', expectText: '200個國家', type: 'paraphrase' },
+  { query: '月活跃用户增长情况如何', expectText: '19.1百萬', type: 'paraphrase' },
+  { query: '付费用户数量达到多少', expectText: '650,300', type: 'keyword' },
+  { query: '开放平台付费用户是怎么定义的', expectText: '50美元', type: 'paraphrase' },
+  { query: '视频生成用的是哪个模型', expectText: 'Hailuo-02', type: 'entity' },
+  { query: '语音合成模型叫什么', expectText: 'Speech-02', type: 'entity' },
+];


### PR DESCRIPTION
全书 1467 chunks 入库（121s）+ 12 道真实针题 × 3 消融模式：

| mode | R@1 | R@4 | R@8 | MRR |
|---|---|---|---|---|
| vector | 58% | 83% | **100%** | 0.725 |
| hybrid（生产配置） | 50% | 75% | **100%** | 0.656 |
| +rerank | 50% | 75% | **100%** | 0.658 |

**发现**：①全模式 R@8=100%——k=8 的 kb_search 在全书干扰下零漏召，端到端可用性在真实规模上成立；②BM25 腿在本题集为负贡献——但题集刻意全改写（BM25 最坏情况），生产保持 hybrid，待 v2.1 补 keyword/条款号题再公平裁决；③rerank 中性，维持默认关。

黄金文档持久化复用（hash-skip），`--cleanup` 可清。

🤖 Generated with [Claude Code](https://claude.com/claude-code)