### PR TITLE
feat(nav): 导航 IA 重构 阶段2 — 副侧边栏工作台 + 项目树 + ··· 菜单 + Projects 落地页

### DIFF
--- a/src/components/claude-chat/session-search-dialog.tsx
+++ b/src/components/claude-chat/session-search-dialog.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useNavigate } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '~/components/ui/command';
+import { useProjects } from '~/lib/hooks/use-projects';
+
+interface SessionRow {
+  id: string;
+  sdkSessionId: string;
+  title: string | null;
+  projectId: string | null;
+}
+
+/**
+ * ⌘K conversation search (IA redesign 2026-06, prd/2026-06-navigation-ia-redesign §4).
+ * Phase 1: title + project filter over the user's sessions (cmdk filters client-side on
+ * the CommandItem `value`). Full-text over message bodies (Meili) is a later enhancement.
+ */
+export function SessionSearchDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const { projects } = useProjects();
+  const projectName = (id: string | null) =>
+    id ? projects.find((p) => p.id === id)?.name ?? null : null;
+
+  // Not scoped to loose: this lists every accessible session (loose + project chats).
+  const { data, isLoading } = useQuery<{ sessions: SessionRow[] }>({
+    queryKey: ['agent-sessions', 'search-all'],
+    queryFn: async () => {
+      const res = await fetch('/api/agent-sessions?limit=100');
+      if (!res.ok) throw new Error('Failed to fetch sessions');
+      return res.json();
+    },
+    enabled: open,
+    staleTime: 30_000,
+  });
+  const sessions = data?.sessions ?? [];
+
+  const go = (s: SessionRow) => {
+    onOpenChange(false);
+    if (s.projectId) {
+      navigate({
+        to: '/agents/projects/$projectId/c/$sessionId',
+        params: { projectId: s.projectId, sessionId: s.sdkSessionId },
+      });
+    } else {
+      navigate({ to: '/agents/c/$sessionId', params: { sessionId: s.sdkSessionId } });
+    }
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="搜索对话"
+      description="按标题或项目搜索你的对话"
+    >
+      <CommandInput placeholder="搜索对话…" />
+      <CommandList>
+        <CommandEmpty>{isLoading ? '加载中…' : '未找到对话'}</CommandEmpty>
+        <CommandGroup heading="近期对话">
+          {sessions.map((s) => {
+            const pname = projectName(s.projectId);
+            return (
+              <CommandItem
+                key={s.id}
+                value={`${s.title ?? ''} ${pname ?? ''} ${s.id}`}
+                onSelect={() => go(s)}
+              >
+                <div className="flex w-full items-center justify-between gap-3">
+                  <span className="truncate text-sm">{s.title || '新对话'}</span>
+                  {pname && (
+                    <span className="shrink-0 text-xs text-muted-foreground">{pname}</span>
+                  )}
+                </div>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -40,7 +40,7 @@ export function NavMain({
 						<SidebarMenu>
 							{section.items.map((item) => (
 								<SidebarMenuItem key={item.title}>
-									<SidebarMenuButton asChild>
+									<SidebarMenuButton asChild tooltip={item.title}>
 										<Link to={item.url}>
 											{item.icon && <item.icon className="size-4" />}
 											<span>{item.title}</span>

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import type { ComponentType, SVGProps } from "react";
+import { toLocalizedString } from "~/lib/utils";
 import {
 	SidebarGroup,
 	SidebarGroupContent,
@@ -40,7 +41,7 @@ export function NavMain({
 						<SidebarMenu>
 							{section.items.map((item) => (
 								<SidebarMenuItem key={item.title}>
-									<SidebarMenuButton asChild tooltip={item.title}>
+									<SidebarMenuButton asChild tooltip={toLocalizedString(item.title)}>
 										<Link to={item.url}>
 											{item.icon && <item.icon className="size-4" />}
 											<span>{item.title}</span>

--- a/src/components/projects/project-menu.tsx
+++ b/src/components/projects/project-menu.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import { MoreHorizontal, UserPlus, Pencil, Trash2, LogOut } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '~/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '~/components/ui/dialog';
+import { Input } from '~/components/ui/input';
+import { Button } from '~/components/ui/button';
+import { authClient } from '~/lib/auth-client';
+import { useProjects, type ProjectDTO } from '~/lib/hooks/use-projects';
+
+/**
+ * Project ··· menu (IA redesign 2026-06, Owner spec):
+ *   owner  → 分享项目 / 重命名项目 / 删除项目
+ *   member → 分享项目 / 离开项目
+ * Backed by useProjects (addMember/updateProject/deleteProject/removeMember). The default
+ * "个人" project is special — the caller (ProjectTreeRow) hides the menu for it.
+ */
+export function ProjectMenu({ project }: { project: ProjectDTO }) {
+  const { data: session } = authClient.useSession();
+  const currentUserId = session?.user?.id;
+  const { updateProject, deleteProject, addMember, removeMember } = useProjects();
+  const isOwner = project.members.find((m) => m.userId === currentUserId)?.role === 'owner';
+
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState(project.name);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [shareEmail, setShareEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const doRename = async () => {
+    const name = renameValue.trim();
+    if (!name || name === project.name) {
+      setRenameOpen(false);
+      return;
+    }
+    setBusy(true);
+    try {
+      await updateProject({ projectId: project.id, name });
+      setRenameOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doShare = async () => {
+    const email = shareEmail.trim();
+    if (!email) return;
+    setBusy(true);
+    try {
+      await addMember(project.id, email);
+      setShareEmail('');
+      setShareOpen(false);
+    } catch (e) {
+      window.alert('邀请失败：' + (e instanceof Error ? e.message : String(e)));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doDelete = async () => {
+    if (!window.confirm(`删除项目「${project.name}」？项目内的对话会移出项目，不会被删除。`)) return;
+    await deleteProject(project.id);
+  };
+
+  const doLeave = async () => {
+    if (!currentUserId) return;
+    if (!window.confirm(`离开项目「${project.name}」？`)) return;
+    await removeMember(project.id, currentUserId);
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="项目操作"
+            onClick={(e) => e.stopPropagation()}
+            className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40" onClick={(e) => e.stopPropagation()}>
+          <DropdownMenuItem onSelect={() => setShareOpen(true)}>
+            <UserPlus className="h-4 w-4" />
+            分享项目
+          </DropdownMenuItem>
+          {isOwner ? (
+            <>
+              <DropdownMenuItem onSelect={() => { setRenameValue(project.name); setRenameOpen(true); }}>
+                <Pencil className="h-4 w-4" />
+                重命名项目
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant="destructive" onSelect={() => void doDelete()}>
+                <Trash2 className="h-4 w-4" />
+                删除项目
+              </DropdownMenuItem>
+            </>
+          ) : (
+            <DropdownMenuItem variant="destructive" onSelect={() => void doLeave()}>
+              <LogOut className="h-4 w-4" />
+              离开项目
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>重命名项目</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') void doRename(); }}
+            autoFocus
+            placeholder="项目名称"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRenameOpen(false)} disabled={busy}>取消</Button>
+            <Button onClick={() => void doRename()} disabled={busy}>保存</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={shareOpen} onOpenChange={setShareOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>分享项目「{project.name}」</DialogTitle>
+          </DialogHeader>
+          <Input
+            type="email"
+            value={shareEmail}
+            onChange={(e) => setShareEmail(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') void doShare(); }}
+            autoFocus
+            placeholder="输入对方邮箱邀请加入"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShareOpen(false)} disabled={busy}>取消</Button>
+            <Button onClick={() => void doShare()} disabled={busy}>邀请</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/projects/projects-rail.tsx
+++ b/src/components/projects/projects-rail.tsx
@@ -20,6 +20,7 @@ import {
 import { CreateProjectDialog } from './create-project-dialog';
 import { SessionSearchDialog } from '~/components/claude-chat/session-search-dialog';
 import { SessionMenu } from './session-menu';
+import { ProjectMenu } from './project-menu';
 import { useProjects, isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
 import { listProjectSessions } from '~/server/function/projects.server';
 import { useRailStore } from '~/lib/stores/rail-store';
@@ -305,25 +306,30 @@ function ProjectTreeRow({
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={onToggle}
+      <div
         className={cn(
-          'group flex w-full items-center gap-1.5 rounded-lg px-2 py-1.5 transition-colors',
+          'group/proj flex items-center gap-1.5 rounded-lg px-2 py-1.5 transition-colors',
           isActive ? 'bg-accent text-foreground' : 'text-foreground/80 hover:bg-accent/60'
         )}
       >
-        <ChevronRight
-          className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')}
-        />
-        <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 flex-1 truncate text-left text-sm">{displayName}</span>
+        <button type="button" onClick={onToggle} className="flex min-w-0 flex-1 items-center gap-1.5">
+          <ChevronRight
+            className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')}
+          />
+          <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-left text-sm">{displayName}</span>
+        </button>
         {shared && (
           <span className="flex items-center" title={sharedLabel}>
             <Users className="h-3.5 w-3.5 text-muted-foreground" />
           </span>
         )}
-      </button>
+        {!project.isDefault && (
+          <div className="opacity-0 transition-opacity group-hover/proj:opacity-100">
+            <ProjectMenu project={project} />
+          </div>
+        )}
+      </div>
 
       {expanded && (
         <div className="ml-5 space-y-0.5 border-l border-border/50 pl-1.5">

--- a/src/components/projects/projects-rail.tsx
+++ b/src/components/projects/projects-rail.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import { CreateProjectDialog } from './create-project-dialog';
 import { SessionSearchDialog } from '~/components/claude-chat/session-search-dialog';
+import { SessionMenu } from './session-menu';
 import { useProjects, isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
 import { listProjectSessions } from '~/server/function/projects.server';
 import { useRailStore } from '~/lib/stores/rail-store';
@@ -233,15 +234,22 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
         ) : (
           <div className="space-y-0.5">
             {recent.map((session) => (
-              <Link
-                key={session.id}
-                to="/agents/c/$sessionId"
-                params={{ sessionId: session.sdkSessionId }}
-                className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground/80 transition-colors hover:bg-accent"
-              >
-                <MessageSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate">{session.title || toLocalizedString(content.rail.newChat)}</span>
-              </Link>
+              <div key={session.id} className="group/sess relative">
+                <Link
+                  to="/agents/c/$sessionId"
+                  params={{ sessionId: session.sdkSessionId }}
+                  className="flex items-center gap-2 rounded-lg px-3 py-2 pr-8 text-sm text-foreground/80 transition-colors hover:bg-accent"
+                >
+                  <MessageSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{session.title || toLocalizedString(content.rail.newChat)}</span>
+                </Link>
+                <div className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/sess:opacity-100">
+                  <SessionMenu
+                    session={{ id: session.id, sdkSessionId: session.sdkSessionId, title: session.title }}
+                    personalLabel={toLocalizedString(content.rail.personal)}
+                  />
+                </div>
+              </div>
             ))}
           </div>
         )}
@@ -328,14 +336,22 @@ function ProjectTreeRow({
           ) : (
             <>
               {shown.map((s) => (
-                <Link
-                  key={s.id}
-                  to="/agents/projects/$projectId/c/$sessionId"
-                  params={{ projectId: project.id, sessionId: s.sdkSessionId }}
-                  className="block truncate rounded-lg px-3 py-1.5 text-sm text-foreground/75 transition-colors hover:bg-accent"
-                >
-                  {s.title || newChatLabel}
-                </Link>
+                <div key={s.id} className="group/sess relative">
+                  <Link
+                    to="/agents/projects/$projectId/c/$sessionId"
+                    params={{ projectId: project.id, sessionId: s.sdkSessionId }}
+                    className="block truncate rounded-lg px-3 py-1.5 pr-8 text-sm text-foreground/75 transition-colors hover:bg-accent"
+                  >
+                    {s.title || newChatLabel}
+                  </Link>
+                  <div className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/sess:opacity-100">
+                    <SessionMenu
+                      session={{ id: s.id, sdkSessionId: s.sdkSessionId, title: s.title }}
+                      projectId={project.id}
+                      personalLabel={personalLabel}
+                    />
+                  </div>
+                </div>
               ))}
               {list.length > PROJECT_SESSION_LIMIT && (
                 <Link

--- a/src/components/projects/projects-rail.tsx
+++ b/src/components/projects/projects-rail.tsx
@@ -3,12 +3,24 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
 import { useIntlayer } from 'react-intlayer';
-import { Plus, FolderPlus, Users, MessageSquare, Loader2, Search, Sparkles } from 'lucide-react';
-import { LetterAvatar } from '~/components/ui/letter-avatar';
+import {
+  Plus,
+  FolderPlus,
+  Folder,
+  Users,
+  MessageSquare,
+  Loader2,
+  Search,
+  Sparkles,
+  ChevronRight,
+  ChevronDown,
+} from 'lucide-react';
 import { CreateProjectDialog } from './create-project-dialog';
 import { SessionSearchDialog } from '~/components/claude-chat/session-search-dialog';
 import { useProjects, isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
+import { listProjectSessions } from '~/server/function/projects.server';
 import { useRailStore } from '~/lib/stores/rail-store';
 import { cn, toLocalizedString } from '~/lib/utils';
 
@@ -22,11 +34,18 @@ interface ProjectsRailProps {
   activeProjectId?: string;
 }
 
+/** How many projects show in the rail tree before "显示更多" routes to the landing page. */
+const RAIL_PROJECT_LIMIT = 5;
+/** How many chats show under an expanded project before "显示更多" routes into the project. */
+const PROJECT_SESSION_LIMIT = 5;
+
 /**
- * Rail-2 for the Projects surface: `[+ New chat]` + a 项目 (Projects) section +
- * a 最近 (Recent) section — the ChatGPT / Claude Desktop layout. Daily chats stay
- * loose under 最近; a Project is an explicit container you create to organize or
- * share. Backed by the projects server functions (useProjects).
+ * Rail-2 — the agent workbench (IA redesign 2026-06, prd §2.2):
+ *   [+新建任务] · 搜索(⌘K) · 项目(入口) · 作品(待建)
+ *   ── 项目 (collapsible group) → project tree: each project expands to its chats ──
+ *   ── 最近 (loose chats) ──
+ * The 项目 GROUP HEADING toggles the tree (it is NOT the landing-page entry — that's the
+ * 项目 entry under 搜索). Project rows expand to their sessions (listProjectSessions).
  */
 export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
   const content = useIntlayer('projects');
@@ -35,6 +54,16 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
   const { projects, isLoading: projectsLoading, ensureDefault, createProject } = useProjects();
   const [createOpen, setCreateOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [projectsOpen, setProjectsOpen] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleProject = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
 
   // ⌘K / Ctrl-K toggles conversation search (IA redesign §4).
   useEffect(() => {
@@ -80,6 +109,8 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
     return <SessionSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />;
   }
 
+  const visibleProjects = projects.slice(0, RAIL_PROJECT_LIMIT);
+
   return (
     <div className="flex h-full w-72 shrink-0 flex-col border-r border-sidebar-border bg-sidebar">
       {/* New chat (loose chat — lands on the chat surface) */}
@@ -99,7 +130,7 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
         </button>
       </div>
 
-      {/* Search + Artifacts entries (IA redesign §2.2) */}
+      {/* Fixed entries: 搜索 / 项目(landing) / 作品 (IA redesign §2.2) */}
       <div className="shrink-0 space-y-0.5 px-3 pb-1">
         <button
           type="button"
@@ -109,6 +140,14 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
           <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="flex-1 text-left">搜索</span>
           <kbd className="rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">⌘K</kbd>
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate({ to: '/agents/projects' })}
+          className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground/80 transition-colors hover:bg-accent"
+        >
+          <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="flex-1 text-left">项目</span>
         </button>
         <button
           type="button"
@@ -123,14 +162,18 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-3">
-        {/* ---- Projects ---- */}
+        {/* ---- 项目 group (heading TOGGLES the tree; not the landing entry) ---- */}
         <div className="flex items-center justify-between px-2 pt-2 pb-1">
-          <Link
-            to="/agents/projects"
-            className="text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
+          <button
+            type="button"
+            onClick={() => setProjectsOpen((v) => !v)}
+            className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
           >
+            <ChevronDown
+              className={cn('h-3.5 w-3.5 transition-transform', !projectsOpen && '-rotate-90')}
+            />
             {content.rail.projectsHeading}
-          </Link>
+          </button>
           <button
             type="button"
             onClick={() => setCreateOpen(true)}
@@ -142,25 +185,37 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
           </button>
         </div>
 
-        {projectsLoading && projects.length === 0 ? (
-          <div className="flex items-center justify-center py-4">
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-          </div>
-        ) : projects.length === 0 ? (
-          <p className="px-3 py-2 text-xs text-muted-foreground/70">{content.rail.noProjects}</p>
-        ) : (
-          <div className="space-y-0.5">
-            {projects.map((project) => (
-              <ProjectRow
-                key={project.id}
-                project={project}
-                isActive={project.id === activeProjectId}
-                personalLabel={toLocalizedString(content.rail.personal)}
-                sharedLabel={toLocalizedString(content.home.sharedBadge)}
-              />
-            ))}
-          </div>
-        )}
+        {projectsOpen &&
+          (projectsLoading && projects.length === 0 ? (
+            <div className="flex items-center justify-center py-4">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : projects.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground/70">{content.rail.noProjects}</p>
+          ) : (
+            <div className="space-y-0.5">
+              {visibleProjects.map((project) => (
+                <ProjectTreeRow
+                  key={project.id}
+                  project={project}
+                  isActive={project.id === activeProjectId}
+                  expanded={expanded.has(project.id)}
+                  onToggle={() => toggleProject(project.id)}
+                  personalLabel={toLocalizedString(content.rail.personal)}
+                  sharedLabel={toLocalizedString(content.home.sharedBadge)}
+                  newChatLabel={toLocalizedString(content.rail.newChat)}
+                />
+              ))}
+              {projects.length > RAIL_PROJECT_LIMIT && (
+                <Link
+                  to="/agents/projects"
+                  className="block rounded-lg px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  显示更多
+                </Link>
+              )}
+            </div>
+          ))}
 
         {/* ---- Recent (loose chats) ---- */}
         <div className="px-2 pt-4 pb-1">
@@ -198,35 +253,103 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
   );
 }
 
-function ProjectRow({
+interface ProjectSessionRow {
+  id: string;
+  sdkSessionId: string;
+  title: string | null;
+}
+
+/**
+ * A project row in the rail tree: clicking the row expands it to its chats
+ * (listProjectSessions, fetched lazily on first expand). The project name itself does
+ * NOT navigate — expand/collapse is the click target (Owner spec). Folder header in the
+ * landing page is the place to open the project.
+ */
+function ProjectTreeRow({
   project,
   isActive,
+  expanded,
+  onToggle,
   personalLabel,
   sharedLabel,
+  newChatLabel,
 }: {
   project: ProjectDTO;
   isActive: boolean;
+  expanded: boolean;
+  onToggle: () => void;
   personalLabel: string;
   sharedLabel: string;
+  newChatLabel: string;
 }) {
   const displayName = project.isDefault ? personalLabel : project.name;
   const shared = isShared(project);
+  const fetchSessions = useServerFn(listProjectSessions);
+
+  const { data: sessions, isLoading } = useQuery<ProjectSessionRow[]>({
+    queryKey: ['project-sessions', project.id],
+    queryFn: () => fetchSessions({ data: { projectId: project.id } }),
+    enabled: expanded,
+    staleTime: 30_000,
+  });
+  const list = sessions ?? [];
+  const shown = list.slice(0, PROJECT_SESSION_LIMIT);
+
   return (
-    <Link
-      to="/agents/projects/$projectId"
-      params={{ projectId: project.id }}
-      className={cn(
-        'group flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors',
-        isActive ? 'bg-accent text-foreground' : 'text-foreground/80 hover:bg-accent/60'
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={cn(
+          'group flex w-full items-center gap-1.5 rounded-lg px-2 py-1.5 transition-colors',
+          isActive ? 'bg-accent text-foreground' : 'text-foreground/80 hover:bg-accent/60'
+        )}
+      >
+        <ChevronRight
+          className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')}
+        />
+        <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-left text-sm">{displayName}</span>
+        {shared && (
+          <span className="flex items-center" title={sharedLabel}>
+            <Users className="h-3.5 w-3.5 text-muted-foreground" />
+          </span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="ml-5 space-y-0.5 border-l border-border/50 pl-1.5">
+          {isLoading ? (
+            <div className="flex items-center px-3 py-2">
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            </div>
+          ) : list.length === 0 ? (
+            <p className="px-3 py-1.5 text-xs text-muted-foreground/70">暂无会话</p>
+          ) : (
+            <>
+              {shown.map((s) => (
+                <Link
+                  key={s.id}
+                  to="/agents/projects/$projectId/c/$sessionId"
+                  params={{ projectId: project.id, sessionId: s.sdkSessionId }}
+                  className="block truncate rounded-lg px-3 py-1.5 text-sm text-foreground/75 transition-colors hover:bg-accent"
+                >
+                  {s.title || newChatLabel}
+                </Link>
+              ))}
+              {list.length > PROJECT_SESSION_LIMIT && (
+                <Link
+                  to="/agents/projects/$projectId"
+                  params={{ projectId: project.id }}
+                  className="block rounded-lg px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  显示更多
+                </Link>
+              )}
+            </>
+          )}
+        </div>
       )}
-    >
-      <LetterAvatar name={displayName} size="sm" className="!size-7 !rounded-md text-xs" />
-      <span className="min-w-0 flex-1 truncate text-sm">{displayName}</span>
-      {shared && (
-        <span className="flex items-center" title={sharedLabel}>
-          <Users className="h-3.5 w-3.5 text-muted-foreground" />
-        </span>
-      )}
-    </Link>
+    </div>
   );
 }

--- a/src/components/projects/projects-rail.tsx
+++ b/src/components/projects/projects-rail.tsx
@@ -9,6 +9,7 @@ import { LetterAvatar } from '~/components/ui/letter-avatar';
 import { CreateProjectDialog } from './create-project-dialog';
 import { SessionSearchDialog } from '~/components/claude-chat/session-search-dialog';
 import { useProjects, isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
+import { useRailStore } from '~/lib/stores/rail-store';
 import { cn, toLocalizedString } from '~/lib/utils';
 
 interface RecentSession {
@@ -30,6 +31,7 @@ interface ProjectsRailProps {
 export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
   const content = useIntlayer('projects');
   const navigate = useNavigate();
+  const collapsed = useRailStore((s) => s.collapsed);
   const { projects, isLoading: projectsLoading, ensureDefault, createProject } = useProjects();
   const [createOpen, setCreateOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -72,6 +74,11 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
     const project = await createProject({ name });
     navigate({ to: '/agents/projects/$projectId', params: { projectId: project.id } });
   };
+
+  // Collapsed: hide the rail but keep the search dialog mounted so ⌘K still works.
+  if (collapsed) {
+    return <SessionSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />;
+  }
 
   return (
     <div className="flex h-full w-72 shrink-0 flex-col border-r border-sidebar-border bg-sidebar">

--- a/src/components/projects/projects-rail.tsx
+++ b/src/components/projects/projects-rail.tsx
@@ -4,9 +4,10 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { useIntlayer } from 'react-intlayer';
-import { Plus, FolderPlus, Users, MessageSquare, Loader2 } from 'lucide-react';
+import { Plus, FolderPlus, Users, MessageSquare, Loader2, Search, Sparkles } from 'lucide-react';
 import { LetterAvatar } from '~/components/ui/letter-avatar';
 import { CreateProjectDialog } from './create-project-dialog';
+import { SessionSearchDialog } from '~/components/claude-chat/session-search-dialog';
 import { useProjects, isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
 import { cn, toLocalizedString } from '~/lib/utils';
 
@@ -31,6 +32,19 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
   const navigate = useNavigate();
   const { projects, isLoading: projectsLoading, ensureDefault, createProject } = useProjects();
   const [createOpen, setCreateOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  // ⌘K / Ctrl-K toggles conversation search (IA redesign §4).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setSearchOpen((v) => !v);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
 
   // Ensure the default "个人/Personal" Project exists — once, only if missing.
   const ensuredRef = useRef(false);
@@ -78,12 +92,38 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
         </button>
       </div>
 
+      {/* Search + Artifacts entries (IA redesign §2.2) */}
+      <div className="shrink-0 space-y-0.5 px-3 pb-1">
+        <button
+          type="button"
+          onClick={() => setSearchOpen(true)}
+          className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground/80 transition-colors hover:bg-accent"
+        >
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="flex-1 text-left">搜索</span>
+          <kbd className="rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">⌘K</kbd>
+        </button>
+        <button
+          type="button"
+          disabled
+          title="即将上线"
+          className="flex w-full cursor-not-allowed items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground/40"
+        >
+          <Sparkles className="h-4 w-4 shrink-0" />
+          <span className="flex-1 text-left">作品</span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">待建</span>
+        </button>
+      </div>
+
       <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-3">
         {/* ---- Projects ---- */}
         <div className="flex items-center justify-between px-2 pt-2 pb-1">
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <Link
+            to="/agents/projects"
+            className="text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
+          >
             {content.rail.projectsHeading}
-          </span>
+          </Link>
           <button
             type="button"
             onClick={() => setCreateOpen(true)}
@@ -146,6 +186,7 @@ export function ProjectsRail({ activeProjectId }: ProjectsRailProps) {
       </div>
 
       <CreateProjectDialog open={createOpen} onOpenChange={setCreateOpen} onCreate={handleCreate} />
+      <SessionSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
     </div>
   );
 }

--- a/src/components/projects/session-menu.tsx
+++ b/src/components/projects/session-menu.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+import { MoreHorizontal, Pencil, Pin, FolderInput, FolderMinus, Trash2 } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuSeparator,
+} from '~/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '~/components/ui/dialog';
+import { Input } from '~/components/ui/input';
+import { Button } from '~/components/ui/button';
+import { assignSessionToProject } from '~/server/function/projects.server';
+import { useProjects, type ProjectDTO } from '~/lib/hooks/use-projects';
+
+export interface MenuSession {
+  id: string; // session row PK — used by /api/agent-sessions/:id (PATCH/DELETE)
+  sdkSessionId: string; // workspace id — used by assignSessionToProject
+  title: string | null;
+}
+
+/**
+ * Conversation ··· menu (IA redesign 2026-06, Owner spec): 重命名 / 置顶 / 移至项目 /
+ * 从项目移除 / 删除. Backed by /api/agent-sessions/:id (PATCH title|favorite, DELETE) and
+ * assignSessionToProject. 归档/分享(会话级) 暂无后端，未列。
+ */
+export function SessionMenu({
+  session,
+  projectId,
+  personalLabel,
+}: {
+  session: MenuSession;
+  /** Present when the session lives inside a project → enables 从项目移除. */
+  projectId?: string;
+  personalLabel: string;
+}) {
+  const qc = useQueryClient();
+  const { projects } = useProjects();
+  const move = useServerFn(assignSessionToProject);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState(session.title ?? '');
+  const [busy, setBusy] = useState(false);
+
+  const refresh = () => {
+    void qc.invalidateQueries({ queryKey: ['project-sessions'] });
+    void qc.invalidateQueries({ queryKey: ['agent-sessions'] });
+  };
+
+  const patch = async (body: Record<string, unknown>) => {
+    await fetch(`/api/agent-sessions/${session.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    refresh();
+  };
+
+  const doRename = async () => {
+    const title = renameValue.trim();
+    if (!title || title === session.title) {
+      setRenameOpen(false);
+      return;
+    }
+    setBusy(true);
+    try {
+      await patch({ title });
+      setRenameOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doMove = async (target: string | null) => {
+    await move({ data: { sdkSessionId: session.sdkSessionId, projectId: target } });
+    refresh();
+  };
+
+  const doDelete = async () => {
+    if (!window.confirm('删除这个对话？此操作不可撤销。')) return;
+    await fetch(`/api/agent-sessions/${session.id}`, { method: 'DELETE' });
+    refresh();
+  };
+
+  // Move targets = projects other than the one it's already in.
+  const moveTargets = projects.filter((p: ProjectDTO) => p.id !== projectId);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="对话操作"
+            onClick={(e) => e.stopPropagation()}
+            className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44" onClick={(e) => e.stopPropagation()}>
+          <DropdownMenuItem onSelect={() => { setRenameValue(session.title ?? ''); setRenameOpen(true); }}>
+            <Pencil className="h-4 w-4" />
+            重命名
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void patch({ favorite: true })}>
+            <Pin className="h-4 w-4" />
+            置顶聊天
+          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <FolderInput className="h-4 w-4" />
+              移至项目
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
+              {moveTargets.length === 0 ? (
+                <DropdownMenuItem disabled>没有其它项目</DropdownMenuItem>
+              ) : (
+                moveTargets.map((p) => (
+                  <DropdownMenuItem key={p.id} onSelect={() => void doMove(p.id)}>
+                    {p.isDefault ? personalLabel : p.name}
+                  </DropdownMenuItem>
+                ))
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          {projectId && (
+            <DropdownMenuItem onSelect={() => void doMove(null)}>
+              <FolderMinus className="h-4 w-4" />
+              从项目移除
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={() => void doDelete()}>
+            <Trash2 className="h-4 w-4" />
+            删除
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>重命名对话</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void doRename();
+            }}
+            autoFocus
+            placeholder="对话标题"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRenameOpen(false)} disabled={busy}>
+              取消
+            </Button>
+            <Button onClick={() => void doRename()} disabled={busy}>
+              保存
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,13 +1,15 @@
+import { PanelLeft } from "lucide-react"
 import { Button } from "~/components/ui/button"
 import { LocaleSwitcher } from "~/components/locale-switcher"
 import { Separator } from "~/components/ui/separator"
-import { SidebarTrigger } from "~/components/ui/sidebar"
 import { useMatches } from "@tanstack/react-router"
 import { useIntlayer } from "react-intlayer"
+import { useRailStore } from "~/lib/stores/rail-store"
 
 export function SiteHeader() {
   const matches = useMatches()
   const content = useIntlayer("app")
+  const toggleRail = useRailStore((s) => s.toggle)
 
   // Get the current route's title from the last matching route
   const currentRoute = matches[matches.length - 1]
@@ -31,14 +33,30 @@ export function SiteHeader() {
 
   const title = content.titles[getTitleKey(pathname)]
 
+  // The collapse key controls the SECONDARY rail (ProjectsRail), which only exists in the
+  // 智能体 module (chat + projects). Main sidebar is now a permanent icon rail (no trigger).
+  const hasRail = pathname.startsWith("/agents/c") || pathname.startsWith("/agents/projects")
+
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
-        <SidebarTrigger className="-ml-1" />
-        <Separator
-          orientation="vertical"
-          className="mx-2 data-[orientation=vertical]:h-4"
-        />
+        {hasRail && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="-ml-1 size-7"
+              onClick={() => toggleRail()}
+              aria-label="折叠/展开侧边栏"
+            >
+              <PanelLeft className="size-4" />
+            </Button>
+            <Separator
+              orientation="vertical"
+              className="mx-2 data-[orientation=vertical]:h-4"
+            />
+          </>
+        )}
         <h1 className="text-base font-medium">{title}</h1>
         <div className="ml-auto flex items-center gap-2">
           <LocaleSwitcher />

--- a/src/lib/stores/rail-store.ts
+++ b/src/lib/stores/rail-store.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface RailState {
+  collapsed: boolean;
+  toggle: () => void;
+  setCollapsed: (collapsed: boolean) => void;
+}
+
+/**
+ * 副侧边栏（ProjectsRail）折叠状态（IA redesign 2026-06, prd §3）。
+ * 顶栏的折叠键（SiteHeader）与 ProjectsRail 跨组件共享这一状态。
+ * 内存态（刷新回到展开）——折叠是会话内临时操作；如需持久化后续再加。
+ */
+export const useRailStore = create<RailState>((set) => ({
+  collapsed: false,
+  toggle: () => set((s) => ({ collapsed: !s.collapsed })),
+  setCollapsed: (collapsed) => set({ collapsed }),
+}));

--- a/src/routes/agents/projects/index.tsx
+++ b/src/routes/agents/projects/index.tsx
@@ -1,25 +1,162 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useIntlayer } from 'react-intlayer';
-import { FolderOpen } from 'lucide-react';
+import { Folder, FolderOpen, Plus, Search, Users } from 'lucide-react';
+import { Input } from '~/components/ui/input';
+import { Button } from '~/components/ui/button';
+import { LetterAvatar } from '~/components/ui/letter-avatar';
+import { CreateProjectDialog } from '~/components/projects/create-project-dialog';
+import { useProjects, type ProjectDTO } from '~/lib/hooks/use-projects';
+import { toLocalizedString } from '~/lib/utils';
 
 export const Route = createFileRoute('/agents/projects/')({
   component: ProjectsIndex,
 });
 
-/** Landing when no specific project is open — prompt to pick or create one. */
+/** Relative time in zh-CN (component runtime — Date is available here). */
+function timeAgo(iso: string): string {
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+  if (diff < 60) return '刚刚';
+  if (diff < 3600) return `${Math.floor(diff / 60)} 分钟前`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)} 小时前`;
+  const days = Math.floor(diff / 86400);
+  if (days === 1) return '昨天';
+  if (days < 30) return `${days} 天前`;
+  return new Date(iso).toLocaleDateString('zh-CN');
+}
+
+/**
+ * Projects landing (IA redesign 2026-06, prd §2.3): card grid of the team's projects —
+ * name + members + updated time. Unlike Claude Desktop's Project (a local folder), an
+ * oxygenie Project is a server-side team container, so cards show team attributes.
+ */
 function ProjectsIndex() {
   const content = useIntlayer('projects');
+  const navigate = useNavigate();
+  const { projects, isLoading, createProject } = useProjects();
+  const [q, setQ] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const personalLabel = toLocalizedString(content.rail.personal);
+  const nameOf = (p: ProjectDTO) => (p.isDefault ? personalLabel : p.name);
+  const filtered = projects.filter((p) => !q || nameOf(p).toLowerCase().includes(q.toLowerCase()));
+
+  const handleCreate = async ({ name }: { name: string }) => {
+    const project = await createProject({ name });
+    navigate({ to: '/agents/projects/$projectId', params: { projectId: project.id } });
+  };
+
   return (
-    <div className="flex h-full items-center justify-center">
-      <div className="flex max-w-md flex-col items-center gap-4 px-6 text-center">
-        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-          <FolderOpen className="h-8 w-8 text-muted-foreground" />
-        </div>
-        <h1 className="font-serif text-2xl font-semibold tracking-tight text-foreground">
-          {content.index.title}
+    <div className="mx-auto flex h-full w-full max-w-5xl flex-col px-6 py-8">
+      <div className="mb-5 flex items-center justify-between">
+        <h1 className="font-serif text-3xl font-semibold tracking-tight text-foreground">
+          {content.rail.projectsHeading}
         </h1>
-        <p className="text-muted-foreground">{content.index.subtitle}</p>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4" />
+          {content.rail.newProject}
+        </Button>
       </div>
+
+      <div className="relative mb-6">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="搜索项目…"
+          className="pl-9"
+        />
+      </div>
+
+      {isLoading && projects.length === 0 ? (
+        <p className="py-12 text-center text-sm text-muted-foreground">加载中…</p>
+      ) : filtered.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <FolderOpen className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <div>
+            <p className="font-medium text-foreground">{content.index.title}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{content.index.subtitle}</p>
+          </div>
+          {!q && (
+            <Button variant="outline" onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4" />
+              {content.rail.newProject}
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((project) => (
+            <ProjectCard
+              key={project.id}
+              project={project}
+              displayName={nameOf(project)}
+              onOpen={() =>
+                navigate({ to: '/agents/projects/$projectId', params: { projectId: project.id } })
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      <CreateProjectDialog open={createOpen} onOpenChange={setCreateOpen} onCreate={handleCreate} />
     </div>
+  );
+}
+
+function ProjectCard({
+  project,
+  displayName,
+  onOpen,
+}: {
+  project: ProjectDTO;
+  displayName: string;
+  onOpen: () => void;
+}) {
+  const members = project.members;
+  const shownAvatars = members.slice(0, 3);
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background p-4 text-left transition-colors hover:border-border hover:bg-accent/40"
+    >
+      <div className="flex items-center gap-2">
+        <Folder className="h-5 w-5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate font-medium text-foreground">{displayName}</span>
+      </div>
+      {project.description && (
+        <p className="line-clamp-2 text-sm text-muted-foreground">{project.description}</p>
+      )}
+      <div className="mt-auto flex items-center justify-between pt-1">
+        <div className="flex items-center">
+          {members.length > 1 ? (
+            <div className="flex -space-x-2">
+              {shownAvatars.map((m) => (
+                <LetterAvatar
+                  key={m.userId}
+                  name={m.name}
+                  size="sm"
+                  className="!size-6 rounded-full ring-2 ring-background"
+                />
+              ))}
+              {members.length > 3 && (
+                <span className="flex size-6 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground ring-2 ring-background">
+                  +{members.length - 3}
+                </span>
+              )}
+            </div>
+          ) : (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Users className="h-3.5 w-3.5" />
+              {members.length} 成员
+            </span>
+          )}
+        </div>
+        <span className="text-xs text-muted-foreground">{timeAgo(project.updatedAt)} 更新</span>
+      </div>
+    </button>
   );
 }

--- a/src/routes/agents/route.tsx
+++ b/src/routes/agents/route.tsx
@@ -78,8 +78,9 @@ export const Route = createFileRoute('/agents')({
 
 function RouteComponent() {
   const { user } = Route.useRouteContext();
+  // open={false} 受控锁定主侧边栏为常驻图标条（IA redesign §3：主条不折叠，只 hover 提示）。
   return (
-    <SidebarProvider defaultOpen={false}>
+    <SidebarProvider open={false}>
       <AppSidebar variant="inset" user={user} />
       <SidebarInset>
         <SiteHeader />


### PR DESCRIPTION
## 阶段2 全量（接 #172 阶段1）

按 Owner 的 Claude Desktop 式交互（prd `2026-06-navigation-ia-redesign`）重做副侧边栏工作台：

- **2a 对话搜索**：`SessionSearchDialog`（cmdk），⌘K 唤起，按标题+项目过滤全部对话跳转；副侧边栏加搜索/作品入口。
- **2b 折叠**：主侧边栏锁为常驻图标条（hover tooltip）、移除其折叠键；顶栏键改管副侧边栏（`rail-store` 共享态），仅智能体模块显示。
- **tooltip fix**：主侧边栏 icon-rail hover 文案（intlayer 节点转字符串）。
- **2c-1 项目树**：搜索下加「项目」入口（→落地页）；「项目」分组标题改折叠开关；项目行可展开显示其会话（`listProjectSessions`），前 5 项目/前 5 会话，超出"显示更多"。
- **2c-2 ··· 菜单**：会话（重命名/置顶/移至项目/移除/删除）+ 项目（owner: 分享/重命名/删除；member: 分享/离开），接现有后端，归档/会话级分享暂无后端未列。
- **2c-3 Projects 落地页**：卡片网格（项目名+成员头像+相对时间），团队属性而非本地路径。

## 验证
每步 lint 0 error + build 成功 + 逐步部署生产 oxygenie.cc（HTTP 200），Owner 逐项确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)