### PR TITLE
chore(release): 发布卫生 + 健康检查加 schema 版本比对

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -296,4 +296,4 @@ How you tested these changes
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](../LICENSE).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -737,7 +737,7 @@ services:
 ```bash
 git pull
 # tag 按用途取：kin:local（常规）或 kin:<feature>-test（灰度）；下面 APP_TAG 必须与之一致。
-DOCKER_BUILDKIT=1 docker build --build-arg BUILD_SHA=$(git rev-parse --short HEAD) -t kin:local .   # 本机 arm64 即可
+DOCKER_BUILDKIT=1 docker build --build-arg BUILD_SHA=$(git rev-parse HEAD) -t kin:local .   # 本机 arm64 即可；用完整 sha（非 --short），与 CI 烤的一致，updater/健康检查按值精确比较
 # ⚠️ 改名(Kin)后必须 source **prod-merged.env**（全量），绝不要 source secrets.env——后者
 #    APP_NAME=oxygenie / APP_NAME_SANITIZED=oxygenie-cc2 是改名前残值，一 source 就把 app/worker
 #    重建到 oxygenie-cc2-private 网络、脱离 kin-private（Kin-redis/Kin-db 所在）→ ENOTFOUND redis = 全站宕机。

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -205,9 +205,11 @@ services:
     networks:
       - private
 
-  # Main application (Nitro + WebSocket server)
-  # Dokploy builds the image locally to include VITE_* environment variables
-  # Build args are passed from Dokploy's environment configuration
+  # Main application (Nitro + WebSocket server). Pulls the prebuilt multi-arch GHCR image
+  # (see x-app-image anchor above) — Dokploy does NOT build this locally. `redeploy` just
+  # re-pulls ${APP_TAG:-latest}; if you push new code first, wait for the `build-image`
+  # GitHub Actions workflow to finish (it publishes the new tag) before redeploying,
+  # otherwise you'll re-pull the previous build (see docs/deployment/dokploy.md).
   app:
     image: *app_image
     pull_policy: always

--- a/docs/deployment/dokploy.md
+++ b/docs/deployment/dokploy.md
@@ -32,6 +32,26 @@
 5. **Smoke test:** `GET /api/health` → `200` · `GET /` → `200` · `GET /ws/agent` → **`426`**
    (426 = the WebSocket server is alive and routed — the agent-chat lifeline).
 
+## Redeploying after pulling new code (avoid a race with CI)
+
+`redeploy` just re-pulls `${APP_TAG:-latest}` from GHCR — it does **not** build anything, and it
+does **not** wait for GitHub Actions. If you push to `main` and immediately hit "redeploy", the
+`build-image` workflow (multi-arch, ~4-5 min) is very likely still running, so you'll silently
+redeploy the **previous** image and think you shipped the new one. Always:
+
+1. Wait for `build-image` to go green for your commit (`gh run list --workflow build-image` or the
+   Actions tab).
+2. *Then* redeploy.
+3. Confirm with `curl https://<your-domain>/api/health` — `version` should equal your commit's full
+   SHA. `schemaVersion.inSync` should be `true` (it compares migrations shipped in the image against
+   migrations actually applied to your database — a quick way to tell "did my migration really run"
+   without shelling into the container).
+
+**Don't run Kin's own online-update sidecar (`updater`) here.** Dokploy already owns this stack's
+lifecycle; a second process independently running `docker compose up --force-recreate` against the
+same stack will fight Dokploy's own reconciliation. Keep `UPDATER_TOKEN` empty and use Dokploy's
+redeploy for updates, per the step above — this is the "what's limited" item below.
+
 ## What works / what's limited on Dokploy
 - ✅ **Works:** the site, sign-up/login, **Agent chat** (your model gateway), Postgres/Redis/MinIO/Meili,
   conversation-history search, file upload, skills/MCP.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kin",
   "description": "Kin — self-hosted, single-org Claude-Agent workspace (based on Constructa scaffold)",
   "repository": "https://github.com/deeptoai-com/kin",
+  "license": "Apache-2.0",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/src/routes/api/health.ts
+++ b/src/routes/api/health.ts
@@ -6,14 +6,33 @@
  * Returns health status for various system components:
  * - Database connectivity
  * - Sessions volume writability
+ * - Schema version (code vs. applied migrations — see schemaVersion below)
  */
 
 import { createFileRoute } from '@tanstack/react-router';
 import { access, constants } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
 interface HealthCheck {
   status: 'ok' | 'error';
   message?: string;
+}
+
+/**
+ * Code-vs-DB migration drift, without needing shell/SSH access to the host: `expected`
+ * is how many migrations ship in THIS image's bundled `drizzle/meta/_journal.json`;
+ * `applied` is how many drizzle has actually run against the connected database
+ * (`drizzle.__drizzle_migrations` row count). `inSync` is the one field anyone
+ * debugging "why does the UI look old" should check first. Best-effort: a DB hiccup
+ * here must not affect the endpoint's overall status (see try/catch below) — this
+ * field is diagnostic, not a liveness gate.
+ */
+interface SchemaVersionCheck {
+  expected: number | null;
+  applied: number | null;
+  inSync: boolean | null;
+  error?: string;
 }
 
 interface HealthStatus {
@@ -25,6 +44,7 @@ interface HealthStatus {
   checks: {
     sessionsVolume: HealthCheck;
   };
+  schemaVersion: SchemaVersionCheck;
 }
 
 async function checkSessionsVolume(): Promise<HealthCheck> {
@@ -40,13 +60,41 @@ async function checkSessionsVolume(): Promise<HealthCheck> {
   }
 }
 
+async function checkSchemaVersion(): Promise<SchemaVersionCheck> {
+  try {
+    const [{ db }, journalRaw] = await Promise.all([
+      import('~/db/client'),
+      readFile(path.join(process.cwd(), 'drizzle/meta/_journal.json'), 'utf-8'),
+    ]);
+    const expected: number = JSON.parse(journalRaw).entries.length;
+
+    const { sql } = await import('drizzle-orm');
+    const rows = await db.execute<{ count: string }>(
+      sql`select count(*)::text as count from drizzle.__drizzle_migrations`,
+    );
+    const applied = Number(rows[0]?.count ?? 0);
+
+    return { expected, applied, inSync: applied === expected };
+  } catch (error) {
+    // Soft failure: unreadable journal, DB unreachable, migrations table not yet
+    // created, etc. Reported for visibility; never blocks the health endpoint.
+    return {
+      expected: null,
+      applied: null,
+      inSync: null,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
 export const Route = createFileRoute('/api/health')({
   server: {
     handlers: {
       GET: async () => {
-        const checks = {
-          sessionsVolume: await checkSessionsVolume(),
-        };
+        const [checks, schemaVersion] = await Promise.all([
+          (async () => ({ sessionsVolume: await checkSessionsVolume() }))(),
+          checkSchemaVersion(),
+        ]);
 
         const isHealthy = Object.values(checks).every((c) => c.status === 'ok');
 
@@ -55,6 +103,7 @@ export const Route = createFileRoute('/api/health')({
           timestamp: new Date().toISOString(),
           version: process.env.BUILD_SHA ?? 'dev',
           checks,
+          schemaVersion,
         };
 
         return new Response(JSON.stringify(healthStatus), {


### PR DESCRIPTION
## 背景

审计 kin.deeptoai.com（长期版本）发布链路时发现的一批问题，本 PR 是「先修的部分」。同批工作也修正了 GitHub 分支保护的失效规则（必需检查名对不上当前 CI job，且已允许 admin 绕过）——那部分通过 GitHub API 直接调整，不在此 PR 的文件变更里。

## 改动

- **许可证文档订正**：CONTRIBUTING.md 写着"贡献按 MIT 授权"，与实际 LICENSE / GitHub 识别的 Apache-2.0 不符；package.json 补 license 字段。
- **Dokploy 部署文档补时序坑**：redeploy 只是重新拉 `:latest`，不等 CI；本次发布模型注册表 v2 时因为推完代码立刻触发 redeploy，拉到了上一版镜像（被误诊为"Dokploy 拉取滞后"，实际是 CI 竞态）。文档现在明确写了"先等 build-image 绿再 redeploy"，并删掉了一句过时误导注释（compose 里说"Dokploy 本地构建"，实际早已改成 pull GHCR）。
- **明确 Kin 自带更新组件不适用于 Dokploy 环境**：它会自己跑 `docker compose up`，和 Dokploy 自身的编排冲突——已写入部署文档，避免任何 Dokploy 用户踩坑。
- **`/api/health` 新增 `schemaVersion`**：比较镜像里打包的迁移文件数 vs 数据库里实际应用的迁移数，任何自托管者不需要 SSH 进容器就能判断"代码和数据库是否同步"。失败按软失败处理，不影响整体健康状态。
- **本地部署配方的 BUILD_SHA 改用完整 sha**（原来用 `--short`），和 CI 产出保持一致，避免精确比较时误判。

## 测试

- `pnpm typecheck` / `pnpm lint` / `pnpm validate-routes` / `pnpm test:unit`：与改动前的 main 对比，无新增失败（既有的 4 处 typecheck 提示 + 24 处路由校验提示 + 2 个测试收集失败均为存量，已用 `git stash` 验证过）。
- `schemaVersion` 逻辑：本地对照 drizzle 驱动（postgres-js）的 `db.execute` 返回结构手动核对过字段访问方式，未接入真实数据库跑通（该部分请求评审时可在预发环境用 `curl /api/health` 验证 `schemaVersion.inSync` 字段）。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>