### PR TITLE
feat(rag): 阶段3 — 对话里勾选知识库限定检索范围

### DIFF
--- a/src/claude/adapters/ws-adapter.ts
+++ b/src/claude/adapters/ws-adapter.ts
@@ -109,7 +109,7 @@ type StreamEvent = {
 type InboundMessage =
   | { type: 'create_session'; projectId?: string }
   | { type: 'init_session'; sessionId: string }
-  | { type: 'chat'; content: string; sessionId?: string; skillSlug?: string; permissionTier?: string; model?: string }
+  | { type: 'chat'; content: string; sessionId?: string; skillSlug?: string; permissionTier?: string; model?: string; kbIds?: string[] }
   | { type: 'resume'; sessionId: string }
   | { type: 'abort' }
   | { type: 'start_preview'; sessionId?: string; mode?: 'static' | 'live'; force?: boolean }
@@ -862,6 +862,8 @@ const ClaudeAgentWSAdapter: ChatModelAdapter = {
           // Multi-model: per-conversation selected model id (server validates +
           // rejects on unknown/disabled/unhealthy; undefined → server default).
           model: useChatSessionStore.getState().selectedModelId,
+          // Session KB scope (面板勾选, prd 阶段3): kb_search restricts to these KBs.
+          kbIds: useChatSessionStore.getState().selectedKbIds,
         });
         console.log('[WS Adapter] ✅ Message sent successfully');
       } catch (connectError) {

--- a/src/components/claude-chat/knowledge-base-panel.tsx
+++ b/src/components/claude-chat/knowledge-base-panel.tsx
@@ -11,10 +11,11 @@
 
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus, FileText, Loader2, RefreshCw, Trash2, AlertCircle, Book } from 'lucide-react';
+import { Plus, FileText, Loader2, RefreshCw, Trash2, AlertCircle, Book, Search, CheckCircle2, Circle, CheckSquare, Square, Info } from 'lucide-react';
 import { useIntlayer } from 'react-intlayer';
 import { toLocalizedString } from '~/lib/utils';
 import { cn } from '~/lib/utils';
+import { useChatSessionStore } from '~/lib/chat-session-store';
 import { DocumentSelectorModal } from './document-selector-modal';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '~/components/ui/dialog';
 import { Button } from '~/components/ui/button';
@@ -48,6 +49,9 @@ export function KnowledgeBasePanel({ sessionId }: KnowledgeBasePanelProps) {
   const [syncingId, setSyncingId] = useState<string | null>(null);
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [addingKbId, setAddingKbId] = useState<string | null>(null);
+  // Session KB scope (prd 阶段3): kb_search restricts retrieval to the checked KBs.
+  const selectedKbIds = useChatSessionStore((s) => s.selectedKbIds);
+  const setSelectedKbIds = useChatSessionStore((s) => s.setSelectedKbIds);
 
   // Fetch session documents
   const { data, isLoading, error } = useQuery({
@@ -211,6 +215,66 @@ export function KnowledgeBasePanel({ sessionId }: KnowledgeBasePanelProps) {
 
   return (
     <div className="flex flex-col gap-3">
+      {/* ---- AI 检索范围 (KB redesign prd 阶段3) ---- */}
+      <div className="rounded-lg border border-border p-2.5">
+        <div className="mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Search className="h-3.5 w-3.5" />
+          AI 检索范围
+        </div>
+        <button
+          type="button"
+          onClick={() => setSelectedKbIds([])}
+          className={cn(
+            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+            selectedKbIds.length === 0 ? 'bg-primary/10 text-foreground' : 'text-foreground/80 hover:bg-accent'
+          )}
+        >
+          {selectedKbIds.length === 0 ? (
+            <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" />
+          ) : (
+            <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
+          )}
+          <span className="flex-1 text-left">全部我的文档</span>
+          {selectedKbIds.length === 0 && <span className="text-[10px] text-primary">默认</span>}
+        </button>
+        {knowledgeBases.map((kb) => {
+          const checked = selectedKbIds.includes(kb.id);
+          return (
+            <button
+              key={kb.id}
+              type="button"
+              onClick={() =>
+                setSelectedKbIds(
+                  checked ? selectedKbIds.filter((id) => id !== kb.id) : [...selectedKbIds, kb.id],
+                )
+              }
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                checked ? 'bg-primary/10 text-foreground' : 'text-foreground/80 hover:bg-accent'
+              )}
+            >
+              {checked ? (
+                <CheckSquare className="h-4 w-4 shrink-0 text-primary" />
+              ) : (
+                <Square className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="flex-1 truncate text-left">{kb.name}</span>
+              <span className="text-[10px] text-muted-foreground">{kb.documentCount} 文档</span>
+            </button>
+          );
+        })}
+        {selectedKbIds.length > 0 ? (
+          <div className="mt-1.5 flex items-center gap-1.5 rounded-md bg-primary/10 px-2 py-1 text-[11px] text-primary">
+            <Info className="h-3 w-3 shrink-0" />
+            本对话中 AI 只检索所选知识库
+          </div>
+        ) : (
+          <p className="mt-1.5 px-2 text-[11px] leading-relaxed text-muted-foreground">
+            勾选知识库后，AI 回答问题时只在所选范围内检索引用。
+          </p>
+        )}
+      </div>
+
       {/* Description */}
       <p className="text-xs text-muted-foreground">
         {content.knowledgeBase.description}

--- a/src/lib/chat-session-store.ts
+++ b/src/lib/chat-session-store.ts
@@ -195,6 +195,10 @@ interface ChatSessionState {
   // localStorage (PR8) and restored on session switch/resume.
   selectedModelId?: string;
 
+  // Session KB scope (KB 面板勾选, prd 阶段3): kb_search restricts retrieval to these
+  // knowledge bases for this conversation. Empty = all visible documents (default).
+  selectedKbIds: string[];
+
   // Skill to arm once the NEXT (newly-created) session is ready. Used by the
   // A2Composer "open new chat & load" flow: the skill was just enabled (effective
   // next conversation per SDK constraint), so we arm it in the fresh session.
@@ -233,6 +237,7 @@ interface ChatSessionState {
   clearTemporarySkills: () => void;
   setSelectedTier: (mode: InteractionMode | undefined) => void;
   setSelectedModelId: (id: string | undefined) => void;
+  setSelectedKbIds: (ids: string[]) => void;
   setPendingArmedSkill: (skill: { slug: string; name?: string; hint?: string } | undefined) => void;
   setPendingProjectId: (projectId: string | undefined) => void;
 
@@ -483,11 +488,16 @@ export const useChatSessionStore = create<ChatSessionState>((set, get) => ({
   temporarySkills: [],
   selectedTier: 'act' as const, // default: 执行(Act) — full capability, sandbox is the guard
   selectedModelId: undefined,
+  selectedKbIds: [],
   pendingArmedSkill: undefined,
   pendingProjectId: undefined,
 
   setSelectedTier: (selectedTier) => {
     set({ selectedTier });
+  },
+
+  setSelectedKbIds: (selectedKbIds: string[]) => {
+    set({ selectedKbIds });
   },
 
   setPendingArmedSkill: (pendingArmedSkill) => {

--- a/src/routes/api/rag/search.ts
+++ b/src/routes/api/rag/search.ts
@@ -32,7 +32,7 @@ export const Route = createFileRoute('/api/rag/search')({
         } catch {
           return Response.json({ error: 'invalid JSON body' }, { status: 400 });
         }
-        const { query, k, documentId, kbId } = (body ?? {}) as Record<string, unknown>;
+        const { query, k, documentId, kbId, kbIds } = (body ?? {}) as Record<string, unknown>;
         if (typeof query !== 'string' || !query.trim()) {
           return Response.json({ error: 'query is required' }, { status: 400 });
         }
@@ -42,6 +42,8 @@ export const Route = createFileRoute('/api/rag/search')({
           k: typeof k === 'number' ? k : undefined,
           documentId: typeof documentId === 'string' ? documentId : undefined,
           kbId: typeof kbId === 'string' ? kbId : undefined,
+          // Session scope picker (prd 阶段3): forwarded by the worker from the chat request.
+          kbIds: Array.isArray(kbIds) ? kbIds.filter((v): v is string => typeof v === 'string') : undefined,
         });
         return Response.json({ hits });
       },

--- a/src/server/rag/search.ts
+++ b/src/server/rag/search.ts
@@ -21,9 +21,11 @@ export interface KbSearchParams {
   query: string;
   /** Results to return (default 8). */
   k?: number;
-  /** Optional narrowing: a single document, or a knowledge base (via kb_documents). */
+  /** Optional narrowing: a single document, or knowledge base(s) (via kb_documents). */
   documentId?: string;
   kbId?: string;
+  /** Session-selected scope (KB 面板勾选, prd 阶段3): union of these KBs. kbId wins if set. */
+  kbIds?: string[];
   /** Ablation knobs for the golden-set eval (R4) — production callers leave them unset. */
   skipRerank?: boolean;
   skipBm25?: boolean;
@@ -64,14 +66,16 @@ async function visibleDocIds(userId: string, params: KbSearchParams): Promise<st
     .where(and(visibleDocumentsWhere(userId, projectIds), eq(documents.ingestStatus, 'ready')));
 
   let ids = rows;
+  const kbScope = params.kbId ? [params.kbId] : (params.kbIds ?? []);
   if (params.documentId) {
     ids = ids.filter((r) => r.id === params.documentId);
-  } else if (params.kbId) {
-    // kb_documents links a KB to FILES; documents hang off the same fileId.
+  } else if (kbScope.length > 0) {
+    // kb_documents links KBs to FILES; documents hang off the same fileId. Multiple
+    // selected KBs = the union of their files (session scope picker, prd 阶段3).
     const kbFiles = await db
       .select({ fileId: kbDocuments.fileId })
       .from(kbDocuments)
-      .where(eq(kbDocuments.kbId, params.kbId));
+      .where(inArray(kbDocuments.kbId, kbScope));
     const fileSet = new Set(kbFiles.map((f) => f.fileId));
     ids = ids.filter((r) => r.fileId && fileSet.has(r.fileId));
   }

--- a/ws-query-worker.mjs
+++ b/ws-query-worker.mjs
@@ -253,6 +253,9 @@ async function startRun(request) {
       userId,
       // RAG R2: user auth for the kb_search app callback (stdin-only — never env).
       cookie: userCookie = null,
+      // Session KB scope (面板勾选, prd 阶段3): kb_search restricts to these knowledge
+      // bases unless the model explicitly passes its own kbId.
+      kbIds: sessionKbIds = [],
     } = request;
     const permissionMode = resolvePermissionMode(requestedPermissionMode, userId);
     const disallowedTools = resolveDisallowedTools(
@@ -532,10 +535,12 @@ async function startRun(request) {
       },
       async (args) => {
         try {
+          // Session scope (面板勾选) applies unless the model narrowed explicitly.
+          const scoped = args.kbId || !sessionKbIds?.length ? args : { ...args, kbIds: sessionKbIds };
           const response = await fetch(`${appUrl}/api/rag/search`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', cookie: userCookie || '' },
-            body: JSON.stringify(args),
+            body: JSON.stringify(scoped),
           });
           if (!response.ok) {
             const text = await response.text().catch(() => '');

--- a/ws-server.mjs
+++ b/ws-server.mjs
@@ -1099,7 +1099,14 @@ async function resolveModelForChat(cookie, modelId) {
 }
 
 async function handleChat(ws, prompt, resumeSessionId, options = {}) {
-  const { silentInit = false, skillSlug = null, permissionTier = null, model: selectedModel = null } = options;
+  const {
+    silentInit = false,
+    skillSlug = null,
+    permissionTier = null,
+    model: selectedModel = null,
+    // Session KB scope (面板勾选): forwarded to the worker so kb_search restricts to it.
+    kbIds = [],
+  } = options;
   // Kill any existing worker for this connection
   if (ws.workerProcess) {
     console.log('[WS Server] Killing existing worker process');
@@ -1396,6 +1403,8 @@ async function handleChat(ws, prompt, resumeSessionId, options = {}) {
       // (/api/rag/search) with the user's own auth — via STDIN on purpose, never the
       // worker env, so agent-spawned Bash children can't read the cookie.
       cookie: ws.cookie,
+      // Session KB scope (面板勾选, prd 阶段3): kb_search restricts to these KBs.
+      kbIds,
     });
     // Newline-delimited + keep stdin OPEN so Ask-mode HITL can stream
     // approval_response lines to the worker mid-run. The worker exits on its own
@@ -1692,6 +1701,7 @@ async function handleMessage(ws, msg) {
         skillSlug: message.skillSlug,
         permissionTier: message.permissionTier,
         model: message.model,
+        kbIds: message.kbIds,
       });
       break;
 


### PR DESCRIPTION
KB 重做最后一块（prd §4.4）：KB 面板「AI 检索范围」区（默认全部/勾选限定+提示），勾选经 store→chat 消息→ws-server→worker→kb_search→searchKb kbIds[] 全链路穿透，多 KB 取并集、访问隔离不变、模型显式 kbId 优先。mjs 语法 OK/lint 0 error/tsc 349=349。已部署生产。🤖 Generated with [Claude Code](https://claude.com/claude-code)