### PR TITLE
feat(rag): RAG 接入 tunnel 生产栈 — parser sidecar + worker/app env

### DIFF
--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -130,6 +130,19 @@ services:
     networks:
       - private
 
+  # RAG PDF→Markdown parser sidecar (U1). Owns the Java/opendataloader dependency so the
+  # app/worker images stay slim. Internal only (no published port): the worker (ingest)
+  # and app (probe / re-parse server fns) reach it at http://parser:7800 on `private`.
+  # Built locally from ./parser-sidecar (first `up` builds it; no registry image).
+  # Only needed when RAG_ENABLED=true; harmless when idle.
+  parser:
+    build:
+      context: ./parser-sidecar
+    container_name: ${APP_NAME:-OxyGenie}-parser
+    restart: unless-stopped
+    networks:
+      - private
+
   # Database migrations (runs before app starts)
   # Uses the same image built by the app service
   migrate:
@@ -201,6 +214,13 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       MODEL_PROBE_ON_BOOT: ${MODEL_PROBE_ON_BOOT:-true}
       MODEL_PROBE_CRON: ${MODEL_PROBE_CRON:-0 */6 * * *}
+      # RAG ingest (rag-line): this BullMQ worker runs the embed pipeline + calls the
+      # parser sidecar. Embedding reuses the ARK token above (doubao default); zhipu is
+      # the optional fallback (ZHIPU_API_KEY). Only exercised when RAG_ENABLED=true.
+      EMBED_PROVIDER: ${EMBED_PROVIDER:-}
+      PARSER_SIDECAR_URL: ${PARSER_SIDECAR_URL:-http://parser:7800}
+      ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
+      EMBEDDING_BASE_URL: ${EMBEDDING_BASE_URL:-}
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     command: ['npx', 'tsx', 'src/worker/index.ts']
@@ -285,6 +305,8 @@ services:
       VITE_GOOGLE_CLIENT_ID: ${VITE_GOOGLE_CLIENT_ID:-}
       # RAG master switch — default OFF (main ships RAG dark); see src/server/rag/flag.ts
       RAG_ENABLED: ${RAG_ENABLED:-}
+      # RAG: app-side probe / re-parse server fns call the parser sidecar (worker has its own).
+      PARSER_SIDECAR_URL: ${PARSER_SIDECAR_URL:-http://parser:7800}
       # Optional: Zhipu key — only for the GLM image tool + Zhipu MCP servers (unset if unused)
       ZHIPU_API_KEY: ${ZHIPU_API_KEY:-}
       # Claude Agent SDK configuration — ARK gateway uses Bearer (ANTHROPIC_AUTH_TOKEN);


### PR DESCRIPTION
## 目的

让 `RAG_ENABLED=true` 在 oxygenie.cc（本地 docker + Cloudflare 隧道生产栈）真正跑得起来。

#166 已把 `RAG_ENABLED` env 转发给 tunnel 的 app 服务，但生产栈实际**跑不了完整 RAG**：没有 parser sidecar 服务、worker/app 也缺 ingest 管线所需的 parser/embed env。本 PR 补齐这三块。

## 改动（仅 `docker-compose.tunnel.yml`，+22 行）

1. **新增 `parser` 服务**：`build: ./parser-sidecar`，仅内部（无对外端口），挂 `private` 网络 → worker（ingest）与 app（probe/re-parse）经 `http://parser:7800` 访问。
2. **worker env**：`PARSER_SIDECAR_URL` + `EMBED_PROVIDER` + `ZHIPU_API_KEY` + `EMBEDDING_BASE_URL`（嵌入复用 worker MODEL_PROBE 段已有的 ARK token，doubao 默认）。
3. **app env**：`PARSER_SIDECAR_URL`（probe / requestDocumentParse server functions 在 app 容器内调 parser）。

## 安全性（仍默认熄火）

`RAG_ENABLED` 不设 → parser 空转、没有任何 ingest 入队（所有入队路径都被 gate）、kb_search 不注册。设 `RAG_ENABLED=true` 才激活。部署时 migrate 服务自动 apply 迁移 0029（page_map，幂等 IF NOT EXISTS）。

## 验证

`docker compose -f docker-compose.tunnel.yml config` 渲染校验通过：parser 服务（build context/private 网络正确）、app 与 worker 两处注入 `PARSER_SIDECAR_URL`、`RAG_ENABLED:"true"` 正确渲染。

**未对运行中的生产栈执行 `up`** —— 实际 `--force-recreate app worker` 会重启对外服务的生产容器，属于维护窗口动作，需 Owner 亲自执行或明确授权。RAG 代码逻辑本身此前已在共享后端用 `rag-eval-v2` 实跑验证（ingest→pgvector+Meili→searchKb 三模式消融）。

## 备注

`docker-compose.dokploy.yml` 未同步（按 CLAUDE.md，Dokploy 是未启用的备选方案）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)