### PR TITLE
feat(rag): 黄金集 v2.1 — keyword/实体/条款号题 + 按题型分桶评测（BM25/rerank 公平复判）

### DIFF
--- a/scripts/rag-eval-v2.ts
+++ b/scripts/rag-eval-v2.ts
@@ -86,6 +86,9 @@ async function main() {
   for (const mode of Object.keys(MODES) as Mode[]) {
     let r1 = 0, r4 = 0, r8 = 0, mrr = 0;
     const misses: string[] = [];
+    // v2.1: per-type breakdown — the lexical-anchor cases (keyword/entity/clause) exist
+    // to judge the BM25 leg / rerank on THEIR home turf instead of a paraphrase-only set.
+    const byType = new Map<string, { n: number; r1: number; r4: number; mrr: number }>();
     for (const c of REAL_GOLDEN_CASES) {
       const hits = await searchKb(EVAL_USER, { query: c.query, k: K, ...MODES[mode], trace: false });
       const rank = hits.findIndex((h) => h.text.includes(c.expectText)) + 1;
@@ -93,9 +96,18 @@ async function main() {
       if (rank >= 1 && rank <= 4) r4++;
       if (rank >= 1) { r8++; mrr += 1 / rank; }
       if (rank < 1 || rank > 4) misses.push(`[${c.type}] ${c.query} (rank=${rank || 'none'})`);
+      const t = byType.get(c.type) ?? { n: 0, r1: 0, r4: 0, mrr: 0 };
+      t.n++;
+      if (rank === 1) t.r1++;
+      if (rank >= 1 && rank <= 4) t.r4++;
+      if (rank >= 1) t.mrr += 1 / rank;
+      byType.set(c.type, t);
     }
     const n = REAL_GOLDEN_CASES.length;
     console.log(`${mode.padEnd(9)} ${pct(r1 / n)} ${pct(r4 / n)} ${pct(r8 / n)}  ${(mrr / n).toFixed(3)}`);
+    for (const [type, t] of [...byType.entries()].sort()) {
+      console.log(`    ${type.padEnd(10)} n=${String(t.n).padEnd(2)} R@1 ${pct(t.r1 / t.n)} R@4 ${pct(t.r4 / t.n)} MRR ${(t.mrr / t.n).toFixed(3)}`);
+    }
     for (const m of misses) console.log(`    ✗ ${m}`);
   }
   console.log('\n(golden doc kept for re-runs — `--cleanup` to remove)');

--- a/tests/golden/rag-golden-set.ts
+++ b/tests/golden/rag-golden-set.ts
@@ -74,13 +74,20 @@ export const GOLDEN_CASES: GoldenCase[] = [
 ];
 
 // ── Golden set v2: REAL corpus (rag-test-docs/minimax.md, 716-page prospectus) ────────
-// Judged by expectText-in-chunk (no section labels in real docs). Queries are
-// paraphrases mined from real facts — none contain the expected literal.
+// Judged by expectText-in-chunk (no section labels in real docs).
+// v2.1 balance fix: v2 was paraphrase-heavy (9/12), which is embedding's home turf —
+// the "BM25 leg hurts / rerank is neutral" conclusion was unfair. v2.1 adds lexical-
+// anchor questions (keyword / entity / clause) whose queries share LITERAL tokens with
+// the target. Anchors are deliberately script-neutral (Latin names, digits, clause
+// numbers like "18C.14"): users type simplified Chinese while the corpus is
+// traditional, so CJK terms never match lexically — only ASCII/digit tokens give the
+// BM25 leg a fair shot.
 
 export interface RealGoldenCase {
   query: string;
   expectText: string;
-  type: 'keyword' | 'paraphrase' | 'entity';
+  /** clause = the query cites a rule/clause number verbatim (上市規則第X條-style). */
+  type: 'keyword' | 'paraphrase' | 'entity' | 'clause';
 }
 
 /** Title used for the persistent golden document row (sourceType 'rag-golden'). */
@@ -99,4 +106,20 @@ export const REAL_GOLDEN_CASES: RealGoldenCase[] = [
   { query: '开放平台付费用户是怎么定义的', expectText: '50美元', type: 'paraphrase' },
   { query: '视频生成用的是哪个模型', expectText: 'Hailuo-02', type: 'entity' },
   { query: '语音合成模型叫什么', expectText: 'Speech-02', type: 'entity' },
+  // ── v2.1: lexical-anchor cases (every anchor verified verbatim in the corpus) ──────
+  // clause: query cites the rule number — BM25's home turf.
+  { query: '上市规则第18C.14条的禁售规定是什么', expectText: '18C.14', type: 'clause' },
+  { query: '上市规则第3.28条对公司秘书资格有什么要求', expectText: '3.28', type: 'clause' },
+  { query: '第8A.24条保留事项的投票是怎么规定的', expectText: '8A.24', type: 'clause' },
+  { query: '现有股东作为基石投资者认购需要根据第10.04条申请什么', expectText: '10.04', type: 'clause' },
+  // keyword: query contains an exact digit token from the target passage.
+  { query: '最高发售价165.00港元之外还要加收什么费用', expectText: '165.00', type: 'keyword' },
+  { query: '备考每股有形资产净值按已发行305,447,288股计算的依据', expectText: '305,447,288', type: 'keyword' },
+  { query: '付费用户650,300名是哪一年达到的', expectText: '650,300', type: 'keyword' },
+  { query: '公司的资金能支撑运营到2030年吗', expectText: '2030年3月', type: 'keyword' },
+  // entity: rare Latin proper noun shared verbatim between query and target.
+  { query: 'Alisoft 持有公司多少股权', expectText: 'Alisoft China Holding Limited', type: 'entity' },
+  { query: 'MiniMax M1 能处理多长的上下文', expectText: '一百萬個tokens', type: 'entity' },
+  { query: 'MiniMax M2 是为什么场景设计的', expectText: '代碼和Agent任務', type: 'entity' },
+  { query: 'Local Linearity 是由谁控制的实体', expectText: 'Local Linearity', type: 'entity' },
 ];


### PR DESCRIPTION
## 目的（rag-line 独立开发线）

v2 真实题集 9/12 是改写题（embedding 主场），"BM25 腿负贡献 / rerank 中性"的结论不公平。v2.1 增补 12 道**词面锚点题**（4 条款号 + 4 keyword + 4 entity，24 个锚点全部逐字核实存在于语料），query 与目标段共享字面 token。锚点刻意选**简繁中立**的形态（拉丁名、数字、"18C.14"式条款号）——用户打简体、语料是繁体，CJK 词永远不词面匹配，只有 ASCII/数字 token 能给 BM25 公平出场机会。eval 输出增加按题型分桶。

## 实测裁决（716 页全书、k=8、doubao@1024，已实跑）

```
            R@1  R@4  R@8   MRR
vector      58%  92% 100%  0.748
hybrid      63%  83%  96%  0.738
+rerank     58%  96%  96%  0.757
```

按题型（hybrid vs vector R@1）：**clause 75%→100%、keyword 60%→80%**（BM25 主场决定性正贡献）；entity 67%→50%、paraphrase R@4 89%→67%（BM25 噪声经 RRF 稀释改写题）。+rerank 把 hybrid 在改写题上的损失救回（paraphrase R@4 100%，MRR 全场最高 0.757），代价 R@1 略降 + 每查 +1.4s。

## 结论修正

- ~~"BM25 负贡献"~~ → **条款号/数字类查询 BM25 决定性正贡献**，生产 hybrid 默认有据；
- ~~"rerank 中性"~~ → rerank = 最佳 R@4/MRR，但 R@1 略降 + 延迟 → **默认关仍合理**，对"宁可多看几条也别漏"的场景值得开。
- 1 道硬题（"资金能支撑运营到2030年吗"）hybrid 模式 k=8 漏召——故意保留，黄金集需要硬尾巴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)