### PR TITLE
fix(documents): 大文件上传爆栈 Maximum call stack size exceeded

### DIFF
--- a/src/routes/agents/documents/route.tsx
+++ b/src/routes/agents/documents/route.tsx
@@ -389,9 +389,21 @@ function DocumentsPage() {
           },
         });
       } else {
-        // 2b) fall back to server-side upload route
-        const arrayBuffer = await file.arrayBuffer();
-        const base64 = window.btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+        // 2b) fall back to server-side upload route.
+        // Encode via FileReader (browser-native, chunked). The old
+        // `String.fromCharCode(...new Uint8Array(buf))` spread a multi-MB byte array
+        // into call arguments and overflowed the stack ("Maximum call stack size
+        // exceeded") on large files — e.g. a 7MB+ prospectus PDF.
+        const base64 = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const result = String(reader.result);
+            const comma = result.indexOf(',');
+            resolve(comma >= 0 ? result.slice(comma + 1) : result);
+          };
+          reader.onerror = () => reject(reader.error ?? new Error('file read failed'));
+          reader.readAsDataURL(file);
+        });
         await directUpload.mutateAsync({
           id,
           key,


### PR DESCRIPTION
## 现象
上传大 PDF（如 7.9MB 的 minimax 招股书）报 `Maximum call stack size exceeded`，文件传不上去。

## 根因
server-side 兜底上传路径（2b，presigned 关闭时走——隧道/生产栈因 MinIO 不对浏览器开放，**永远**走这条）用 `window.btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)))` 编码 base64。`...` spread 把每个字节当成独立函数参数，几百万字节直接爆调用栈，文件一个字节都没传出去就崩了。

## 修复
改用 `FileReader.readAsDataURL`（浏览器原生、分块、不爆栈），剥掉 `data:...;base64,` 前缀。server 端 `Buffer.from(b64,'base64')` 不变。

## 验证
- lint 0 error；镜像 build 成功（编译通过）。
- **已部署生产 oxygenie.cc**（recreate app worker，HTTP 200）。待用户重传 7.9MB PDF 确认。
- 注：生产 MinIO 不对外，presigned 直传不可行，上传必走此 base64 路径；7.9MB→~10.5MB RPC payload 经 nitro 默认 body（无小硬限制）可过。更大文件（数十 MB）未来若需要，应另开 multipart 上传端点，非本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)