### PR TITLE
fix(kb): KB 详情列表空 + 删除不刷新 + 加入知识库不进 RAG

### DIFF
--- a/src/routes/agents/documents/route.tsx
+++ b/src/routes/agents/documents/route.tsx
@@ -155,7 +155,9 @@ function DocumentsPage() {
   // Query KB documents when a KB is selected
   const { data: kbDocuments = [], isLoading: kbDocsLoading } = useQuery({
     queryKey: ['kb-documents', selectedKbId],
-    queryFn: () => getKbDocumentsFn({ kbId: selectedKbId! }),
+    // NB: server fns take { data: ... } — passing the payload bare makes the validator
+    // see undefined and the query silently error into an empty list (bug: KB 列表显示空).
+    queryFn: () => getKbDocumentsFn({ data: { kbId: selectedKbId! } }),
     enabled: !!selectedKbId,
   });
 
@@ -231,7 +233,15 @@ function DocumentsPage() {
     },
     onSuccess: async () => {
       setSelectedFiles(new Map());
-      await router.invalidate();
+      // The list renders from the 'documents-list' query (loader is only initialData),
+      // so router.invalidate() alone never refreshes it — invalidate every affected query.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['documents-list'] }),
+        queryClient.invalidateQueries({ queryKey: ['documents'] }),
+        queryClient.invalidateQueries({ queryKey: ['knowledge-bases'] }),
+        queryClient.invalidateQueries({ queryKey: ['kb-documents'] }),
+        router.invalidate(),
+      ]);
     },
     onError: (err: unknown) => {
       setDeleteError(err instanceof Error ? err.message : content.selectedBar.delete);

--- a/src/server/function/knowledge-bases.server.ts
+++ b/src/server/function/knowledge-bases.server.ts
@@ -9,8 +9,12 @@ import { getRequest } from '@tanstack/react-start/server';
 import { z } from 'zod';
 import { db } from '~/db/db-config';
 import { knowledgeBases, kbDocuments, files } from '~/db/schema';
+import { documents } from '~/db/schema/document.schema';
 import { auth } from '~/server/auth.server';
 import { eq, and, desc, sql, count } from 'drizzle-orm';
+import { isRagEnabled } from '~/server/rag/flag';
+import { scheduleRagIngest } from '~/server/rag/queue';
+import { estimateTokens } from '~/server/rag/tier';
 
 const requireUser = async () => {
   const { headers } = getRequest();
@@ -218,6 +222,7 @@ export const addKbDocuments = createServerFn({ method: 'POST' })
     // Add documents (ignore duplicates)
     const added = [];
     const errors = [];
+    const docIdsToIngest: string[] = [];
 
     for (const fileId of data.fileIds) {
       try {
@@ -259,12 +264,64 @@ export const addKbDocuments = createServerFn({ method: 'POST' })
           .returning();
 
         added.push(kbDoc);
+
+        // Joining a KB means joining the RAG pipeline (KB redesign prd §4.3): ensure the
+        // file has a documents row and schedule parse/embed. Without this the file sits
+        // in the KB with no status and never becomes searchable.
+        const [existingDoc] = await db
+          .select({ id: documents.id, ingestStatus: documents.ingestStatus, content: documents.content })
+          .from(documents)
+          .where(eq(documents.fileId, fileId))
+          .limit(1);
+
+        const isPdf = (file.name ?? '').toLowerCase().endsWith('.pdf');
+        const ragEnabled = isRagEnabled();
+
+        if (!existingDoc) {
+          // No document yet (plain file-library upload): create one. PDFs get parsed by
+          // the sidecar (parse 'pending'); other binary types have nothing to parse yet.
+          const [createdDoc] = await db
+            .insert(documents)
+            .values({
+              title: file.name,
+              content: '',
+              fileType: file.fileType,
+              filename: file.name,
+              sourceType: 'knowledge-base',
+              source: file.key,
+              fileId: file.id,
+              userId: user.id,
+              clientId: user.id,
+              parseStatus: isPdf ? 'pending' : 'ready',
+              ingestStatus: ragEnabled && isPdf ? 'pending' : 'none',
+            })
+            .returning({ id: documents.id });
+          if (ragEnabled && isPdf && createdDoc) docIdsToIngest.push(createdDoc.id);
+        } else if (ragEnabled && existingDoc.ingestStatus === 'none') {
+          // Document exists but was never embedded — activate it now that it joined a KB.
+          const hasContent = Boolean(existingDoc.content?.trim().length);
+          if (hasContent || isPdf) {
+            await db
+              .update(documents)
+              .set({
+                ingestStatus: 'pending',
+                ...(hasContent ? { tokenEstimate: estimateTokens(existingDoc.content ?? '') } : {}),
+              })
+              .where(eq(documents.id, existingDoc.id));
+            docIdsToIngest.push(existingDoc.id);
+          }
+        }
       } catch (error) {
         errors.push({
           fileId,
           error: error instanceof Error ? error.message : 'Unknown error'
         });
       }
+    }
+
+    // After the loop so a queue failure never breaks the KB membership writes.
+    for (const docId of docIdsToIngest) {
+      await scheduleRagIngest(docId);
     }
 
     return {


### PR DESCRIPTION
Owner 实测三连 bug：①getKbDocumentsFn 裸传参数（唯一一处没包 {data}）→ 列表静默空 ②删除只刷 loader 不刷 query → 不即时更新 ③addKbDocuments 只写关联不建 document 不触发 ingest → 状态空且永不可检索（语义缺口：进知识库=进 RAG 管线，prd §4.3）。已部署生产，存量 backfill 后用户路径 minimax 1467 chunks 100% 带页码 ready。tsc 基线对比无新增错误。🤖 Generated with [Claude Code](https://claude.com/claude-code)