### PR TITLE
feat(updater): online auto-update P1/P2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -370,3 +370,23 @@ CLOUDFLARED_TUNNEL_TOKEN=""
 # If you want to run the app/worker containers from a built image:
 APP_IMAGE="ghcr.io/your-org/your-repo/app"
 APP_TAG="latest"
+
+# =============================================================================
+# ONLINE AUTO-UPDATE (Kin M3 — "Web Server Update" in the admin panel)
+# =============================================================================
+# Lets a system admin upgrade the server in place from the panel (pull -> migrate ->
+# recreate worker -> recreate app), with image rollback on health-gate failure.
+# Requires M0 (multi-arch GHCR images) + D1 (prod pulls GHCR) to be end-to-end useful.
+#
+# Shared secret between `app` and the `updater` sidecar. Generate per-deploy:
+#   openssl rand -hex 32
+# Empty = the updater rejects every request (401) and the panel button stays disabled.
+UPDATER_TOKEN=""
+# How the app reaches the updater sidecar over the internal network (no host port).
+# UPDATER_URL="http://updater:5066"
+# UPDATER_PORT="5066"
+# Update-check cadence (BullMQ repeat; default every 6h). Read-only GHCR digest poll.
+# UPDATE_CHECK_CRON="0 */6 * * *"
+# Override the GHCR image to poll (defaults to APP_IMAGE:APP_TAG when APP_IMAGE is a
+# ghcr.io ref, else ghcr.io/deeptoai-com/kin/app:latest).
+# UPDATE_CHECK_IMAGE="ghcr.io/deeptoai-com/kin/app:latest"

--- a/Dockerfile.updater
+++ b/Dockerfile.updater
@@ -1,0 +1,23 @@
+# Updater sidecar image — Kin online auto-update (M3).
+#
+# Deliberately a DEDICATED, minimal image (not the app image): this decouples the updater
+# from the app stack so it is never pulled/recreated when the app is upgraded, and so it can
+# never force-recreate itself (防自杀, spec §4.2/§5). It provides exactly what controller.mjs
+# needs to drive the host daemon over the mounted /var/run/docker.sock:
+#   - the docker CLI + bundled `docker compose` v2 plugin (official docker:*-cli images ship it)
+#   - node (to run the Node-stdlib controller; no npm deps)
+#
+# Build:  docker build -f Dockerfile.updater -t kin-updater:local .
+# (If a future base image ever drops the bundled compose plugin, add:
+#    RUN apk add --no-cache docker-cli-compose )
+FROM docker:28-cli
+
+RUN apk add --no-cache nodejs
+
+WORKDIR /app
+COPY src/updater/controller.mjs ./src/updater/controller.mjs
+
+# Internal-only service — compose does NOT publish this port to the host.
+EXPOSE 5066
+
+CMD ["node", "src/updater/controller.mjs"]

--- a/drizzle/0033_warm_mastermind.sql
+++ b/drizzle/0033_warm_mastermind.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "update_status" (
+	"id" text PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+	"image" text,
+	"current_sha" text,
+	"latest_sha" text,
+	"latest_digest" text,
+	"update_available" boolean DEFAULT false NOT NULL,
+	"checked_at" timestamp with time zone,
+	"error" text
+);

--- a/drizzle/meta/0033_snapshot.json
+++ b/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,4086 @@
+{
+  "id": "61e498f4-80f2-4ff6-b293-4e9ab47d6ebb",
+  "prevId": "153e815a-dc74-4edb-a704-69974ad7cf5d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_key_unique": {
+          "name": "files_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_chunks": {
+      "name": "document_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_path": {
+          "name": "section_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_start": {
+          "name": "page_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_end": {
+          "name": "page_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_chunk_id": {
+          "name": "parent_chunk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_prefix": {
+          "name": "context_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_document_chunks_document": {
+          "name": "idx_document_chunks_document",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_chunks_content_hash": {
+          "name": "idx_document_chunks_content_hash",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_document_chunks_embedding_hnsw": {
+          "name": "idx_document_chunks_embedding_hnsw",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_chunks_document_id_documents_id_fk": {
+          "name": "document_chunks_document_id_documents_id_fk",
+          "tableFrom": "document_chunks",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_chunks_file_id_files_id_fk": {
+          "name": "document_chunks_file_id_files_id_fk",
+          "tableFrom": "document_chunks",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "document_chunks_parent_chunk_id_document_chunks_id_fk": {
+          "name": "document_chunks_parent_chunk_id_document_chunks_id_fk",
+          "tableFrom": "document_chunks",
+          "tableTo": "document_chunks",
+          "columnsFrom": [
+            "parent_chunk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_char_count": {
+          "name": "total_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_line_count": {
+          "name": "total_line_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parse_method": {
+          "name": "parse_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "ingest_status": {
+          "name": "ingest_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "ingest_progress": {
+          "name": "ingest_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "token_estimate": {
+          "name": "token_estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rag_tier": {
+          "name": "rag_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toc": {
+          "name": "toc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_map": {
+          "name": "page_map",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_model": {
+          "name": "embed_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_dim": {
+          "name": "embed_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_documents_project": {
+          "name": "idx_documents_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_user": {
+          "name": "idx_documents_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_file_id_files_id_fk": {
+          "name": "documents_file_id_files_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_project_id_project_id_fk": {
+          "name": "documents_project_id_project_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_role": {
+          "name": "system_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_info": {
+      "name": "billing_info",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line1": {
+          "name": "line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line2": {
+          "name": "line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat": {
+          "name": "vat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_info_user_id_user_id_fk": {
+          "name": "billing_info_user_id_user_id_fk",
+          "tableFrom": "billing_info",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_allotment": {
+          "name": "monthly_allotment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allotment_used": {
+          "name": "allotment_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "extra_credits": {
+          "name": "extra_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_daily_refill_at": {
+          "name": "last_daily_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_user_id_user_id_fk": {
+          "name": "credit_balances_user_id_user_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta": {
+          "name": "delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_ledger_user_id_user_id_fk": {
+          "name": "credit_ledger_user_id_user_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polar'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_url": {
+          "name": "hosted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'paid'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invoices_external_id_idx": {
+          "name": "invoices_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_user_id_user_id_fk": {
+          "name": "invoices_user_id_user_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_credits": {
+          "name": "monthly_credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polar_product_id": {
+          "name": "polar_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_amount_cents": {
+          "name": "unit_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_subscription_id": {
+          "name": "polar_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscriptions_plan_id_plans_id_fk": {
+          "name": "subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_polar_subscription_id_unique": {
+          "name": "subscriptions_polar_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polar_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_record": {
+      "name": "usage_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_turns": {
+          "name": "num_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "is_error": {
+          "name": "is_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_record_user_id_idx": {
+          "name": "usage_record_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_record_run_id_idx": {
+          "name": "usage_record_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_record_created_at_idx": {
+          "name": "usage_record_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_record_user_id_user_id_fk": {
+          "name": "usage_record_user_id_user_id_fk",
+          "tableFrom": "usage_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_owner": {
+          "name": "idx_project_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_one_default_per_owner": {
+          "name": "idx_project_one_default_per_owner",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"project\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_owner_user_id_user_id_fk": {
+          "name": "project_owner_user_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_member": {
+      "name": "project_member",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "project_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_member_user": {
+          "name": "idx_project_member_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_member_project_id_project_id_fk": {
+          "name": "project_member_project_id_project_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_member_user_id_user_id_fk": {
+          "name": "project_member_user_id_user_id_fk",
+          "tableFrom": "project_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_member_project_id_user_id_pk": {
+          "name": "project_member_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_session": {
+      "name": "agent_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branched_from_session_id": {
+          "name": "branched_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_sdk_session_id": {
+          "name": "real_sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_home_path": {
+          "name": "claude_home_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_session_user": {
+          "name": "idx_agent_session_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_session_project": {
+          "name": "idx_agent_session_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_session_updated": {
+          "name": "idx_agent_session_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_session_user_sdk": {
+          "name": "idx_agent_session_user_sdk",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sdk_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_session_user_id_user_id_fk": {
+          "name": "agent_session_user_id_user_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_project_id_project_id_fk": {
+          "name": "agent_session_project_id_project_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_session_branched_from_session_id_agent_session_id_fk": {
+          "name": "agent_session_branched_from_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent_session",
+          "columnsFrom": [
+            "branched_from_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_document": {
+      "name": "session_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_document_session": {
+          "name": "idx_session_document_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_document_file": {
+          "name": "idx_session_document_file",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_document_unique": {
+          "name": "idx_session_document_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_document_session_id_agent_session_id_fk": {
+          "name": "session_document_session_id_agent_session_id_fk",
+          "tableFrom": "session_document",
+          "tableTo": "agent_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_document_file_id_files_id_fk": {
+          "name": "session_document_file_id_files_id_fk",
+          "tableFrom": "session_document",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_attachment": {
+      "name": "message_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded": {
+          "name": "uploaded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenced": {
+          "name": "referenced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_message_attachment_session": {
+          "name": "idx_message_attachment_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_attachment_message": {
+          "name": "idx_message_attachment_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_attachment_session_message": {
+          "name": "idx_message_attachment_session_message",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_attachment_session_id_agent_session_id_fk": {
+          "name": "message_attachment_session_id_agent_session_id_fk",
+          "tableFrom": "message_attachment",
+          "tableTo": "agent_session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_bases": {
+      "name": "knowledge_bases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_knowledge_bases_user": {
+          "name": "idx_knowledge_bases_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_knowledge_bases_project": {
+          "name": "idx_knowledge_bases_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_bases_project_id_project_id_fk": {
+          "name": "knowledge_bases_project_id_project_id_fk",
+          "tableFrom": "knowledge_bases",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_documents": {
+      "name": "kb_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kb_id": {
+          "name": "kb_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kb_documents_kb": {
+          "name": "idx_kb_documents_kb",
+          "columns": [
+            {
+              "expression": "kb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_documents_file": {
+          "name": "idx_kb_documents_file",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_documents_unique": {
+          "name": "idx_kb_documents_unique",
+          "columns": [
+            {
+              "expression": "kb_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_documents_kb_id_knowledge_bases_id_fk": {
+          "name": "kb_documents_kb_id_knowledge_bases_id_fk",
+          "tableFrom": "kb_documents",
+          "tableTo": "knowledge_bases",
+          "columnsFrom": [
+            "kb_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kb_documents_file_id_files_id_fk": {
+          "name": "kb_documents_file_id_files_id_fk",
+          "tableFrom": "kb_documents",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fullName": {
+          "name": "fullName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOnboardingComplete": {
+          "name": "isOnboardingComplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_id_user_id_fk": {
+          "name": "profile_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_username_unique": {
+          "name": "profile_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_catalog": {
+      "name": "skill_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_zh": {
+          "name": "title_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_zh": {
+          "name": "summary_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "skill_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "skill_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reusability_status": {
+          "name": "reusability_status",
+          "type": "skill_reusability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suitable_for_zh": {
+          "name": "suitable_for_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_zh": {
+          "name": "problem_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_task_zh": {
+          "name": "first_task_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_notes_zh": {
+          "name": "risk_notes_zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_emoji": {
+          "name": "icon_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_weight": {
+          "name": "sort_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "adds_count": {
+          "name": "adds_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "skill_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'curated'"
+        },
+        "upstream": {
+          "name": "upstream",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "install_command": {
+          "name": "install_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills_sh_url": {
+          "name": "skills_sh_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_icon": {
+          "name": "source_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "skill_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'official'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_catalog_official_slug": {
+          "name": "idx_skill_catalog_official_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope = 'official'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_catalog_user_slug": {
+          "name": "idx_skill_catalog_user_slug",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "scope = 'user'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_catalog_category": {
+          "name": "idx_skill_catalog_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_catalog_sort": {
+          "name": "idx_skill_catalog_sort",
+          "columns": [
+            {
+              "expression": "sort_weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_catalog_owner_user_id_user_id_fk": {
+          "name": "skill_catalog_owner_user_id_user_id_fk",
+          "tableFrom": "skill_catalog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_content_cache": {
+      "name": "skill_content_cache",
+      "schema": "",
+      "columns": {
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_md": {
+          "name": "skill_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files": {
+          "name": "files",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_scraped_at": {
+          "name": "upstream_scraped_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skill_content_cache_catalog_id_skill_catalog_id_fk": {
+          "name": "skill_content_cache_catalog_id_skill_catalog_id_fk",
+          "tableFrom": "skill_content_cache",
+          "tableTo": "skill_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_enablement": {
+      "name": "skill_enablement",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skill_enablement_user_id_user_id_fk": {
+          "name": "skill_enablement_user_id_user_id_fk",
+          "tableFrom": "skill_enablement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_enablement_catalog_id_skill_catalog_id_fk": {
+          "name": "skill_enablement_catalog_id_skill_catalog_id_fk",
+          "tableFrom": "skill_enablement",
+          "tableTo": "skill_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "skill_enablement_user_id_catalog_id_pk": {
+          "name": "skill_enablement_user_id_catalog_id_pk",
+          "columns": [
+            "user_id",
+            "catalog_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_schema_cache": {
+      "name": "skill_schema_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "skill_schema_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'missing'"
+        },
+        "generator_version": {
+          "name": "generator_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_skill_schema_catalog_hash": {
+          "name": "idx_skill_schema_catalog_hash",
+          "columns": [
+            {
+              "expression": "catalog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_schema_cache_catalog_id_skill_catalog_id_fk": {
+          "name": "skill_schema_cache_catalog_id_skill_catalog_id_fk",
+          "tableFrom": "skill_schema_cache",
+          "tableTo": "skill_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_connection": {
+      "name": "model_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_style": {
+          "name": "auth_style",
+          "type": "model_auth_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bearer'"
+        },
+        "token_env": {
+          "name": "token_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anthropic_version": {
+          "name": "anthropic_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2023-06-01'"
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_opus": {
+          "name": "alias_opus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_sonnet": {
+          "name": "alias_sonnet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_haiku": {
+          "name": "alias_haiku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_subagent": {
+          "name": "alias_subagent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_definition": {
+      "name": "model_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_definition_connection_id_model_connection_id_fk": {
+          "name": "model_definition_connection_id_model_connection_id_fk",
+          "tableFrom": "model_definition",
+          "tableTo": "model_connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_health": {
+      "name": "model_health",
+      "schema": "",
+      "columns": {
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "model_health_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "probe_error": {
+          "name": "probe_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_health_model_id_model_definition_id_fk": {
+          "name": "model_health_model_id_model_definition_id_fk",
+          "tableFrom": "model_health",
+          "tableTo": "model_definition",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_search_trace": {
+      "name": "rag_search_trace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_doc_count": {
+          "name": "visible_doc_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vector_ids": {
+          "name": "vector_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bm25_ids": {
+          "name": "bm25_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fused_ids": {
+          "name": "fused_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reranked_ids": {
+          "name": "reranked_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_ids": {
+          "name": "returned_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "degraded": {
+          "name": "degraded",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rag_search_trace_user": {
+          "name": "idx_rag_search_trace_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rag_search_trace_created": {
+          "name": "idx_rag_search_trace_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rag_search_trace_session": {
+          "name": "idx_rag_search_trace_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ocr_jobs": {
+      "name": "ocr_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tables": {
+          "name": "tables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ocr_jobs_user": {
+          "name": "idx_ocr_jobs_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ocr_jobs_file_id_files_id_fk": {
+          "name": "ocr_jobs_file_id_files_id_fk",
+          "tableFrom": "ocr_jobs",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.update_status": {
+      "name": "update_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'singleton'"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_sha": {
+          "name": "current_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_sha": {
+          "name": "latest_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_digest": {
+          "name": "latest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_available": {
+          "name": "update_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.agent_id": {
+      "name": "agent_id",
+      "schema": "public",
+      "values": [
+        "assistant-agent",
+        "translator-agent"
+      ]
+    },
+    "public.project_role": {
+      "name": "project_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    },
+    "public.skill_category": {
+      "name": "skill_category",
+      "schema": "public",
+      "values": [
+        "ai_engineering",
+        "research",
+        "writing",
+        "design_frontend",
+        "automation",
+        "learning",
+        "security"
+      ]
+    },
+    "public.skill_level": {
+      "name": "skill_level",
+      "schema": "public",
+      "values": [
+        "L1",
+        "L2",
+        "L3",
+        "L4",
+        "L5"
+      ]
+    },
+    "public.skill_reusability": {
+      "name": "skill_reusability",
+      "schema": "public",
+      "values": [
+        "ready",
+        "minor_adaptation",
+        "major_adaptation",
+        "unknown"
+      ]
+    },
+    "public.skill_schema_status": {
+      "name": "skill_schema_status",
+      "schema": "public",
+      "values": [
+        "missing",
+        "valid",
+        "stale",
+        "failed",
+        "needs_review"
+      ]
+    },
+    "public.skill_scope": {
+      "name": "skill_scope",
+      "schema": "public",
+      "values": [
+        "official",
+        "user"
+      ]
+    },
+    "public.skill_source": {
+      "name": "skill_source",
+      "schema": "public",
+      "values": [
+        "curated",
+        "upstream",
+        "builtin",
+        "upload"
+      ]
+    },
+    "public.model_auth_style": {
+      "name": "model_auth_style",
+      "schema": "public",
+      "values": [
+        "bearer",
+        "x-api-key"
+      ]
+    },
+    "public.model_health_status": {
+      "name": "model_health_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy",
+        "unknown"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1781434303489,
       "tag": "0032_rag_trace_session",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1781528776856,
+      "tag": "0033_warm_mastermind",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/admin/server-update-dialog.tsx
+++ b/src/components/admin/server-update-dialog.tsx
@@ -1,0 +1,347 @@
+/**
+ * Server Update Dialog — admin-only 4-step "Web server update" flow (Kin M3, FR3–FR8).
+ *
+ * Opened from the sidebar "update available" entry. Steps:
+ *   1. Web server update — current/latest version + release notes + auto-check toggle
+ *   2. Are you absolutely sure? — warning + "check service status"
+ *   3. Ready to update — live service health checklist (verifyServices)
+ *   4. In progress — live phase chips (getApplyStatus), then auto-reload when /api/health flips
+ *
+ * Reuses the design-system shadcn primitives (Dialog/Button/Badge/Switch) + intlayer i18n.
+ * Degrades gracefully when the updater sidecar is unreachable (pre-M0 wiring): mutations
+ * surface an error rather than crashing.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useIntlayer } from 'react-intlayer';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { Button } from '~/components/ui/button';
+import { Switch } from '~/components/ui/switch';
+import { verifyServices, applyUpdate, getApplyStatus } from '~/server/function/updater.server';
+import {
+  Loader2,
+  CheckCircle2,
+  AlertTriangle,
+  ExternalLink,
+  RefreshCw,
+  Server,
+  ArrowRight,
+  Sparkles,
+  XCircle,
+  Check,
+} from 'lucide-react';
+
+export interface UpdateStatusView {
+  currentSha: string;
+  latestSha: string | null;
+  updateAvailable: boolean;
+  image: string | null;
+}
+
+interface ServiceRow {
+  service: string | null;
+  state: string | null;
+  health: string | null;
+  status: string | null;
+}
+
+interface ServerUpdateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  status: UpdateStatusView;
+  autoCheck: boolean;
+  onAutoCheckChange: (value: boolean) => void;
+  releaseNotesUrl?: string;
+}
+
+const short = (sha: string | null | undefined) => (sha ? sha.slice(0, 7) : '—');
+
+// updater phase -> 0..3 chip index (or special states)
+const PHASE_INDEX: Record<string, number> = {
+  'recording-good-image': 0,
+  pulling: 0,
+  migrating: 1,
+  'recreating-worker': 2,
+  'recreating-app': 3,
+  'health-gate': 3,
+  done: 4,
+};
+
+export function ServerUpdateDialog({
+  open,
+  onOpenChange,
+  status,
+  autoCheck,
+  onAutoCheckChange,
+  releaseNotesUrl = 'https://github.com/Deeptoai-com/kin/releases',
+}: ServerUpdateDialogProps) {
+  const sv = useIntlayer('serverUpdate');
+  const [step, setStep] = useState(1);
+  const [services, setServices] = useState<ServiceRow[]>([]);
+  const [allRunning, setAllRunning] = useState(false);
+  const [phase, setPhase] = useState<string>('pulling');
+  const [failed, setFailed] = useState<{ rolledBack: boolean } | null>(null);
+  const sawDowntime = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      setStep(1);
+      setServices([]);
+      setFailed(null);
+      setPhase('pulling');
+      sawDowntime.current = false;
+    }
+  }, [open]);
+
+  const verifyMutation = useMutation({
+    mutationFn: () => verifyServices(),
+    onSuccess: (data) => {
+      setServices((data?.services as ServiceRow[]) ?? []);
+      setAllRunning(Boolean(data?.allRunning));
+      setStep(3);
+    },
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: () => applyUpdate(),
+    onSuccess: () => setStep(4),
+  });
+
+  // Step 4: poll updater phase (best-effort) + app health; reload when the version flips.
+  useEffect(() => {
+    if (step !== 4) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const st = await getApplyStatus();
+        if (!cancelled && typeof st?.phase === 'string') setPhase(st.phase);
+        if (!cancelled && st?.error) setFailed({ rolledBack: Boolean(st?.rolledBack) });
+      } catch {
+        // app likely recreating — fall through to the health poll
+      }
+      try {
+        const res = await fetch('/api/health', { cache: 'no-store' });
+        if (res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { version?: string };
+          const versionChanged = body?.version && body.version !== status.currentSha;
+          if (!cancelled && (versionChanged || sawDowntime.current)) {
+            window.location.reload();
+            return;
+          }
+        } else {
+          sawDowntime.current = true;
+        }
+      } catch {
+        sawDowntime.current = true;
+      }
+    };
+    void tick();
+    const id = setInterval(tick, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [step, status.currentSha]);
+
+  const phaseIndex = PHASE_INDEX[phase] ?? 0;
+  const mutationError = verifyMutation.error || applyMutation.error;
+
+  const chips = [
+    { label: sv.step4.phasePull.value },
+    { label: sv.step4.phaseMigrate.value },
+    { label: sv.step4.phaseWorker.value },
+    { label: sv.step4.phaseApp.value },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !applyMutation.isPending && step !== 4 && onOpenChange(o)}>
+      <DialogContent className="max-w-lg">
+        {step === 1 && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Server className="size-5" /> {sv.step1.title}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-3 py-2">
+              <div className="flex flex-wrap items-center gap-2 text-sm">
+                <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
+                  {sv.common.currentVersion} {short(status.currentSha)}
+                </span>
+                {status.updateAvailable && (
+                  <>
+                    <ArrowRight className="size-4 text-muted-foreground" />
+                    <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-xs text-primary">
+                      <Sparkles className="size-3" /> {sv.step1.newVersion} {short(status.latestSha)}
+                    </span>
+                  </>
+                )}
+                {!status.updateAvailable && (
+                  <span className="text-xs text-muted-foreground">{sv.step1.upToDate}</span>
+                )}
+              </div>
+              <a
+                href={releaseNotesUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              >
+                <ExternalLink className="size-3.5" /> {sv.step1.releaseNotes}
+              </a>
+              <div className="flex items-center justify-between border-t pt-3">
+                <span className="text-sm text-muted-foreground">{sv.step1.autoCheck}</span>
+                <Switch checked={autoCheck} onCheckedChange={onAutoCheckChange} aria-label={sv.step1.autoCheck.value} />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                {sv.common.cancel}
+              </Button>
+              <Button disabled={!status.updateAvailable} onClick={() => setStep(2)}>
+                {sv.step1.updateServer}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="size-5 text-amber-500" /> {sv.step2.title}
+              </DialogTitle>
+              <DialogDescription className="pt-1 leading-relaxed">{sv.step2.warning}</DialogDescription>
+            </DialogHeader>
+            {mutationError && (
+              <p className="text-sm text-destructive">{String((mutationError as Error).message)}</p>
+            )}
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                {sv.common.cancel}
+              </Button>
+              <Button onClick={() => verifyMutation.mutate()} disabled={verifyMutation.isPending}>
+                {verifyMutation.isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                {sv.step2.verifyStatus}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 3 && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Server className="size-5" /> {sv.step3.title}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-2 py-2">
+              {services.length === 0 && (
+                <p className="text-sm text-muted-foreground">{sv.step3.checking}</p>
+              )}
+              <div className="grid grid-cols-2 gap-x-6 gap-y-1">
+                {services.map((s) => {
+                  const running = (s.state ?? '').toLowerCase() === 'running';
+                  return (
+                    <span key={s.service ?? Math.random()} className="flex items-center gap-2 py-1 text-sm">
+                      {running ? (
+                        <CheckCircle2 className="size-4 text-emerald-500" />
+                      ) : (
+                        <XCircle className="size-4 text-destructive" />
+                      )}
+                      {s.service}
+                    </span>
+                  );
+                })}
+              </div>
+              {services.length > 0 && (
+                <p className={`text-sm ${allRunning ? 'text-emerald-600' : 'text-amber-600'}`}>
+                  {allRunning ? sv.step3.allRunning : sv.step3.someNotRunning}
+                </p>
+              )}
+              {mutationError && (
+                <p className="text-sm text-destructive">{String((mutationError as Error).message)}</p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                {sv.common.cancel}
+              </Button>
+              <Button variant="outline" onClick={() => verifyMutation.mutate()} disabled={verifyMutation.isPending}>
+                <RefreshCw className={`mr-2 size-4 ${verifyMutation.isPending ? 'animate-spin' : ''}`} />
+                {sv.step3.recheck}
+              </Button>
+              <Button onClick={() => applyMutation.mutate()} disabled={applyMutation.isPending}>
+                {applyMutation.isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                {sv.step3.confirmUpgrade}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === 4 && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                {failed ? (
+                  <AlertTriangle className="size-5 text-destructive" />
+                ) : (
+                  <Loader2 className="size-5 animate-spin text-primary" />
+                )}
+                {sv.step4.title}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-3 py-2">
+              <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                {chips.map((chip, i) => {
+                  const done = !failed && phaseIndex > i;
+                  const active = !failed && phaseIndex === i;
+                  return (
+                    <span key={chip.label} className="flex items-center gap-1.5">
+                      {i > 0 && <span className="text-muted-foreground/50">›</span>}
+                      <span
+                        className={
+                          done
+                            ? 'flex items-center gap-1 text-emerald-600'
+                            : active
+                              ? 'flex items-center gap-1 font-medium text-primary'
+                              : 'flex items-center gap-1 text-muted-foreground/60'
+                        }
+                      >
+                        {done ? <Check className="size-3" /> : active ? <Loader2 className="size-3 animate-spin" /> : null}
+                        {chip.label}
+                      </span>
+                    </span>
+                  );
+                })}
+              </div>
+              {failed ? (
+                <p className="text-sm text-destructive">
+                  {failed.rolledBack ? sv.step4.rolledBack : sv.step4.failed}
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  {phaseIndex >= 4 ? sv.step4.done : sv.step4.willReload}
+                </p>
+              )}
+            </div>
+            {failed && (
+              <DialogFooter>
+                <Button variant="outline" onClick={() => onOpenChange(false)}>
+                  {sv.common.close}
+                </Button>
+              </DialogFooter>
+            )}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,7 +1,9 @@
 import { Link } from '@tanstack/react-router';
 import type * as React from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useIntlayer } from 'react-intlayer';
+import { ArrowUpCircle } from 'lucide-react';
 import { NavMain } from '~/components/nav-main';
 import { NavUser } from '~/components/nav-user';
 import {
@@ -21,6 +23,8 @@ import ScanIcon from 'virtual:icons/ri/scan-2-line';
 import ShieldIcon from 'virtual:icons/ri/shield-line';
 import { FEATURE_CONFIG } from '~/config/features';
 import { isAdminUser } from '~/server/function/skills.server';
+import { getUpdateStatus } from '~/server/function/updater.server';
+import { ServerUpdateDialog } from '~/components/admin/server-update-dialog';
 
 type SidebarUser = {
   name?: string | null;
@@ -31,6 +35,7 @@ type SidebarUser = {
 
 export function AppSidebar({ user, ...props }: React.ComponentProps<typeof Sidebar> & { user: SidebarUser }) {
   const content = useIntlayer('app');
+  const sv = useIntlayer('serverUpdate');
 
   // Query admin status using Server Function directly
   const { data: adminCheck } = useQuery({
@@ -40,6 +45,28 @@ export function AppSidebar({ user, ...props }: React.ComponentProps<typeof Sideb
     refetchOnWindowFocus: false,
   });
   const isAdmin = adminCheck?.isAdmin ?? false;
+
+  // Online auto-update: "auto-check" (default ON) controls the background re-poll cadence.
+  // Persisted per-browser; the worker always checks server-side regardless.
+  const [autoCheck, setAutoCheck] = useState(true);
+  useEffect(() => {
+    const v = typeof window !== 'undefined' ? window.localStorage.getItem('kin.autoCheckUpdates') : null;
+    if (v !== null) setAutoCheck(v === 'true');
+  }, []);
+  const handleAutoCheck = (value: boolean) => {
+    setAutoCheck(value);
+    if (typeof window !== 'undefined') window.localStorage.setItem('kin.autoCheckUpdates', String(value));
+  };
+
+  const [updateOpen, setUpdateOpen] = useState(false);
+  const { data: updateStatus } = useQuery({
+    queryKey: ['update-status'],
+    queryFn: async () => await getUpdateStatus(),
+    enabled: isAdmin,
+    staleTime: 60 * 1000,
+    refetchInterval: autoCheck ? 10 * 60 * 1000 : false,
+    refetchOnWindowFocus: false,
+  });
 
   // Three independent modules (IA redesign 2026-06, docs/project/prd/2026-06-navigation-ia-redesign-prd.md).
   // Projects moved into the agent workbench (副侧边栏 ProjectsRail); dashboards/charts moved to admin.
@@ -103,25 +130,52 @@ export function AppSidebar({ user, ...props }: React.ComponentProps<typeof Sideb
     : navSections;
 
   return (
-    <Sidebar collapsible="icon" {...props}>
-      <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:!p-1.5">
-              <Link to="/agents/c">
-                <HomeSmileIcon className="!size-5" />
-                <span className="font-semibold text-base">{content.common.appName}</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
-      <SidebarContent>
-        <NavMain sections={allSections} />
-      </SidebarContent>
-      <SidebarFooter>
-        <NavUser user={resolvedUser} />
-      </SidebarFooter>
-    </Sidebar>
+    <>
+      <Sidebar collapsible="icon" {...props}>
+        <SidebarHeader>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:!p-1.5">
+                <Link to="/agents/c">
+                  <HomeSmileIcon className="!size-5" />
+                  <span className="font-semibold text-base">{content.common.appName}</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
+        <SidebarContent>
+          <NavMain sections={allSections} />
+          {isAdmin && updateStatus?.updateAvailable && (
+            <SidebarMenu className="px-2">
+              <SidebarMenuItem>
+                <SidebarMenuButton onClick={() => setUpdateOpen(true)}>
+                  <ArrowUpCircle className="size-4 text-primary" />
+                  <span>{sv.sidebar.updateAvailable}</span>
+                  <span className="ml-auto inline-block size-2 rounded-full bg-primary" aria-hidden="true" />
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          )}
+        </SidebarContent>
+        <SidebarFooter>
+          <NavUser user={resolvedUser} />
+        </SidebarFooter>
+      </Sidebar>
+      {isAdmin && updateStatus && (
+        <ServerUpdateDialog
+          open={updateOpen}
+          onOpenChange={setUpdateOpen}
+          status={{
+            currentSha: updateStatus.currentSha,
+            latestSha: updateStatus.latestSha,
+            updateAvailable: updateStatus.updateAvailable,
+            image: updateStatus.image,
+          }}
+          autoCheck={autoCheck}
+          onAutoCheckChange={handleAutoCheck}
+        />
+      )}
+    </>
   );
 }

--- a/src/contents/server-update.content.ts
+++ b/src/contents/server-update.content.ts
@@ -1,0 +1,201 @@
+import type { Dictionary } from 'intlayer';
+import { t } from 'intlayer';
+
+/**
+ * Online auto-update ("Web server update") content dictionary.
+ * Drives the admin sidebar "update available" entry + the 4-step update dialog (Kin M3).
+ */
+const serverUpdateContent = {
+  content: {
+    sidebar: {
+      updateAvailable: t({
+        en: 'Update available',
+        'zh-Hans': '有可用更新',
+        'zh-Hant': '有可用更新',
+        fr: 'Mise à jour disponible',
+        ja: 'アップデートあり',
+        ko: '업데이트 있음',
+      }),
+    },
+    common: {
+      currentVersion: t({
+        en: 'Current',
+        'zh-Hans': '当前',
+        'zh-Hant': '當前',
+        fr: 'Actuelle',
+        ja: '現在',
+        ko: '현재',
+      }),
+      cancel: t({ en: 'Cancel', 'zh-Hans': '取消', 'zh-Hant': '取消', fr: 'Annuler', ja: 'キャンセル', ko: '취소' }),
+      close: t({ en: 'Close', 'zh-Hans': '关闭', 'zh-Hant': '關閉', fr: 'Fermer', ja: '閉じる', ko: '닫기' }),
+    },
+    step1: {
+      title: t({
+        en: 'Web server update',
+        'zh-Hans': '服务端更新',
+        'zh-Hant': '服務端更新',
+        fr: 'Mise à jour du serveur',
+        ja: 'サーバー更新',
+        ko: '서버 업데이트',
+      }),
+      newVersion: t({
+        en: 'New version available',
+        'zh-Hans': '有新版本可用',
+        'zh-Hant': '有新版本可用',
+        fr: 'Nouvelle version disponible',
+        ja: '新しいバージョンがあります',
+        ko: '새 버전이 있습니다',
+      }),
+      upToDate: t({
+        en: "You're on the latest version",
+        'zh-Hans': '已是最新版本',
+        'zh-Hant': '已是最新版本',
+        fr: 'Vous avez la dernière version',
+        ja: '最新バージョンです',
+        ko: '최신 버전입니다',
+      }),
+      releaseNotes: t({
+        en: 'Release notes',
+        'zh-Hans': '更新说明',
+        'zh-Hant': '更新說明',
+        fr: 'Notes de version',
+        ja: 'リリースノート',
+        ko: '릴리스 노트',
+      }),
+      autoCheck: t({
+        en: 'Check for updates automatically',
+        'zh-Hans': '自动检查更新',
+        'zh-Hant': '自動檢查更新',
+        fr: 'Vérifier les mises à jour automatiquement',
+        ja: '自動的に更新を確認',
+        ko: '자동으로 업데이트 확인',
+      }),
+      updateServer: t({
+        en: 'Update server',
+        'zh-Hans': '更新服务端',
+        'zh-Hant': '更新服務端',
+        fr: 'Mettre à jour',
+        ja: 'サーバーを更新',
+        ko: '서버 업데이트',
+      }),
+    },
+    step2: {
+      title: t({
+        en: 'Are you absolutely sure?',
+        'zh-Hans': '确定要继续吗？',
+        'zh-Hant': '確定要繼續嗎？',
+        fr: 'Êtes-vous absolument sûr ?',
+        ja: '本当によろしいですか？',
+        ko: '정말 계속하시겠습니까?',
+      }),
+      warning: t({
+        en: 'The panel will be briefly unavailable during the upgrade and the page will reload automatically when it finishes. Please confirm all services are running first.',
+        'zh-Hans': '升级期间面板会短暂不可用，完成后页面会自动刷新。建议先确认各项服务都在运行。',
+        'zh-Hant': '升級期間面板會短暫不可用，完成後頁面會自動重新整理。建議先確認各項服務都在執行。',
+        fr: "Le panneau sera brièvement indisponible pendant la mise à jour et la page se rechargera automatiquement à la fin. Veuillez d'abord confirmer que tous les services sont actifs.",
+        ja: 'アップグレード中はパネルが一時的に利用できなくなり、完了後にページが自動的に再読み込みされます。先にすべてのサービスが稼働中か確認してください。',
+        ko: '업그레이드 중에는 패널을 잠시 사용할 수 없으며 완료되면 페이지가 자동으로 새로고침됩니다. 먼저 모든 서비스가 실행 중인지 확인하세요.',
+      }),
+      verifyStatus: t({
+        en: 'Check service status',
+        'zh-Hans': '检查服务状态',
+        'zh-Hant': '檢查服務狀態',
+        fr: 'Vérifier les services',
+        ja: 'サービス状態を確認',
+        ko: '서비스 상태 확인',
+      }),
+    },
+    step3: {
+      title: t({
+        en: 'Ready to update',
+        'zh-Hans': '准备升级',
+        'zh-Hant': '準備升級',
+        fr: 'Prêt à mettre à jour',
+        ja: '更新の準備完了',
+        ko: '업데이트 준비 완료',
+      }),
+      checking: t({
+        en: 'Checking services…',
+        'zh-Hans': '正在检查服务…',
+        'zh-Hant': '正在檢查服務…',
+        fr: 'Vérification des services…',
+        ja: 'サービスを確認中…',
+        ko: '서비스 확인 중…',
+      }),
+      allRunning: t({
+        en: 'All services are running. You can continue.',
+        'zh-Hans': '所有服务在运行，可以继续。',
+        'zh-Hant': '所有服務都在執行，可以繼續。',
+        fr: 'Tous les services sont actifs. Vous pouvez continuer.',
+        ja: 'すべてのサービスが稼働中です。続行できます。',
+        ko: '모든 서비스가 실행 중입니다. 계속할 수 있습니다.',
+      }),
+      someNotRunning: t({
+        en: 'Some services are not running. Updating now is not recommended.',
+        'zh-Hans': '部分服务未在运行，不建议此时升级。',
+        'zh-Hant': '部分服務未在執行，不建議此時升級。',
+        fr: "Certains services ne sont pas actifs. La mise à jour n'est pas recommandée maintenant.",
+        ja: '一部のサービスが稼働していません。今の更新は推奨されません。',
+        ko: '일부 서비스가 실행되고 있지 않습니다. 지금 업데이트하는 것은 권장되지 않습니다.',
+      }),
+      recheck: t({ en: 'Re-check', 'zh-Hans': '重新检查', 'zh-Hant': '重新檢查', fr: 'Revérifier', ja: '再確認', ko: '다시 확인' }),
+      confirmUpgrade: t({
+        en: 'Confirm update',
+        'zh-Hans': '确认升级',
+        'zh-Hant': '確認升級',
+        fr: 'Confirmer la mise à jour',
+        ja: '更新を確定',
+        ko: '업데이트 확인',
+      }),
+    },
+    step4: {
+      title: t({
+        en: 'Server update in progress',
+        'zh-Hans': '正在升级服务端',
+        'zh-Hant': '正在升級服務端',
+        fr: 'Mise à jour en cours',
+        ja: 'サーバー更新中',
+        ko: '서버 업데이트 진행 중',
+      }),
+      willReload: t({
+        en: 'Updating, please wait — the page will reload automatically when it finishes.',
+        'zh-Hans': '正在升级，请稍候 —— 完成后页面会自动刷新到新版本。',
+        'zh-Hant': '正在升級，請稍候 —— 完成後頁面會自動重新整理到新版本。',
+        fr: 'Mise à jour en cours, veuillez patienter — la page se rechargera automatiquement à la fin.',
+        ja: '更新中です。完了するとページが自動的に再読み込みされます。',
+        ko: '업데이트 중입니다. 완료되면 페이지가 자동으로 새로고침됩니다.',
+      }),
+      phasePull: t({ en: 'Pull image', 'zh-Hans': '拉镜像', 'zh-Hant': '拉取映像', fr: "Récupérer l'image", ja: 'イメージ取得', ko: '이미지 받기' }),
+      phaseMigrate: t({ en: 'Migrate', 'zh-Hans': '迁移数据库', 'zh-Hant': '遷移資料庫', fr: 'Migrer', ja: 'マイグレーション', ko: '마이그레이션' }),
+      phaseWorker: t({ en: 'Swap worker', 'zh-Hans': '换 worker', 'zh-Hant': '換 worker', fr: 'Remplacer worker', ja: 'worker 切替', ko: 'worker 교체' }),
+      phaseApp: t({ en: 'Swap app', 'zh-Hans': '换 app', 'zh-Hant': '換 app', fr: "Remplacer l'app", ja: 'app 切替', ko: 'app 교체' }),
+      done: t({
+        en: 'Update complete. Reloading…',
+        'zh-Hans': '升级完成，正在刷新…',
+        'zh-Hant': '升級完成，正在重新整理…',
+        fr: 'Mise à jour terminée. Rechargement…',
+        ja: '更新が完了しました。再読み込み中…',
+        ko: '업데이트 완료. 새로고침 중…',
+      }),
+      failed: t({
+        en: 'Update failed.',
+        'zh-Hans': '升级失败。',
+        'zh-Hant': '升級失敗。',
+        fr: 'Échec de la mise à jour.',
+        ja: '更新に失敗しました。',
+        ko: '업데이트에 실패했습니다.',
+      }),
+      rolledBack: t({
+        en: 'Update failed and was rolled back to the previous version.',
+        'zh-Hans': '升级失败，已回滚到上一个版本。',
+        'zh-Hant': '升級失敗，已回滾到上一個版本。',
+        fr: 'La mise à jour a échoué et a été annulée vers la version précédente.',
+        ja: '更新に失敗し、前のバージョンにロールバックされました。',
+        ko: '업데이트에 실패하여 이전 버전으로 롤백되었습니다.',
+      }),
+    },
+  },
+  key: 'serverUpdate',
+} satisfies Dictionary;
+
+export default serverUpdateContent;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -16,3 +16,4 @@ export * from './skill-catalog.schema';
 export * from './model.schema';
 export * from './rag-trace.schema';
 export * from './ocr-job.schema';
+export * from './update-status.schema';

--- a/src/db/schema/update-status.schema.ts
+++ b/src/db/schema/update-status.schema.ts
@@ -1,0 +1,34 @@
+/**
+ * update_status — single-row table holding the result of the latest GHCR update check.
+ *
+ * Written by the BullMQ `update-check` repeat job (src/worker/processors/updateCheck.ts),
+ * read by the admin "Web Server Update" UI to decide whether to light the "可更新" badge.
+ *
+ * Online auto-update (Kin M3). PRD: docs/4. PRD/2026-06-14-在线自动更新-PRD.md (FR2/FR3).
+ * Always upserted against the fixed primary key `singleton` so there is exactly one row.
+ */
+
+import { pgTable, text, boolean } from 'drizzle-orm/pg-core';
+import { timestamptz } from './_shared';
+
+export const updateStatus = pgTable('update_status', {
+  // Fixed PK so the table holds a single row; onConflictDoUpdate target.
+  id: text('id').primaryKey().default('singleton'),
+  // Image ref that was checked, e.g. ghcr.io/deeptoai-com/kin/app:latest
+  image: text('image'),
+  // git SHA the worker is currently running (process.env.BUILD_SHA), null pre-M0.
+  currentSha: text('current_sha'),
+  // git SHA of the GHCR :latest image (org.opencontainers.image.revision label), best-effort.
+  latestSha: text('latest_sha'),
+  // GHCR :latest manifest digest (sha256:...), used by the updater apply step.
+  latestDigest: text('latest_digest'),
+  // True only when current vs latest git SHA differ (and both are known).
+  updateAvailable: boolean('update_available').notNull().default(false),
+  // Last time the check ran (success or failure).
+  checkedAt: timestamptz('checked_at'),
+  // Last check error message, null on success.
+  error: text('error'),
+});
+
+export type UpdateStatusRow = typeof updateStatus.$inferSelect;
+export type NewUpdateStatusRow = typeof updateStatus.$inferInsert;

--- a/src/routes/api/health.ts
+++ b/src/routes/api/health.ts
@@ -19,6 +19,9 @@ interface HealthCheck {
 interface HealthStatus {
   status: 'healthy' | 'unhealthy';
   timestamp: string;
+  /** Current running version — git SHA baked into the image at build time (FR1).
+   * Used by the online auto-update flow to detect/poll the running version. */
+  version: string;
   checks: {
     sessionsVolume: HealthCheck;
   };
@@ -50,6 +53,7 @@ export const Route = createFileRoute('/api/health')({
         const healthStatus: HealthStatus = {
           status: isHealthy ? 'healthy' : 'unhealthy',
           timestamp: new Date().toISOString(),
+          version: process.env.BUILD_SHA ?? 'dev',
           checks,
         };
 

--- a/src/server/function/updater.server.ts
+++ b/src/server/function/updater.server.ts
@@ -1,0 +1,120 @@
+/**
+ * Online auto-update — admin-gated server functions (Kin M3).
+ *
+ * The same-origin bridge between the admin "Web Server Update" UI and the privileged updater
+ * sidecar. Every function is double-gated (FR9): requireSystemAdmin() here (systemRole==='admin')
+ * AND a Bearer UPDATER_TOKEN on the wire to the updater (which also checks it).
+ *
+ * Follows the preview runtime client shape (src/preview/runtime.js) — POST JSON, tolerant
+ * parse — but ADDS the Authorization header the preview path omits. Only createServerFn
+ * instances are exported (no plain server-only values) so nothing drags postgres into the
+ * client bundle.
+ *
+ * PRD FR3/FR4/FR5/FR6/FR7/FR9. Spec §4.4.
+ */
+
+import { createServerFn } from '@tanstack/react-start';
+import { requireSystemAdmin } from '~/server/admin.server';
+
+const UPDATER_URL = (process.env.UPDATER_URL || 'http://updater:5066').replace(/\/+$/, '');
+const UPDATER_TOKEN = process.env.UPDATER_TOKEN || '';
+
+/** Concrete, fully-serializable shape of the updater sidecar's responses (all fields optional). */
+interface UpdaterResponse {
+  ok?: boolean;
+  // /v1/update/check
+  service?: string;
+  runningImageId?: string | null;
+  targetImage?: string;
+  // /v1/update/verify
+  services?: Array<{
+    service: string | null;
+    state: string | null;
+    health: string | null;
+    status: string | null;
+  }>;
+  allRunning?: boolean;
+  // /v1/update/apply (+ apply/status)
+  started?: boolean;
+  phase?: string;
+  inProgress?: boolean;
+  startedAt?: number | null;
+  rolledBack?: boolean;
+  updated?: boolean;
+  // error path
+  error?: string;
+}
+
+/** POST to the updater sidecar with the shared Bearer token; tolerant JSON parse. */
+async function updaterPost(path: string, payload: Record<string, unknown> = {}): Promise<UpdaterResponse> {
+  const res = await fetch(`${UPDATER_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${UPDATER_TOKEN}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  let body: UpdaterResponse | null = null;
+  try {
+    body = text ? (JSON.parse(text) as UpdaterResponse) : null;
+  } catch {
+    body = { error: text };
+  }
+  if (!res.ok) {
+    const msg = body?.error || `Updater returned ${res.status}`;
+    throw new Error(msg);
+  }
+  return body ?? {};
+}
+
+/**
+ * Read the latest detection result written by the worker `update-check` job — drives the
+ * "可更新" badge + current/latest version chips (FR3). Admin-only.
+ */
+export const getUpdateStatus = createServerFn({ method: 'GET' }).handler(async () => {
+  await requireSystemAdmin();
+  const { db } = await import('~/db/db-config');
+  const { updateStatus } = await import('~/db/schema/update-status.schema');
+  const rows = await db.select().from(updateStatus).limit(1);
+  const row = rows[0] ?? null;
+  return {
+    currentSha: row?.currentSha ?? process.env.BUILD_SHA ?? 'dev',
+    latestSha: row?.latestSha ?? null,
+    latestDigest: row?.latestDigest ?? null,
+    updateAvailable: row?.updateAvailable ?? false,
+    checkedAt: row?.checkedAt ?? null,
+    image: row?.image ?? null,
+    error: row?.error ?? null,
+  };
+});
+
+/** On-demand: ask the updater what image is currently running vs target (FR3). Admin-only. */
+export const checkUpdate = createServerFn({ method: 'POST' }).handler(async () => {
+  await requireSystemAdmin();
+  return updaterPost('/v1/update/check');
+});
+
+/** Service health snapshot for the "Ready to Update" dialog (FR4). Admin-only. */
+export const verifyServices = createServerFn({ method: 'POST' }).handler(async () => {
+  await requireSystemAdmin();
+  return updaterPost('/v1/update/verify');
+});
+
+/** Trigger the ordered in-place upgrade (FR5/FR6). Returns 202-started; UI then polls health. */
+export const applyUpdate = createServerFn({ method: 'POST' }).handler(async () => {
+  await requireSystemAdmin();
+  // Pass the detected target git SHA so the updater health gate can positively confirm it.
+  const { db } = await import('~/db/db-config');
+  const { updateStatus } = await import('~/db/schema/update-status.schema');
+  const rows = await db.select().from(updateStatus).limit(1);
+  const targetVersion = rows[0]?.latestSha ?? undefined;
+  return updaterPost('/v1/update/apply', targetVersion ? { targetVersion } : {});
+});
+
+/** Best-effort upgrade progress (phase) while the app is still reachable (FR7). Admin-only. */
+export const getApplyStatus = createServerFn({ method: 'GET' }).handler(async () => {
+  await requireSystemAdmin();
+  return updaterPost('/v1/update/apply/status');
+});

--- a/src/server/updater/registry.ts
+++ b/src/server/updater/registry.ts
@@ -1,0 +1,129 @@
+/**
+ * GHCR (GitHub Container Registry) anonymous manifest/label query — online auto-update (Kin M3).
+ *
+ * Public GHCR packages are anonymously pullable, so detection needs NO PAT. We:
+ *   1. fetch an anonymous bearer token for `repository:<repo>:pull`,
+ *   2. read the tag's manifest digest (Docker-Content-Digest),
+ *   3. (best-effort) resolve the image's git revision label
+ *      `org.opencontainers.image.revision` so we can compare against the running BUILD_SHA.
+ *
+ * No external deps — uses global fetch (Node >=18; project pins node:24). Network/HTTP errors
+ * propagate to the caller (the worker job records them into update_status.error).
+ *
+ * Spec: docs/5. 研发实施/.../2026-06-14-kin-在线自动更新-设计与实施规格.md §4.1(c).
+ * NOTE: until M0 publishes images to ghcr.io/deeptoai-com/kin/app this returns nothing useful;
+ * the parsing/HTTP logic is unit-tested with a mocked fetch (tests/unit/updater-registry.test.ts).
+ */
+
+const GHCR_HOST = 'https://ghcr.io';
+
+// Accept both OCI and Docker media types, index (multi-arch) and single manifests.
+const MANIFEST_ACCEPT = [
+  'application/vnd.oci.image.index.v1+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ');
+
+export interface GhcrLatest {
+  /** Docker-Content-Digest of the requested tag (the index/manifest digest). */
+  digest: string | null;
+  /** org.opencontainers.image.revision label (git sha) of the latest image, best-effort. */
+  revision: string | null;
+}
+
+/**
+ * Parse an image ref like `ghcr.io/owner/repo/app:latest` (host + tag both optional)
+ * into `{ repository, tag }`. A pinned `@sha256:...` digest is ignored for tag queries.
+ */
+export function parseGhcrImage(image: string, fallbackTag = 'latest'): { repository: string; tag: string } {
+  let ref = image.trim();
+  if (ref.startsWith('ghcr.io/')) ref = ref.slice('ghcr.io/'.length);
+
+  // Drop a pinned digest (`repo@sha256:...`) — we query by tag.
+  const at = ref.indexOf('@');
+  if (at !== -1) ref = ref.slice(0, at);
+
+  // Split a trailing `:tag` (a colon whose remainder has no `/`, so we don't mistake a
+  // port in a host that slipped through).
+  let tag = fallbackTag;
+  const colon = ref.lastIndexOf(':');
+  if (colon !== -1 && !ref.slice(colon + 1).includes('/')) {
+    tag = ref.slice(colon + 1) || fallbackTag;
+    ref = ref.slice(0, colon);
+  }
+  return { repository: ref, tag };
+}
+
+async function anonymousToken(repository: string): Promise<string> {
+  const url = `${GHCR_HOST}/token?service=ghcr.io&scope=repository:${repository}:pull`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GHCR token request failed: ${res.status}`);
+  const body = (await res.json()) as { token?: string };
+  if (!body.token) throw new Error('GHCR token response missing token');
+  return body.token;
+}
+
+/**
+ * Fetch the latest digest + git revision label for a GHCR image tag.
+ * `revision` is best-effort: any failure to resolve the config blob label yields null
+ * rather than throwing, so a missing label (e.g. pre-M0 images) degrades gracefully.
+ */
+export async function queryGhcrLatest(image: string): Promise<GhcrLatest> {
+  const { repository, tag } = parseGhcrImage(image);
+  const token = await anonymousToken(repository);
+  const headers = { Authorization: `Bearer ${token}`, Accept: MANIFEST_ACCEPT };
+
+  const manRes = await fetch(`${GHCR_HOST}/v2/${repository}/manifests/${encodeURIComponent(tag)}`, { headers });
+  if (!manRes.ok) throw new Error(`GHCR manifest request failed: ${manRes.status}`);
+  const digest = manRes.headers.get('docker-content-digest');
+  const manifest = (await manRes.json()) as ManifestLike;
+
+  let revision: string | null = null;
+  try {
+    revision = await readRevisionLabel(repository, manifest, headers);
+  } catch {
+    revision = null;
+  }
+  return { digest, revision };
+}
+
+interface ManifestLike {
+  manifests?: Array<{ digest?: string; platform?: { architecture?: string; os?: string } }>;
+  config?: { digest?: string };
+}
+
+/**
+ * Resolve `org.opencontainers.image.revision` from an image's config blob.
+ * For a multi-arch index, pick the linux/amd64 child (falling back to the first child),
+ * fetch its manifest, then its config blob, and read the label.
+ */
+async function readRevisionLabel(
+  repository: string,
+  manifest: ManifestLike,
+  headers: Record<string, string>,
+): Promise<string | null> {
+  let imageManifest = manifest;
+
+  const children = manifest?.manifests;
+  if (Array.isArray(children) && children.length > 0) {
+    const chosen =
+      children.find((m) => m?.platform?.architecture === 'amd64' && m?.platform?.os === 'linux') ?? children[0];
+    if (!chosen?.digest) return null;
+    const childRes = await fetch(`${GHCR_HOST}/v2/${repository}/manifests/${chosen.digest}`, { headers });
+    if (!childRes.ok) return null;
+    imageManifest = (await childRes.json()) as ManifestLike;
+  }
+
+  const configDigest = imageManifest?.config?.digest;
+  if (!configDigest) return null;
+  const cfgRes = await fetch(`${GHCR_HOST}/v2/${repository}/blobs/${configDigest}`, { headers });
+  if (!cfgRes.ok) return null;
+  const config = (await cfgRes.json()) as {
+    config?: { Labels?: Record<string, string> };
+    container_config?: { Labels?: Record<string, string> };
+  };
+  const labels = config?.config?.Labels ?? config?.container_config?.Labels ?? null;
+  const rev = labels?.['org.opencontainers.image.revision'];
+  return typeof rev === 'string' && rev.length > 0 ? rev : null;
+}

--- a/src/updater/controller.mjs
+++ b/src/updater/controller.mjs
@@ -1,0 +1,421 @@
+/**
+ * Updater sidecar — privileged executor for Kin online auto-update (M3).
+ *
+ * A small Node stdlib HTTP server (no deps) that drives `docker compose` to upgrade the
+ * running stack in place: pull → migrate → recreate worker → recreate app. It runs in its
+ * OWN container (dedicated docker-cli image, see Dockerfile.updater) so it is NEVER in the
+ * set of services it force-recreates — it cannot kill itself mid-upgrade (防自杀).
+ *
+ * Substrate (json/readBody/route/createServer + 500 catch) is copied from
+ * src/preview/controller.mjs. UNLIKE that template, every mutating endpoint here is gated by
+ * a Bearer token (UPDATER_TOKEN, constant-time compare) — this service mounts the Docker
+ * socket (= host root) and must not be callable unauthenticated. It listens on the internal
+ * network only and never publishes a host port.
+ *
+ * Spec: docs/5. 研发实施/.../2026-06-14-kin-在线自动更新-设计与实施规格.md §4.2/§5/§6/§7.
+ * PRD : docs/4. PRD/2026-06-14-在线自动更新-PRD.md (FR4/FR5/FR6/FR8/FR9).
+ *
+ * ⚠ End-to-end apply requires M0 (multi-arch GHCR images) + D1 (prod pulls GHCR). Until then
+ * `pull` has nothing to fetch on the production tunnel stack (oxygenie:local, pull_policy:never).
+ * The auth gate + routing + verify(ps) are unit-tested; apply is validated once M0/D1 land.
+ */
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+// ── Config (env) ─────────────────────────────────────────────────────────────
+const PORT = Number(process.env.UPDATER_PORT || 5066);
+const TOKEN = process.env.UPDATER_TOKEN || '';
+const COMPOSE_PROJECT = process.env.UPDATER_COMPOSE_PROJECT || 'oxygenie';
+const COMPOSE_FILE = process.env.UPDATER_COMPOSE_FILE || '/work/docker-compose.tunnel.yml';
+const WORK_DIR = process.env.UPDATER_WORK_DIR || '/work';
+const APP_IMAGE = process.env.APP_IMAGE || 'ghcr.io/deeptoai-com/kin/app';
+const APP_TAG = process.env.APP_TAG || 'latest';
+const HEALTH_URL = process.env.UPDATER_HEALTH_URL || 'http://app:5000/api/health';
+const ROLLBACK_TAG = process.env.UPDATER_ROLLBACK_TAG || 'rollback';
+
+// Compose SERVICE names (stable, unlike container_name which varies by APP_NAME casing).
+const APP_SERVICE = process.env.UPDATER_APP_SERVICE || 'app';
+const WORKER_SERVICE = process.env.UPDATER_WORKER_SERVICE || 'worker';
+const PREVIEW_SERVICE = process.env.UPDATER_PREVIEW_SERVICE || 'preview-controller';
+const MIGRATE_SERVICE = process.env.UPDATER_MIGRATE_SERVICE || 'migrate';
+
+// Timeouts (ms)
+const PULL_TIMEOUT_MS = Number(process.env.UPDATER_PULL_TIMEOUT_MS || 600000);
+const MIGRATE_TIMEOUT_MS = Number(process.env.UPDATER_MIGRATE_TIMEOUT_MS || 600000);
+const RECREATE_TIMEOUT_MS = Number(process.env.UPDATER_RECREATE_TIMEOUT_MS || 300000);
+const HEALTH_GATE_TIMEOUT_MS = Number(process.env.UPDATER_HEALTH_GATE_TIMEOUT_MS || 180000);
+
+// ── HTTP substrate (copied from preview/controller.mjs) ──────────────────────
+function json(res, status, payload) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (!chunks.length) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+// ── Auth: constant-time Bearer check (NEW vs the preview-controller template) ─
+function safeEqual(a, b) {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  // Length leaks but the token is a 32-byte random hex string — acceptable.
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/** Returns true when the request carries the correct `Authorization: Bearer <UPDATER_TOKEN>`. */
+function isAuthorized(req) {
+  if (!TOKEN) return false; // fail closed: no token configured => nobody is authorized
+  const header = req.headers['authorization'] || '';
+  return safeEqual(header, `Bearer ${TOKEN}`);
+}
+
+// ── docker / docker compose helpers ──────────────────────────────────────────
+function runDocker(args, { timeoutMs = 120000, extraEnv = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'docker',
+      args,
+      {
+        cwd: WORK_DIR,
+        timeout: timeoutMs,
+        maxBuffer: 16 * 1024 * 1024,
+        env: { ...process.env, APP_IMAGE, APP_TAG, ...extraEnv },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const e = new Error(`docker ${args.join(' ')} failed: ${error.message}\n${stderr || ''}`.trim());
+          e.stdout = stdout;
+          e.stderr = stderr;
+          reject(e);
+          return;
+        }
+        resolve({ stdout: stdout || '', stderr: stderr || '' });
+      },
+    );
+  });
+}
+
+function compose(extraArgs, opts) {
+  return runDocker(['compose', '-p', COMPOSE_PROJECT, '-f', COMPOSE_FILE, ...extraArgs], opts);
+}
+
+/** Parse compose `--format json` output (NDJSON in compose v2, or a JSON array). */
+function parseComposeJson(stdout) {
+  const text = (stdout || '').trim();
+  if (!text) return [];
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  }
+}
+
+/**
+ * Image id of the RUNNING container for a compose service — the rollback anchor / pre-pull
+ * baseline. NOTE: `docker compose images <svc>` lists images of CREATED containers (what the
+ * container is currently running), NOT what `compose pull` just fetched. We query a single
+ * service, so the (at most one) row is the one we want.
+ */
+async function serviceImageId(service) {
+  try {
+    const { stdout } = await compose(['images', '--format', 'json', service], { timeoutMs: 60000 });
+    const rows = parseComposeJson(stdout);
+    const row = rows[0]; // single-service query => at most one row
+    return row ? row.ID || row.id || null : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Image id of a locally-present image ref (e.g. the freshly-pulled APP_IMAGE:APP_TAG). */
+async function inspectImageId(ref) {
+  try {
+    const { stdout } = await runDocker(['image', 'inspect', ref, '--format', '{{.Id}}'], { timeoutMs: 60000 });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Compare two docker image ids, tolerating a `sha256:` prefix and short-vs-full hex. */
+function sameImage(a, b) {
+  if (!a || !b) return false;
+  const na = a.replace(/^sha256:/, '').toLowerCase();
+  const nb = b.replace(/^sha256:/, '').toLowerCase();
+  return na === nb || na.startsWith(nb) || nb.startsWith(na);
+}
+
+async function fetchHealth() {
+  try {
+    const res = await fetch(HEALTH_URL, { signal: AbortSignal.timeout(5000) });
+    const body = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, version: body?.version ?? null };
+  } catch {
+    return { ok: false, status: 0, version: null };
+  }
+}
+
+/**
+ * Poll the app health endpoint until it is 200 AND we can confirm the new version.
+ * Preference order for "version is new" (FR8 / spec §5 step 6):
+ *   1. targetVersion known -> require last.version === targetVersion (positive assertion).
+ *   2. else baseline known -> require last.version present AND != previousVersion.
+ *   3. else (both unknown)  -> require last.version present (NEVER auto-pass on a null version).
+ * versionVerified=false for case 3 signals the change wasn't positively confirmed.
+ */
+async function healthGate(previousVersion, targetVersion) {
+  const deadline = Date.now() + HEALTH_GATE_TIMEOUT_MS;
+  let last = { ok: false, status: 0, version: null };
+  while (Date.now() < deadline) {
+    last = await fetchHealth();
+    let versionOk = false;
+    let versionVerified = false;
+    if (last.version) {
+      if (targetVersion) {
+        versionOk = last.version === targetVersion;
+        versionVerified = versionOk;
+      } else if (previousVersion) {
+        versionOk = last.version !== previousVersion;
+        versionVerified = versionOk;
+      } else {
+        versionOk = true; // app is up + reports a version, but we cannot prove it changed
+        versionVerified = false;
+      }
+    }
+    if (last.ok && versionOk) return { passed: true, versionVerified, ...last };
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  return { passed: false, versionVerified: false, ...last };
+}
+
+// ── Apply state (single in-flight upgrade) ───────────────────────────────────
+/** @type {{inProgress:boolean, phase:string, startedAt:number|null, error:string|null, rolledBack:boolean, updated:boolean, versionVerified:boolean}} */
+const applyState = {
+  inProgress: false,
+  phase: 'idle',
+  startedAt: null,
+  error: null,
+  rolledBack: false,
+  updated: false,
+  versionVerified: false,
+};
+
+function setPhase(phase) {
+  applyState.phase = phase;
+  console.error(`[Updater] phase: ${phase}`);
+}
+
+/**
+ * The ordered upgrade. Runs detached (the app container is recreated mid-flight, which would
+ * drop the triggering HTTP connection); the UI observes completion by polling /api/health.
+ */
+async function runApply(targetVersion) {
+  applyState.inProgress = true;
+  applyState.error = null;
+  applyState.rolledBack = false;
+  applyState.updated = false;
+  applyState.versionVerified = false;
+  applyState.startedAt = Date.now();
+
+  let goodImageId = null;
+  let previousVersion = null;
+
+  try {
+    // 1. Rollback anchor + baseline: the currently-running app image id and version.
+    //    (Inside try so the finally always resets inProgress.)
+    setPhase('recording-good-image');
+    goodImageId = await serviceImageId(APP_SERVICE);
+    previousVersion = (await fetchHealth()).version;
+
+    // 2. Pull the new image (compose pull ignores pull_policy and always fetches).
+    setPhase('pulling');
+    await compose(['pull', APP_SERVICE, WORKER_SERVICE, PREVIEW_SERVICE, MIGRATE_SERVICE], {
+      timeoutMs: PULL_TIMEOUT_MS,
+    });
+    // Compare the RUNNING image (goodImageId) against the freshly-PULLED image in the local
+    // store. Do NOT re-query `compose images`, which still reflects the old running container.
+    const pulledImageId = await inspectImageId(`${APP_IMAGE}:${APP_TAG}`);
+    if (sameImage(goodImageId, pulledImageId)) {
+      setPhase('idle');
+      applyState.updated = false;
+      console.error('[Updater] no-op: pulled image identical to running image');
+      return;
+    }
+
+    // 3. Migrate (one-shot; the migrate service already retries db readiness up to 20x).
+    setPhase('migrating');
+    await compose(['run', '--rm', MIGRATE_SERVICE], { timeoutMs: MIGRATE_TIMEOUT_MS });
+
+    // 4. Recreate worker first (no inbound traffic — invisible to users).
+    setPhase('recreating-worker');
+    await compose(['up', '-d', '--no-deps', '--force-recreate', WORKER_SERVICE], {
+      timeoutMs: RECREATE_TIMEOUT_MS,
+    });
+
+    // 5. Recreate app + preview-controller (app is briefly unavailable; WS auto-reconnects).
+    //    updater is deliberately NOT in this list.
+    setPhase('recreating-app');
+    await compose(['up', '-d', '--no-deps', '--force-recreate', APP_SERVICE, PREVIEW_SERVICE], {
+      timeoutMs: RECREATE_TIMEOUT_MS,
+    });
+
+    // 6. Health gate.
+    setPhase('health-gate');
+    const gate = await healthGate(previousVersion, targetVersion);
+    if (!gate.passed) {
+      throw new Error(`health gate failed (status=${gate.status}, version=${gate.version ?? 'n/a'})`);
+    }
+
+    setPhase('done');
+    applyState.updated = true;
+    applyState.versionVerified = gate.versionVerified;
+    console.error('[Updater] upgrade complete', { version: gate.version, versionVerified: gate.versionVerified });
+  } catch (error) {
+    applyState.error = error instanceof Error ? error.message : String(error);
+    console.error('[Updater] upgrade FAILED:', applyState.error);
+    // 7. Rollback the IMAGE only (never the DB) to the recorded good image id.
+    // KNOWN LIMITATIONS (spec §7, documented for the operator; not auto-handled here):
+    //  (a) DB is forward-only — after rollback the OLD code runs against the NEW schema. The
+    //      mitigation is backward-compatible/annotated migrations, not a DB downgrade.
+    //  (b) This re-point is an in-flight override (APP_TAG=rollback for this recreate only).
+    //      Because /work is mounted read-only, we cannot persist it; a later plain `compose up`
+    //      or host reboot could resolve :latest back to the bad image. Once D1 lands, pin the
+    //      good digest durably (e.g. write APP_TAG to the deploy .env) outside the read-only mount.
+    if (goodImageId) {
+      try {
+        setPhase('rolling-back');
+        await runDocker(['tag', goodImageId, `${APP_IMAGE}:${ROLLBACK_TAG}`], { timeoutMs: 60000 });
+        await compose(['up', '-d', '--no-deps', '--force-recreate', APP_SERVICE, WORKER_SERVICE, PREVIEW_SERVICE], {
+          timeoutMs: RECREATE_TIMEOUT_MS,
+          extraEnv: { APP_TAG: ROLLBACK_TAG },
+        });
+        applyState.rolledBack = true;
+        console.error('[Updater] rolled back to previous good image');
+      } catch (rbErr) {
+        console.error('[Updater] ROLLBACK FAILED:', rbErr instanceof Error ? rbErr.message : String(rbErr));
+      }
+    }
+    setPhase('error');
+  } finally {
+    applyState.inProgress = false;
+  }
+}
+
+// ── Endpoints ────────────────────────────────────────────────────────────────
+
+/** Report the running app image + the configured target image (detection is the worker's job). */
+async function handleCheck() {
+  const imageId = await serviceImageId(APP_SERVICE);
+  return { service: APP_SERVICE, runningImageId: imageId, targetImage: `${APP_IMAGE}:${APP_TAG}` };
+}
+
+/** Service health snapshot for the "Ready to Update" dialog (FR4). */
+async function handleVerify() {
+  const { stdout } = await compose(['ps', '--format', 'json'], { timeoutMs: 60000 });
+  const rows = parseComposeJson(stdout);
+  const services = rows.map((r) => ({
+    service: r.Service || r.service || r.Name || r.name,
+    state: r.State || r.state || null,
+    health: r.Health || r.health || null,
+    status: r.Status || r.status || null,
+  }));
+  const allRunning = services.length > 0 && services.every((s) => (s.state || '').toLowerCase() === 'running');
+  return { services, allRunning };
+}
+
+/** Kick off the upgrade in the background; respond 202 immediately (FR5/FR6/FR7). */
+function handleApply(body) {
+  if (applyState.inProgress) {
+    return { status: 409, body: { error: 'update already in progress', phase: applyState.phase } };
+  }
+  // Optional target git SHA from the caller (server fn passes update_status.latestSha) so the
+  // health gate can positively confirm the new version.
+  const targetVersion = typeof body?.targetVersion === 'string' ? body.targetVersion : null;
+  // Detached — do NOT await (the app recreate would drop this connection).
+  void runApply(targetVersion);
+  return { status: 202, body: { started: true, phase: applyState.phase } };
+}
+
+// ── Router ───────────────────────────────────────────────────────────────────
+async function route(req, res) {
+  // Liveness probe — open, no auth (no side effects, no secrets).
+  if (req.method === 'GET' && req.url === '/health') {
+    json(res, 200, { ok: true });
+    return;
+  }
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  // AUTH GATE — before the body stream is consumed and before any docker call.
+  if (!isAuthorized(req)) {
+    json(res, 401, { error: 'Unauthorized' });
+    return;
+  }
+
+  const reqBody = await readBody(req); // also rejects malformed JSON
+
+  if (req.url === '/v1/update/check') {
+    json(res, 200, { ok: true, ...(await handleCheck()) });
+    return;
+  }
+  if (req.url === '/v1/update/verify') {
+    json(res, 200, { ok: true, ...(await handleVerify()) });
+    return;
+  }
+  if (req.url === '/v1/update/apply') {
+    const { status, body } = handleApply(reqBody);
+    json(res, status, body);
+    return;
+  }
+  if (req.url === '/v1/update/apply/status') {
+    json(res, 200, { ok: true, ...applyState });
+    return;
+  }
+  json(res, 404, { error: 'Not found' });
+}
+
+const server = http.createServer((req, res) => {
+  route(req, res).catch((error) => {
+    console.error('[Updater]', error);
+    json(res, 500, {
+      error: error instanceof Error ? error.message : String(error),
+      ...(error?.stderr && { stderr: error.stderr }),
+    });
+  });
+});
+
+// Only bind the port when run directly (`node src/updater/controller.mjs`), so the module can
+// be imported by unit tests (sameImage/parseComposeJson) without starting a server.
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+if (isDirectRun) {
+  server.listen(PORT, () => {
+    console.error(`[Updater] Listening on :${PORT}`);
+    console.error(`[Updater] Compose: -p ${COMPOSE_PROJECT} -f ${COMPOSE_FILE}`);
+    console.error(`[Updater] Target image: ${APP_IMAGE}:${APP_TAG}`);
+    if (!TOKEN) console.error('[Updater] WARNING: UPDATER_TOKEN is empty — all requests will be rejected (401).');
+  });
+}
+
+export { sameImage, parseComposeJson };

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,6 +6,7 @@ import { logger } from '~/lib/logger'
 import { runDailyCreditRefill } from './processors/dailyCreditRefill.ts'
 import { reindexDocuments } from './processors/reindexDocuments.ts'
 import { probeModels } from './processors/probeModels.ts'
+import { runUpdateCheck } from './processors/updateCheck.ts'
 import { ingestDocument } from '~/server/rag/ingest'
 import { RAG_QUEUE, RAG_INGEST_JOB } from '~/server/rag/queue'
 
@@ -34,6 +35,9 @@ const worker = new Worker(
       case 'probe-models':
         logger.info('[worker] running probe-models job')
         return probeModels((job.data as { modelId?: string } | undefined)?.modelId)
+      case 'update-check':
+        logger.info('[worker] running update-check job')
+        return runUpdateCheck()
       default:
         logger.warn(`[worker] Unknown job "${job.name}" - ignoring`)
     }
@@ -100,6 +104,16 @@ events.on('failed', ({ jobId, failedReason }) =>
   if ((process.env.MODEL_PROBE_ON_BOOT ?? 'true').toLowerCase() !== 'false') {
     await queue.add('probe-models', {}, { jobId: `probe-boot-${Date.now()}` })
     logger.info('[worker] queued probe-models on boot')
+  }
+
+  // Online auto-update: poll GHCR for a newer server image on a cadence (default every 6h)
+  // and persist the verdict to update_status for the admin "Web Server Update" UI (FR2).
+  // Read-only/unprivileged — never touches the Docker socket. Reuses the `existing` array.
+  const updateCheckCron = process.env.UPDATE_CHECK_CRON ?? '0 */6 * * *'
+  const hasUpdateCheck = existing.some((j) => j.name === 'update-check' && j.cron === updateCheckCron)
+  if (!hasUpdateCheck) {
+    await queue.add('update-check', {}, { repeat: { pattern: updateCheckCron }, jobId: 'update-check' })
+    logger.info('[worker] scheduled update-check', { cron: updateCheckCron })
   }
 
   if (process.env.SEARCH_REINDEX_ON_BOOT === 'true') {

--- a/src/worker/processors/updateCheck.ts
+++ b/src/worker/processors/updateCheck.ts
@@ -1,0 +1,88 @@
+/**
+ * BullMQ processor: detect whether a newer server image is published, and persist the
+ * verdict to update_status (PRD FR2). Runs on the 6h `update-check` repeat job.
+ *
+ * Detection is read-only and unprivileged: it does NOT touch the Docker socket. It compares
+ * the git SHA the worker is running (process.env.BUILD_SHA — baked into the shared app image)
+ * against the git revision label of the GHCR :latest image. The admin UI reads the row to
+ * decide whether to light the "可更新" badge; applying an update is a separate, gated action.
+ *
+ * Spec §4.3. Mirrors probeModels.ts (db client import + onConflictDoUpdate upsert).
+ */
+
+import { db } from '~/db/client';
+import { updateStatus } from '~/db/schema/update-status.schema';
+import { queryGhcrLatest } from '~/server/updater/registry';
+import { logger } from '~/lib/logger';
+
+const SINGLETON = 'singleton';
+
+/**
+ * Resolve the image to poll. Prefer an explicit GHCR ref (APP_IMAGE) + APP_TAG; otherwise
+ * fall back to the final Kin GHCR coordinates. The local production tag (`oxygenie:local`,
+ * pre-D1) is not a GHCR ref, so we only poll when APP_IMAGE actually points at a registry.
+ */
+function resolveImage(): string {
+  const explicit = process.env.UPDATE_CHECK_IMAGE?.trim();
+  if (explicit) return explicit;
+  const appImage = process.env.APP_IMAGE?.trim();
+  const appTag = process.env.APP_TAG?.trim() || 'latest';
+  if (appImage && appImage.includes('ghcr.io')) return `${appImage}:${appTag}`;
+  return 'ghcr.io/deeptoai-com/kin/app:latest';
+}
+
+/** Query GHCR, compute updateAvailable, upsert the single update_status row. */
+export async function runUpdateCheck(): Promise<{ updateAvailable: boolean }> {
+  const image = resolveImage();
+  const currentSha = process.env.BUILD_SHA ?? null;
+  const now = new Date();
+
+  try {
+    const { digest, revision } = await queryGhcrLatest(image);
+    // Only claim an update when we can compare two known git SHAs and they differ.
+    // Unknown (pre-M0 images without the revision label) is treated as "no update" so we
+    // never nag the admin on a signal we can't trust.
+    const updateAvailable = Boolean(currentSha && revision && currentSha !== revision);
+
+    await db
+      .insert(updateStatus)
+      .values({
+        id: SINGLETON,
+        image,
+        currentSha,
+        latestSha: revision,
+        latestDigest: digest,
+        updateAvailable,
+        checkedAt: now,
+        error: null,
+      })
+      .onConflictDoUpdate({
+        target: updateStatus.id,
+        set: {
+          image,
+          currentSha,
+          latestSha: revision,
+          latestDigest: digest,
+          updateAvailable,
+          checkedAt: now,
+          error: null,
+        },
+      });
+
+    logger.info('[update-check] done', { image, currentSha, latestSha: revision, updateAvailable });
+    return { updateAvailable };
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    // Record the error but keep the last-known latest* values; do not flip updateAvailable.
+    await db
+      .insert(updateStatus)
+      .values({ id: SINGLETON, image, currentSha, updateAvailable: false, checkedAt: now, error })
+      .onConflictDoUpdate({
+        target: updateStatus.id,
+        set: { image, currentSha, checkedAt: now, error },
+      });
+
+    logger.error('[update-check] failed', { image, error });
+    return { updateAvailable: false };
+  }
+}

--- a/tests/unit/update-check.test.ts
+++ b/tests/unit/update-check.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the update-check worker processor LOGIC (no real DB, no network).
+ * Mocks the db client + the GHCR registry query, and asserts updateAvailable is computed
+ * from git-SHA comparison and persisted via the singleton upsert.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── capture the drizzle upsert chain: db.insert(table).values(v).onConflictDoUpdate({set}) ──
+// vi.hoisted so these exist before the hoisted vi.mock factories run.
+const { insert, captured, queryGhcrLatest } = vi.hoisted(() => {
+  const captured: { values?: Record<string, unknown>; set?: Record<string, unknown> } = {};
+  const onConflictDoUpdate = vi.fn((arg: { set: Record<string, unknown> }) => {
+    captured.set = arg.set;
+    return Promise.resolve();
+  });
+  const values = vi.fn((v: Record<string, unknown>) => {
+    captured.values = v;
+    return { onConflictDoUpdate };
+  });
+  const insert = vi.fn(() => ({ values }));
+  const queryGhcrLatest = vi.fn();
+  return { insert, captured, queryGhcrLatest };
+});
+
+vi.mock('~/db/client', () => ({ db: { insert } }));
+vi.mock('~/lib/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('~/server/updater/registry', () => ({ queryGhcrLatest }));
+
+import { runUpdateCheck } from '~/worker/processors/updateCheck';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete captured.values;
+  delete captured.set;
+  process.env.BUILD_SHA = 'currentsha';
+  process.env.UPDATE_CHECK_IMAGE = 'ghcr.io/deeptoai-com/kin/app:latest';
+});
+
+describe('runUpdateCheck', () => {
+  it('flags updateAvailable when the latest git SHA differs', async () => {
+    queryGhcrLatest.mockResolvedValue({ digest: 'sha256:X', revision: 'newersha' });
+    const res = await runUpdateCheck();
+    expect(res.updateAvailable).toBe(true);
+    expect(captured.values).toMatchObject({
+      id: 'singleton',
+      currentSha: 'currentsha',
+      latestSha: 'newersha',
+      latestDigest: 'sha256:X',
+      updateAvailable: true,
+      error: null,
+    });
+  });
+
+  it('does NOT flag an update when running the same SHA', async () => {
+    queryGhcrLatest.mockResolvedValue({ digest: 'sha256:X', revision: 'currentsha' });
+    const res = await runUpdateCheck();
+    expect(res.updateAvailable).toBe(false);
+    expect(captured.values).toMatchObject({ updateAvailable: false });
+  });
+
+  it('is conservative (no update) when the revision label is unknown', async () => {
+    queryGhcrLatest.mockResolvedValue({ digest: 'sha256:X', revision: null });
+    const res = await runUpdateCheck();
+    expect(res.updateAvailable).toBe(false);
+  });
+
+  it('records the error and does not flag an update when the query throws', async () => {
+    queryGhcrLatest.mockRejectedValue(new Error('GHCR token request failed: 503'));
+    const res = await runUpdateCheck();
+    expect(res.updateAvailable).toBe(false);
+    expect(captured.set).toMatchObject({ error: 'GHCR token request failed: 503' });
+    // must not clobber latest* on error (only id/image/currentSha/checkedAt/error in the set)
+    expect(captured.set).not.toHaveProperty('updateAvailable');
+  });
+});

--- a/tests/unit/updater-controller.test.ts
+++ b/tests/unit/updater-controller.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Integration-ish test for the updater sidecar's AUTH GATE + routing.
+ * Spawns the real controller (Node stdlib, no deps) as a child process and exercises it
+ * over HTTP. The auth check runs BEFORE any docker call, so these assertions need no docker:
+ *   - GET /health        -> 200 (open liveness)
+ *   - POST without token  -> 401
+ *   - POST with wrong tok -> 401
+ *   - POST /apply w/ token -> 202 (gate opens; the actual upgrade runs detached and is N/A here)
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+const PORT = 5267;
+const TOKEN = 'test-updater-token';
+const BASE = `http://127.0.0.1:${PORT}`;
+let child: ChildProcess;
+
+beforeAll(async () => {
+  child = spawn('node', ['src/updater/controller.mjs'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      UPDATER_PORT: String(PORT),
+      UPDATER_TOKEN: TOKEN,
+      // point compose at a non-existent file so any (unexpected) docker call fails fast
+      UPDATER_COMPOSE_FILE: '/nonexistent/docker-compose.yml',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  // wait for the "Listening on" banner (printed to stderr)
+  await new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('updater did not start in time')), 10000);
+    child.stderr?.on('data', (b: Buffer) => {
+      if (b.toString().includes('Listening on')) {
+        clearTimeout(t);
+        resolve();
+      }
+    });
+    child.on('error', reject);
+  });
+});
+
+afterAll(() => {
+  child?.kill('SIGKILL');
+});
+
+describe('updater controller auth gate', () => {
+  it('serves open liveness on GET /health', async () => {
+    const res = await fetch(`${BASE}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('rejects an unauthenticated mutating request with 401', async () => {
+    const res = await fetch(`${BASE}/v1/update/apply`, { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a wrong Bearer token with 401', async () => {
+    const res = await fetch(`${BASE}/v1/update/apply`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer wrong-token' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('lets the correct Bearer token through the gate (202 started)', async () => {
+    const res = await fetch(`${BASE}/v1/update/apply`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toMatchObject({ started: true });
+  });
+});

--- a/tests/unit/updater-helpers.test.ts
+++ b/tests/unit/updater-helpers.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the updater controller's pure helpers (the critical no-op-detection fix):
+ *  - sameImage: tolerant docker image-id comparison (sha256: prefix, short vs full hex)
+ *  - parseComposeJson: compose v2 `--format json` output (array OR NDJSON OR empty)
+ * Importing the controller does NOT start the server (it only listens when run directly).
+ */
+import { describe, it, expect } from 'vitest';
+import { sameImage, parseComposeJson } from '~/updater/controller.mjs';
+
+describe('sameImage', () => {
+  it('matches identical full ids', () => {
+    expect(sameImage('sha256:abcdef0123', 'sha256:abcdef0123')).toBe(true);
+  });
+  it('matches across a sha256: prefix difference', () => {
+    expect(sameImage('sha256:abcdef0123', 'abcdef0123')).toBe(true);
+  });
+  it('matches a short id against the full id (prefix)', () => {
+    expect(sameImage('abcdef012345', 'sha256:abcdef0123456789deadbeef')).toBe(true);
+  });
+  it('does not match different ids', () => {
+    expect(sameImage('sha256:aaaa1111', 'sha256:bbbb2222')).toBe(false);
+  });
+  it('is false when either id is missing (so apply proceeds, never silently no-ops)', () => {
+    expect(sameImage(null, 'sha256:abc')).toBe(false);
+    expect(sameImage('sha256:abc', null)).toBe(false);
+  });
+});
+
+describe('parseComposeJson', () => {
+  it('parses a JSON array', () => {
+    expect(parseComposeJson('[{"ID":"a"},{"ID":"b"}]')).toEqual([{ ID: 'a' }, { ID: 'b' }]);
+  });
+  it('parses NDJSON (one object per line, compose v2)', () => {
+    expect(parseComposeJson('{"ID":"a"}\n{"ID":"b"}\n')).toEqual([{ ID: 'a' }, { ID: 'b' }]);
+  });
+  it('returns [] for empty output', () => {
+    expect(parseComposeJson('')).toEqual([]);
+    expect(parseComposeJson('   ')).toEqual([]);
+  });
+  it('wraps a single JSON object into an array', () => {
+    expect(parseComposeJson('{"ID":"a"}')).toEqual([{ ID: 'a' }]);
+  });
+});

--- a/tests/unit/updater-registry.test.ts
+++ b/tests/unit/updater-registry.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the GHCR registry query (online auto-update detection).
+ * Pure: global fetch is stubbed; no network. Covers image-ref parsing and the
+ * token -> manifest(index) -> child manifest -> config-blob label walk.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseGhcrImage, queryGhcrLatest } from '~/server/updater/registry';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('parseGhcrImage', () => {
+  it('splits host, repository and tag', () => {
+    expect(parseGhcrImage('ghcr.io/deeptoai-com/kin/app:latest')).toEqual({
+      repository: 'deeptoai-com/kin/app',
+      tag: 'latest',
+    });
+  });
+  it('defaults the tag to latest when omitted', () => {
+    expect(parseGhcrImage('ghcr.io/deeptoai-com/kin/app')).toEqual({
+      repository: 'deeptoai-com/kin/app',
+      tag: 'latest',
+    });
+  });
+  it('honours an explicit tag', () => {
+    expect(parseGhcrImage('ghcr.io/owner/repo/app:v1.2.3')).toEqual({
+      repository: 'owner/repo/app',
+      tag: 'v1.2.3',
+    });
+  });
+  it('ignores a pinned digest', () => {
+    expect(parseGhcrImage('ghcr.io/owner/repo/app@sha256:abc')).toEqual({
+      repository: 'owner/repo/app',
+      tag: 'latest',
+    });
+  });
+});
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe('queryGhcrLatest', () => {
+  it('returns digest + revision via the multi-arch index walk', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/token')) return jsonResponse({ token: 'tok' });
+      if (url.endsWith('/manifests/latest')) {
+        return jsonResponse(
+          { manifests: [{ digest: 'sha256:child', platform: { architecture: 'amd64', os: 'linux' } }] },
+          { 'docker-content-digest': 'sha256:INDEX' },
+        );
+      }
+      if (url.endsWith('/manifests/sha256:child')) {
+        return jsonResponse({ config: { digest: 'sha256:cfg' } });
+      }
+      if (url.endsWith('/blobs/sha256:cfg')) {
+        return jsonResponse({ config: { Labels: { 'org.opencontainers.image.revision': 'deadbeef' } } });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await queryGhcrLatest('ghcr.io/deeptoai-com/kin/app:latest');
+    expect(result).toEqual({ digest: 'sha256:INDEX', revision: 'deadbeef' });
+  });
+
+  it('handles a single (non-index) manifest with a top-level config', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/token')) return jsonResponse({ token: 'tok' });
+      if (url.endsWith('/manifests/latest')) {
+        return jsonResponse({ config: { digest: 'sha256:cfg' } }, { 'docker-content-digest': 'sha256:SINGLE' });
+      }
+      if (url.endsWith('/blobs/sha256:cfg')) {
+        return jsonResponse({ config: { Labels: { 'org.opencontainers.image.revision': 'cafe' } } });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await queryGhcrLatest('ghcr.io/owner/repo/app');
+    expect(result).toEqual({ digest: 'sha256:SINGLE', revision: 'cafe' });
+  });
+
+  it('degrades revision to null when the label is absent (e.g. pre-M0 images)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/token')) return jsonResponse({ token: 'tok' });
+      if (url.endsWith('/manifests/latest')) {
+        return jsonResponse({ config: { digest: 'sha256:cfg' } }, { 'docker-content-digest': 'sha256:D' });
+      }
+      if (url.endsWith('/blobs/sha256:cfg')) return jsonResponse({ config: { Labels: {} } });
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await queryGhcrLatest('ghcr.io/owner/repo/app');
+    expect(result).toEqual({ digest: 'sha256:D', revision: null });
+  });
+});


### PR DESCRIPTION
Dokploy-style in-panel server update: version identity (BUILD_SHA from M0 + /api/health), updater sidecar (socket control), update-check job, four-step confirm dialog, migrate→recreate→rollback. Migration 0033 (update_status). 24 tests pass; compose config clean. apply E2E on a live stack pending (deferred).