### PR TITLE
feat(rag): 引用可点击 — [n] 来源 chip（悬停弹原文+页码）+ 来源列表卡

### DIFF
--- a/src/components/claude-chat/assistant-turn-card.tsx
+++ b/src/components/claude-chat/assistant-turn-card.tsx
@@ -17,6 +17,7 @@ import { ImageArtifact } from '~/components/claude-chat/artifact-image';
 import { DiffView } from '~/components/agent-chat/diff-view';
 import { cn } from '~/lib/utils';
 import { parseSearchResult, type SearchSource } from '~/lib/search-results';
+import { parseKbSearchResult, KbSearchSources, type KbSource } from '~/components/claude-chat/kb-search-sources';
 import { buildAssistantTurn, formatArgsSummary, stripMarkdown, truncate, type RenderItem, type SearchGroup, type StepActivity, type StepActivityStatus } from '~/lib/turn-builder';
 import { useChatSessionStore, type ContentPart } from '~/lib/chat-session-store';
 import { readWorkspaceBinaryFile, getMimeType } from '~/lib/artifacts/artifact-registry';
@@ -211,6 +212,19 @@ function ActivityDetailDrawer({
       } as const;
     }
 
+    // kb_search BEFORE the generic search branch (its name contains 'search' too):
+    // render structured knowledge-base sources instead of web-search link cards.
+    if (toolName.includes('kb_search') || toolName.includes('kb-search')) {
+      const kbSources = parseKbSearchResult(target.result);
+      if (kbSources) {
+        return {
+          type: 'kb-sources',
+          title: target.displayName,
+          kbSources,
+        } as const;
+      }
+    }
+
     if (toolName.includes('search')) {
       const searchResult = parseSearchResult(target.result);
       return {
@@ -343,6 +357,7 @@ function ActivityDetailDrawer({
           </DrawerClose>
         </DrawerHeader>
         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 pb-6">
+          {detail.type === 'kb-sources' && <KbSearchSources sources={detail.kbSources} />}
           {detail.type === 'search' && (
             <>
               {detail.queries && detail.queries.length > 0 && (
@@ -565,6 +580,20 @@ export const AssistantTurnCard: FC<AssistantTurnCardProps> = ({
   const hasResponse = Boolean(responseText);
   const hasActivities = activities.length > 0;
 
+  // kb_search sources of this turn → [n] markers in the answer become citation chips
+  // (hover/click pops the passage). Later calls win on duplicate numbers.
+  const kbSources = useMemo(() => {
+    let sources: KbSource[] | undefined;
+    for (const a of activities) {
+      if (a.kind !== 'tool') continue;
+      const name = a.toolName.toLowerCase();
+      if (!name.includes('kb_search') && !name.includes('kb-search')) continue;
+      const parsed = parseKbSearchResult(a.result);
+      if (parsed) sources = sources ? [...sources.filter((s) => !parsed.some((p) => p.n === s.n)), ...parsed] : parsed;
+    }
+    return sources;
+  }, [activities]);
+
   // D1.4 Cowork 折叠头：完成后用「Worked Xs · N steps · 改 K 文件」概览（有耗时/步数才显示），
   // 运行中仍用实时 previewText。stepCount=0（纯思考轮）回退到 previewText 避免「0 steps」。
   const summaryText = useMemo(() => {
@@ -758,6 +787,7 @@ export const AssistantTurnCard: FC<AssistantTurnCardProps> = ({
             mode="minimal"
             onUrlClick={onUrlClick}
             onFileClick={onFileClick}
+            kbSources={kbSources}
           />
         </div>
       )}

--- a/src/components/claude-chat/kb-search-sources.tsx
+++ b/src/components/claude-chat/kb-search-sources.tsx
@@ -1,0 +1,132 @@
+/**
+ * kb_search citations (KB redesign 收尾): turn the model's [1][2] markers into
+ * something a non-technical user can USE — a clickable chip that pops the source
+ * (document title / section path / page range / passage text).
+ *
+ * Data comes from parsing the kb_search tool result envelope the worker formats:
+ *   <retrieved-passages note="...">
+ *   [1] 标题 — 章节路径 (p.21) \n 正文
+ *   \n\n---\n\n
+ *   [2] ...
+ *   </retrieved-passages>
+ * The format is ours (ws-query-worker.mjs), so parsing it client-side is stable and
+ * costs zero extra tokens (no JSON duplication into the prompt).
+ */
+
+'use client';
+
+import { BookOpen, FileText } from 'lucide-react';
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from '~/components/ui/hover-card';
+
+export interface KbSource {
+  n: number;
+  title: string;
+  section: string | null;
+  pageStart: number | null;
+  pageEnd: number | null;
+  text: string;
+}
+
+/** Parse the worker's retrieved-passages envelope into structured sources. */
+export function parseKbSearchResult(raw: unknown): KbSource[] | null {
+  const text = typeof raw === 'string' ? raw : raw ? JSON.stringify(raw) : '';
+  if (!text.includes('<retrieved-passages')) return null;
+  const inner = text
+    .replace(/^[\s\S]*?<retrieved-passages[^>]*>\n?/, '')
+    .replace(/\n?<\/retrieved-passages>[\s\S]*$/, '');
+  const blocks = inner.split(/\n\n---\n\n/);
+  const sources: KbSource[] = [];
+  for (const block of blocks) {
+    const m = block.match(/^\[(\d+)\]\s*([^\n]*)\n([\s\S]*)$/);
+    if (!m) continue;
+    let header = m[2].trim();
+    let pageStart: number | null = null;
+    let pageEnd: number | null = null;
+    const pm = header.match(/\s*\(p\.(\d+)(?:-(\d+))?\)\s*$/);
+    if (pm) {
+      pageStart = Number(pm[1]);
+      pageEnd = pm[2] ? Number(pm[2]) : pageStart;
+      header = header.slice(0, pm.index).trim();
+    }
+    const dash = header.indexOf(' — ');
+    const title = dash >= 0 ? header.slice(0, dash).trim() : header;
+    const section = dash >= 0 ? header.slice(dash + 3).trim() : null;
+    sources.push({ n: Number(m[1]), title, section, pageStart, pageEnd, text: m[3].trim() });
+  }
+  return sources.length > 0 ? sources : null;
+}
+
+function pageLabel(s: KbSource): string | null {
+  if (s.pageStart == null) return null;
+  return s.pageEnd && s.pageEnd !== s.pageStart ? `第 ${s.pageStart}-${s.pageEnd} 页` : `第 ${s.pageStart} 页`;
+}
+
+/** The [n] chip in answer text — hover/click pops the source passage. */
+export function KbCitation({ n, source }: { n: number; source?: KbSource }) {
+  if (!source) {
+    return <sup className="mx-0.5 text-[11px] text-muted-foreground">[{n}]</sup>;
+  }
+  const pages = pageLabel(source);
+  return (
+    <HoverCard openDelay={150} closeDelay={120}>
+      <HoverCardTrigger asChild>
+        <sup>
+          <button
+            type="button"
+            className="mx-0.5 inline-flex h-4 min-w-4 cursor-pointer items-center justify-center rounded bg-primary/15 px-1 align-super text-[10px] font-medium text-primary transition-colors hover:bg-primary/25"
+          >
+            {n}
+          </button>
+        </sup>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" align="start" className="w-80 p-3">
+        <div className="flex items-start gap-2">
+          <BookOpen className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">{source.title}</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {source.section ?? ''}
+              {source.section && pages ? ' · ' : ''}
+              {pages ?? ''}
+            </p>
+          </div>
+        </div>
+        <p className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-xs leading-relaxed text-foreground/85">
+          {source.text}
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+/** Source list card — rendered for the kb_search tool detail (drawer / inline). */
+export function KbSearchSources({ sources }: { sources: KbSource[] }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">从你的知识库中检索到 {sources.length} 段相关内容：</p>
+      {sources.map((s) => {
+        const pages = pageLabel(s);
+        return (
+          <div key={s.n} data-kb-src={s.n} className="rounded-lg border border-border/70 p-2.5">
+            <div className="flex items-center gap-2">
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-primary/15 text-[11px] font-medium text-primary">
+                {s.n}
+              </span>
+              <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate text-sm text-foreground">{s.title}</span>
+              {pages && (
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{pages}</span>
+              )}
+            </div>
+            {s.section && <p className="mt-1 truncate pl-7 text-xs text-muted-foreground">{s.section}</p>}
+            <p className="mt-1.5 line-clamp-3 pl-7 text-xs leading-relaxed text-foreground/80">{s.text}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/claude-chat/streaming-markdown.tsx
+++ b/src/components/claude-chat/streaming-markdown.tsx
@@ -11,13 +11,33 @@
  */
 
 import { memo, useMemo } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import {
   markdownRemarkPlugins,
   createMarkdownComponents,
   preprocessLinks,
   type RenderMode,
 } from '~/components/claude-chat/markdown-components';
+import { KbCitation, type KbSource } from '~/components/claude-chat/kb-search-sources';
+
+/**
+ * Turn bare [n] citation markers (from kb_search answers) into anchor links the `a`
+ * override below renders as clickable source chips. Only applied when the turn actually
+ * has kb sources. Handles runs like [2][3] (matched as a whole, then split), skips
+ * markdown links `[x](...)`/`[x][y]`, index access `arr[1]`, and code spans/fences.
+ */
+function preprocessKbCitations(content: string): string {
+  return content
+    .split(/(```[\s\S]*?```|`[^`\n]*`)/)
+    .map((seg, i) =>
+      i % 2 === 1
+        ? seg
+        : seg.replace(/(?<![\w\]])((?:\[\d{1,2}\])+)(?!\()/g, (run) =>
+            run.replace(/\[(\d{1,2})\]/g, '[$1](#kb-cite-$1)'),
+          ),
+    )
+    .join('');
+}
 
 type StreamingMarkdownProps = {
   content: string;
@@ -35,6 +55,11 @@ type StreamingMarkdownProps = {
    * Callback when a file path is clicked
    */
   onFileClick?: (path: string) => void;
+  /**
+   * kb_search sources for this turn — enables rendering bare [n] markers as
+   * clickable citation chips (hover/click → source passage popover).
+   */
+  kbSources?: KbSource[];
 };
 
 type Block = {
@@ -105,18 +130,34 @@ interface MemoizedBlockProps {
   mode?: RenderMode;
   onUrlClick?: (url: string) => void;
   onFileClick?: (path: string) => void;
+  kbSources?: KbSource[];
 }
 
 const MemoizedBlock = memo(
-  function MemoizedBlock({ content, mode = 'minimal', onUrlClick, onFileClick }: MemoizedBlockProps) {
+  function MemoizedBlock({ content, mode = 'minimal', onUrlClick, onFileClick, kbSources }: MemoizedBlockProps) {
+    const hasCitations = !!kbSources?.length;
     // Preprocess content to convert raw URLs and file paths to markdown links
-    const processedContent = useMemo(() => preprocessLinks(content), [content]);
+    const processedContent = useMemo(() => {
+      const linked = preprocessLinks(content);
+      return hasCitations ? preprocessKbCitations(linked) : linked;
+    }, [content, hasCitations]);
 
-    // Create components with callbacks
-    const components = useMemo(
-      () => createMarkdownComponents({ mode, onUrlClick, onFileClick }),
-      [mode, onUrlClick, onFileClick]
-    );
+    // Create components with callbacks; with kb sources, the `a` override renders
+    // #kb-cite-n anchors as source chips (hover/click → passage popover).
+    const components = useMemo<Components>(() => {
+      const base = createMarkdownComponents({ mode, onUrlClick, onFileClick });
+      if (!hasCitations) return base;
+      const BaseA = base.a as React.ComponentType<Record<string, unknown>> | undefined;
+      const CitationAwareA = (props: { href?: string; children?: React.ReactNode } & Record<string, unknown>) => {
+        const href = props.href ?? '';
+        if (href.startsWith('#kb-cite-')) {
+          const n = Number(href.slice('#kb-cite-'.length));
+          return <KbCitation n={n} source={kbSources!.find((s) => s.n === n)} />;
+        }
+        return BaseA ? <BaseA {...props} /> : <a {...(props as React.ComponentProps<'a'>)} />;
+      };
+      return { ...base, a: CitationAwareA as Components['a'] };
+    }, [mode, onUrlClick, onFileClick, hasCitations, kbSources]);
 
     return (
       <ReactMarkdown
@@ -131,7 +172,8 @@ const MemoizedBlock = memo(
     prev.content === next.content &&
     prev.mode === next.mode &&
     prev.onUrlClick === next.onUrlClick &&
-    prev.onFileClick === next.onFileClick
+    prev.onFileClick === next.onFileClick &&
+    prev.kbSources === next.kbSources
 );
 
 export const StreamingMarkdown = ({
@@ -140,6 +182,7 @@ export const StreamingMarkdown = ({
   mode = 'minimal',
   onUrlClick,
   onFileClick,
+  kbSources,
 }: StreamingMarkdownProps) => {
   const blocks = useMemo(
     () => (isStreaming ? splitIntoBlocks(content) : []),
@@ -153,6 +196,7 @@ export const StreamingMarkdown = ({
         mode={mode}
         onUrlClick={onUrlClick}
         onFileClick={onFileClick}
+        kbSources={kbSources}
       />
     );
   }
@@ -169,6 +213,7 @@ export const StreamingMarkdown = ({
             mode={mode}
             onUrlClick={onUrlClick}
             onFileClick={onFileClick}
+            kbSources={block.isCodeBlock ? undefined : kbSources}
           />
         );
       })}


### PR DESCRIPTION
RAG 引用闭环最后一步（Owner: [1][2] 要能点击看原文）。解析 worker retrieved-passages 信封→KbCitation chip（HoverCard 弹文档/章节/页码/原文）+ kb_search 工具详情专属来源卡（之前误入 web-search 分支）。解析器真格式全过/regex 六边界用例全过/lint 0。已部署生产。🤖 Generated with [Claude Code](https://claude.com/claude-code)