### PR TITLE
feat(projects): 项目管理 — 详情页菜单 + 设置弹窗 + edit 入口

### DIFF
--- a/src/components/projects/project-home.tsx
+++ b/src/components/projects/project-home.tsx
@@ -9,6 +9,8 @@ import { Plus, Share2, MessageSquare, FileText, Upload, Loader2 } from 'lucide-r
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '~/components/ui/tabs';
 import { LetterAvatar } from '~/components/ui/letter-avatar';
 import { ShareProjectDialog } from './share-project-dialog';
+import { ProjectMenu } from './project-menu';
+import { ProjectSettingsDialog } from './project-settings-dialog';
 import { isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
 import { listProjectSessions } from '~/server/function/projects.server';
 import { useChatSessionStore } from '~/lib/chat-session-store';
@@ -35,6 +37,7 @@ export function ProjectHome({ project, currentUserId, personalLabel }: ProjectHo
   const navigate = useNavigate();
   const setPendingProjectId = useChatSessionStore((s) => s.setPendingProjectId);
   const [shareOpen, setShareOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const isOwner = project.ownerUserId === currentUserId;
 
@@ -76,6 +79,9 @@ export function ProjectHome({ project, currentUserId, personalLabel }: ProjectHo
               <Share2 className="h-4 w-4" />
               {content.home.share}
             </button>
+            {!project.isDefault && (
+              <ProjectMenu project={project} onOpenSettings={() => setSettingsOpen(true)} />
+            )}
           </div>
         </div>
 
@@ -129,6 +135,7 @@ export function ProjectHome({ project, currentUserId, personalLabel }: ProjectHo
       </div>
 
       <ShareProjectDialog open={shareOpen} onOpenChange={setShareOpen} project={project} isOwner={isOwner} />
+      <ProjectSettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} project={project} />
     </div>
   );
 }

--- a/src/components/projects/project-menu.tsx
+++ b/src/components/projects/project-menu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { MoreHorizontal, UserPlus, Pencil, Trash2, LogOut } from 'lucide-react';
+import { MoreHorizontal, Settings, UserPlus, Pencil, Trash2, LogOut } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -28,7 +28,14 @@ import { useProjects, type ProjectDTO } from '~/lib/hooks/use-projects';
  * Backed by useProjects (addMember/updateProject/deleteProject/removeMember). The default
  * "个人" project is special — the caller (ProjectTreeRow) hides the menu for it.
  */
-export function ProjectMenu({ project }: { project: ProjectDTO }) {
+export function ProjectMenu({
+  project,
+  onOpenSettings,
+}: {
+  project: ProjectDTO;
+  /** When provided, the menu shows 「项目设置」(detail-page menu);副侧边栏 omits it. */
+  onOpenSettings?: () => void;
+}) {
   const { data: session } = authClient.useSession();
   const currentUserId = session?.user?.id;
   const { updateProject, deleteProject, addMember, removeMember } = useProjects();
@@ -95,6 +102,12 @@ export function ProjectMenu({ project }: { project: ProjectDTO }) {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-40" onClick={(e) => e.stopPropagation()}>
+          {onOpenSettings && (
+            <DropdownMenuItem onSelect={onOpenSettings}>
+              <Settings className="h-4 w-4" />
+              项目设置
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem onSelect={() => setShareOpen(true)}>
             <UserPlus className="h-4 w-4" />
             分享项目

--- a/src/components/projects/project-settings-dialog.tsx
+++ b/src/components/projects/project-settings-dialog.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '~/components/ui/dialog';
+import { Input } from '~/components/ui/input';
+import { Textarea } from '~/components/ui/textarea';
+import { Button } from '~/components/ui/button';
+import { authClient } from '~/lib/auth-client';
+import { useProjects, type ProjectDTO } from '~/lib/hooks/use-projects';
+
+/**
+ * Project settings (IA redesign 2026-06, prd §7). Owner-editable: 名称 + 指令 + 删除项目.
+ * Member sees a read-only view (updateProject is owner-only — assertProjectOwner).
+ * 记忆 scope / emoji 不做（oxygenie 无记忆系统；emoji 需 schema 字段）。指令"生效"（注入
+ * worker system prompt）是单独的 agent-线工作；此弹窗只负责存储 instructions。
+ */
+export function ProjectSettingsDialog({
+  open,
+  onOpenChange,
+  project,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: ProjectDTO;
+}) {
+  const { data: session } = authClient.useSession();
+  const isOwner = project.ownerUserId === session?.user?.id;
+  const { updateProject, deleteProject } = useProjects();
+  const navigate = useNavigate();
+
+  const [name, setName] = useState(project.name);
+  const [instructions, setInstructions] = useState(project.instructions ?? '');
+  const [busy, setBusy] = useState(false);
+
+  // Reset fields to the project's current values whenever the dialog (re)opens.
+  useEffect(() => {
+    if (open) {
+      setName(project.name);
+      setInstructions(project.instructions ?? '');
+    }
+  }, [open, project.name, project.instructions]);
+
+  const save = async () => {
+    if (!isOwner) return;
+    setBusy(true);
+    try {
+      await updateProject({
+        projectId: project.id,
+        name: name.trim() || project.name,
+        instructions,
+      });
+      onOpenChange(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!isOwner) return;
+    if (!window.confirm(`删除项目「${project.name}」？项目内的对话会移出项目，不会被删除。`)) return;
+    await deleteProject(project.id);
+    onOpenChange(false);
+    navigate({ to: '/agents/projects' });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>项目设置</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-foreground">项目名称</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={!isOwner}
+              placeholder="项目名称"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-foreground">指令</label>
+            <p className="text-xs text-muted-foreground">设置项目背景信息，自定义 AI 在本项目内的回复方式。</p>
+            <Textarea
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              disabled={!isOwner}
+              rows={4}
+              placeholder="例如：用中文回答。参考项目里的资料。回答要简短且突出重点。"
+            />
+          </div>
+
+          {!isOwner && (
+            <p className="text-xs text-muted-foreground">仅项目所有者可修改设置。</p>
+          )}
+        </div>
+
+        <DialogFooter className="flex items-center">
+          {isOwner && (
+            <Button
+              variant="outline"
+              onClick={() => void remove()}
+              className="border-destructive/50 text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              删除项目
+            </Button>
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+              {isOwner ? '取消' : '关闭'}
+            </Button>
+            {isOwner && (
+              <Button onClick={() => void save()} disabled={busy}>
+                保存
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/projects/projects-rail.tsx
+++ b/src/components/projects/projects-rail.tsx
@@ -17,11 +17,13 @@ import {
   ChevronRight,
   ChevronDown,
   Pin,
+  Pencil,
 } from 'lucide-react';
 import { CreateProjectDialog } from './create-project-dialog';
 import { SessionSearchDialog } from '~/components/claude-chat/session-search-dialog';
 import { SessionMenu } from './session-menu';
 import { ProjectMenu } from './project-menu';
+import { ProjectSettingsDialog } from './project-settings-dialog';
 import { useProjects, isShared, type ProjectDTO } from '~/lib/hooks/use-projects';
 import { listProjectSessions } from '~/server/function/projects.server';
 import { useRailStore } from '~/lib/stores/rail-store';
@@ -352,6 +354,7 @@ function ProjectTreeRow({
 }) {
   const displayName = project.isDefault ? personalLabel : project.name;
   const shared = isShared(project);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const fetchSessions = useServerFn(listProjectSessions);
 
   const { data: sessions, isLoading } = useQuery<ProjectSessionRow[]>({
@@ -384,7 +387,18 @@ function ProjectTreeRow({
           </span>
         )}
         {!project.isDefault && (
-          <div className="opacity-0 transition-opacity group-hover/proj:opacity-100">
+          <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/proj:opacity-100">
+            <button
+              type="button"
+              aria-label="项目设置"
+              onClick={(e) => {
+                e.stopPropagation();
+                setSettingsOpen(true);
+              }}
+              className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
             <ProjectMenu project={project} />
           </div>
         )}
@@ -430,6 +444,9 @@ function ProjectTreeRow({
             </>
           )}
         </div>
+      )}
+      {!project.isDefault && (
+        <ProjectSettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} project={project} />
       )}
     </div>
   );


### PR DESCRIPTION
prd §7 主体：项目设置弹窗(名称/指令/删除)、详情页 ··· 菜单、副侧边栏 ✏️ edit 入口；owner 可编辑 member 只读；默认项目受保护。跳过记忆/举报，emoji/指令生效单独排期。已部署 oxygenie.cc。🤖 Generated with [Claude Code](https://claude.com/claude-code)